### PR TITLE
BAU: Expect data from Connector to be well formed

### DIFF
--- a/app/web/modules/gateway_accounts/detail.njk
+++ b/app/web/modules/gateway_accounts/detail.njk
@@ -39,7 +39,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Toggle 3DS</th>
-        <td class="govuk-table__cell">{{ account.toggle_3ds | capitalize }}</td>
+        <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Previously Connector returned all values on strings on the gateway
account route - this updates the template to expect formed Bools/ Longs.

Changes accounting for https://github.com/alphagov/pay-connector/pull/1109