### PR TITLE
PP-4931 make direct debit account creation work

### DIFF
--- a/app/lib/pay-request/api_utils/directDebitConnector.js
+++ b/app/lib/pay-request/api_utils/directDebitConnector.js
@@ -1,0 +1,22 @@
+const directDebitConnectorMethods = function directDebitConnectorMethods (instance) {
+  const axiosInstance = instance || this
+
+  const accounts = function accounts () {
+    return axiosInstance.get('/v1/api/accounts').then(utilExtractData)
+  }
+
+  const account = function account (id) {
+    return axiosInstance.get(`/v1/api/accounts/${id}`).then(utilExtractData)
+  }
+
+  const createAccount = function createAccount (account) {
+    return axiosInstance.post('/v1/api/accounts', account).then(utilExtractData)
+  }
+
+  // @TODO(sfount) extract and standardise this - there should be no need to repeat this over and over
+  const utilExtractData = response => response.data
+
+  return { accounts, account, createAccount }
+}
+
+module.exports = directDebitConnectorMethods

--- a/app/lib/pay-request/api_utils/index.js
+++ b/app/lib/pay-request/api_utils/index.js
@@ -6,5 +6,6 @@ const serviceStore = require('./../../services.store')
 index[serviceStore.ADMINUSERS.key] = require('./adminUsers')
 index[serviceStore.CONNECTOR.key] = require('./connector')
 index[serviceStore.PUBLICAUTH.key] = require('./publicAuth')
+index[serviceStore.DIRECTDEBITCONNECTOR.key] = require('./directDebitConnector')
 
 module.exports = index

--- a/app/lib/pay-request/client.js
+++ b/app/lib/pay-request/client.js
@@ -24,8 +24,9 @@ const buildPayBaseClient = function buildPayBaseClient (service) {
     maxContentLength: 5 * 1000 * 1000,
 
     // @TODO(sfount) configure headers based on each services requirements
-    headers:
-        service.key === serviceStore.DIRECTDEBITCONNECTOR.key ? { 'Content-Type': 'application/json' } : '',
+    headers: {
+      'Content-Type': 'application/json'
+    },
     // @TODO(sfount) this should only ignore authorized TLS in a non-production environment
     httpsAgent: new https.Agent({
       rejectUnauthorized: false

--- a/app/lib/pay-request/client.js
+++ b/app/lib/pay-request/client.js
@@ -24,7 +24,8 @@ const buildPayBaseClient = function buildPayBaseClient (service) {
     maxContentLength: 5 * 1000 * 1000,
 
     // @TODO(sfount) configure headers based on each services requirements
-    // headers: { 'X-Auth-header': 'secretscontent' }
+    headers:
+        service.key === serviceStore.DIRECTDEBITCONNECTOR.key ? { 'Content-Type': 'application/json' } : '',
     // @TODO(sfount) this should only ignore authorized TLS in a non-production environment
     httpsAgent: new https.Agent({
       rejectUnauthorized: false

--- a/app/web/modules/gateway_accounts/create.njk
+++ b/app/web/modules/gateway_accounts/create.njk
@@ -84,7 +84,7 @@
         }
       }, 
       items: [
-        { value: "direct-debit-sandbox", text: "Sandbox", checked: recovered.provider === "direct-debit-sandbox" },
+        { value: "sandbox", text: "Sandbox", checked: recovered.provider === "direct-debit-sandbox" },
         { value: "gocardless", text: "Gocardless", checked: recovered.provider === "gocardless" }
       ]
     })

--- a/app/web/modules/gateway_accounts/createSuccess.njk
+++ b/app/web/modules/gateway_accounts/createSuccess.njk
@@ -7,7 +7,7 @@
 	</h1>
 	<div class="govuk-panel__body">
 		Your account reference
-		<br><strong>{{ account.gateway_account_id }}</strong>
+		<br><h5>{{ gatewayAccountIdDerived }}</h5>
 	</div>
 </div>
 
@@ -17,7 +17,7 @@ A {{ account.type | upper }} Gateway account has been created through Admin User
 
 <h2 class="govuk-heading-m">Actions taken</h2>
 <ol class="govuk-list govuk-list--number">
-	<li>New {{ account.type }} {{ provider | capitalize }} account ({{ account.gateway_account_id }}) record created</li>
+	<li>New {{ account.type }} {{ provider | capitalize }} account ({{ gatewayAccountIdDerived }}) record created</li>
  
   <!-- @TODO(sfount) not a scalable pattern -->
   {% if provider === 'stripe' %}
@@ -25,14 +25,14 @@ A {{ account.type | upper }} Gateway account has been created through Admin User
   {% endif %}
   
   {% if linkedService %}
-	<li>(System Link) Service ‘{{ account.service_name }}’ linked to new Gateway account ({{ account.gateway_account_id }})</li>
+	<li>(System Link) Service ‘{{ account.service_name }}’ linked to new Gateway account ({{ gatewayAccountIdDerived }})</li>
 	<li>Service ‘{{ account.service_name }}’ go live status updated to ‘LIVE’</li>
 	{% endif %}
 </ol>
 
 <h2 class="govuk-heading-m">Relevant resources</h2>
 <ul class="govuk-list">
-	<li><a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ account.gateway_account_id }}">{{ account.type | upper }} Gateway account ({{ account.gateway_account_id }}) details</a></li>
+	<li><a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ gatewayAccountIdDerived }}">{{ account.type | upper }} Gateway account ({{ gatewayAccountIdDerived }}) details</a></li>
 	<li><a class="govuk-link govuk-link--no-visited-state" href="/services/{{ linkedService }}">{{ account.service_name }} details</a></li>
 </ul>
 

--- a/app/web/modules/gateway_accounts/createSuccess.njk
+++ b/app/web/modules/gateway_accounts/createSuccess.njk
@@ -7,7 +7,8 @@
 	</h1>
 	<div class="govuk-panel__body">
 		Your account reference
-		<br><h5>{{ gatewayAccountIdDerived }}</h5>
+		<br>
+		<p class="govuk-!-font-size-24"> <strong>{{ gatewayAccountIdDerived }}</strong></p>
 	</div>
 </div>
 

--- a/app/web/modules/gateway_accounts/detail.njk
+++ b/app/web/modules/gateway_accounts/detail.njk
@@ -17,6 +17,12 @@
         <th class="govuk-table__header" scope="col">ID</th>
         <td class="govuk-table__cell">{{ account.gateway_account_id }}</td>
       </tr>
+      {% if account.gateway_account_external_id %}
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Gateway account external ID</th>
+          <td class="govuk-table__cell">{{ account.gateway_account_external_id }}</td>
+        </tr>
+      {% endif %}
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Type</th>
         <td class="govuk-table__cell">{{ account.type | capitalize }}</td>
@@ -43,7 +49,7 @@
         <th class="govuk-table__header" scope="col">Analytics</th>
         <td class="govuk-table__cell"><code>{{ account.analytics_id }}</code></td>
       </tr>
-      {% if account.payment_method != 'DIRECT_DEBIT' %}
+      {% if account.toggle_3ds != undefined %}
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Toggle 3DS</th>
             <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>

--- a/app/web/modules/gateway_accounts/detail.njk
+++ b/app/web/modules/gateway_accounts/detail.njk
@@ -34,7 +34,7 @@
       <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Payment method</th>
           <td class="govuk-table__cell">
-              {% if account.payment_method %} {{ account.payment_method }}  {%else %} CARD {% endif %}
+              {% if account.payment_method %} {{ account.payment_method }}  {% else %} CARD {% endif %}
           </td>
       </tr>
       <tr class="govuk-table__row">
@@ -62,7 +62,7 @@
   <div>
     {{ govukButton({
     text: "Manage API keys",
-    href: "/gateway_accounts/" + account.gateway_account_id + "/api_keys"
+    href: "/gateway_accounts/" + gatewayAccountId + "/api_keys"
     })
     }}
   </div>

--- a/app/web/modules/gateway_accounts/detail.njk
+++ b/app/web/modules/gateway_accounts/detail.njk
@@ -4,7 +4,7 @@
 
 {% block main %}
   <h1 class="govuk-heading-m">Gateway account details</h1>
-  
+
   {% if services.external_id %}
   <div>
     <a href="/services/{{ services.external_id }}" class="govuk-back-link">Associated service {{services.name}} ({{ services.id }})</a>
@@ -26,6 +26,12 @@
         <td class="govuk-table__cell">{{ account.description }}</td>
       </tr>
       <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Payment method</th>
+          <td class="govuk-table__cell">
+              {% if account.payment_method %} {{ account.payment_method }}  {%else %} CARD {% endif %}
+          </td>
+      </tr>
+      <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Payment provider</th>
         <td class="govuk-table__cell">{{ account.payment_provider | capitalize }}</td>
       </tr>
@@ -37,10 +43,13 @@
         <th class="govuk-table__header" scope="col">Analytics</th>
         <td class="govuk-table__cell"><code>{{ account.analytics_id }}</code></td>
       </tr>
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">Toggle 3DS</th>
-        <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
-      </tr>
+      {% if account.payment_method != 'DIRECT_DEBIT' %}
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Toggle 3DS</th>
+            <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
+          </tr>
+      {% endif %}
+
     </tbody>
   </table>
 

--- a/app/web/modules/gateway_accounts/gatewayAccount.model.js
+++ b/app/web/modules/gateway_accounts/gatewayAccount.model.js
@@ -7,27 +7,31 @@ const sandbox = {
   directDebit: 'direct-debit-sandbox'
 }
 const providers = {
-  card: [ sandbox.card, 'worldpay', 'smartpay', 'epdq', 'stripe' ],
-  directDebit: [ sandbox.directDebit, 'gocardless' ]
+  card: [sandbox.card, 'worldpay', 'smartpay', 'epdq', 'stripe'],
+  directDebit: [sandbox.directDebit, 'gocardless']
+}
+const paymentMethod = {
+  card: 'card',
+  directDebit: 'direct-debit'
 }
 
 const schema = {
   live: Joi.string().required().valid('live', 'not-live').required(),
-  paymentMethod: Joi.string().valid('card', 'direct-debit').required(),
+  paymentMethod: Joi.string().valid(paymentMethod.card, paymentMethod.directDebit).required(),
   description: Joi.string().required(),
   serviceName: Joi.string().required(),
   provider: Joi
     .when('paymentMethod', {
-      is: 'card',
+      is: paymentMethod.card,
       then: Joi.string().required().valid(providers.card)
     })
     .when('paymentMethod', {
-      is: 'direct-debit',
+      is: paymentMethod.directDebit,
       then: Joi.string().required().valid(providers.directDebit)
     })
     .when('live', {
       is: 'live',
-      then: Joi.string().required().invalid('card-sandbox', 'direct-debit-sandbox')
+      then: Joi.string().required().invalid(sandbox.card, sandbox.directDebit)
     }),
   analyticsId: Joi.string().required(),
   credentials: Joi.string().allow('')
@@ -50,6 +54,9 @@ class GatewayAccount {
     if (parsed.live === 'live' && [sandbox.card, sandbox.directDebit].includes(parsed.provider)) {
       throw new ValidationError('GatewayAccount live accounts cannot use Sandbox providers.')
     }
+
+    parsed.isDirectDebit = parsed.paymentMethod === paymentMethod.directDebit
+
     Object.assign(this, parsed)
   }
 

--- a/app/web/modules/gateway_accounts/gatewayAccount.model.js
+++ b/app/web/modules/gateway_accounts/gatewayAccount.model.js
@@ -4,7 +4,7 @@ const { ValidationError } = require('./../../../lib/errors')
 
 const sandbox = {
   card: 'card-sandbox',
-  directDebit: 'direct-debit-sandbox'
+  directDebit: 'sandbox'
 }
 const providers = {
   card: [sandbox.card, 'worldpay', 'smartpay', 'epdq', 'stripe'],

--- a/app/web/modules/gateway_accounts/gateway_accounts.http.js
+++ b/app/web/modules/gateway_accounts/gateway_accounts.http.js
@@ -9,6 +9,10 @@ const overview = async function overview (req, res, next) {
   const { accounts } = await Connector.accounts()
   res.render('gateway_accounts/overview', { accounts, messages: req.flash('info') })
 }
+const overviewDirectDebit = async function overview (req, res, next) {
+  const { accounts } = await DirectDebitConnector.accounts()
+  res.render('gateway_accounts/overview', { accounts, messages: req.flash('info') })
+}
 
 const create = async function create (req, res, next) {
   const linkedService = req.query.service
@@ -95,5 +99,5 @@ const deleteApiKey = async function deleteApiKey (req, res, next) {
   res.redirect(`/gateway_accounts/${accountId}/api_keys`)
 }
 
-const handlers = { overview, create, confirm, writeAccount, detail, apiKeys, deleteApiKey }
+const handlers = { overview, overviewDirectDebit, create, confirm, writeAccount, detail, apiKeys, deleteApiKey }
 module.exports = wrapAsyncErrorHandlers(handlers)

--- a/app/web/modules/gateway_accounts/gateway_accounts.http.js
+++ b/app/web/modules/gateway_accounts/gateway_accounts.http.js
@@ -9,7 +9,7 @@ const overview = async function overview (req, res, next) {
   const { accounts } = await Connector.accounts()
   res.render('gateway_accounts/overview', { accounts, messages: req.flash('info') })
 }
-const overviewDirectDebit = async function overview (req, res, next) {
+const overviewDirectDebit = async function overviewDirectDebit (req, res, next) {
   const { accounts } = await DirectDebitConnector.accounts()
   res.render('gateway_accounts/overview', { accounts, messages: req.flash('info') })
 }
@@ -66,13 +66,10 @@ const writeAccount = async function writeAccount (req, res, next) {
 const detail = async function detail (req, res, next) {
   const id = req.params.id
   let services = {}
-  let account = ''
+  const isDirectDebitID = id.match(/^DIRECT_DEBIT:/)
+  const readAccountMethod = isDirectDebitID ? DirectDebitConnector.account : Connector.account
 
-  if (id.match(/^DIRECT_DEBIT:/)) {
-    account = await DirectDebitConnector.account(id)
-  } else {
-    account = await Connector.account(id)
-  }
+  const account = await readAccountMethod(id)
 
   try {
     services = await AdminUsers.gatewayAccountServices(id)
@@ -80,7 +77,7 @@ const detail = async function detail (req, res, next) {
     logger.warn(`Services request for gateway account ${id} returned "${error.message}"`)
   }
 
-  res.render('gateway_accounts/detail', { account, services })
+  res.render('gateway_accounts/detail', { account, gatewayAccountId: id, services })
 }
 
 const apiKeys = async function apiKeys (req, res, next) {

--- a/app/web/modules/gateway_accounts/gateway_accounts.http.js
+++ b/app/web/modules/gateway_accounts/gateway_accounts.http.js
@@ -1,6 +1,6 @@
 const logger = require('./../../../lib/logger')
 
-const { Connector, AdminUsers, PublicAuth } = require('./../../../lib/pay-request')
+const { Connector, DirectDebitConnector, AdminUsers, PublicAuth } = require('./../../../lib/pay-request')
 const { wrapAsyncErrorHandlers } = require('./../../../lib/routes')
 
 const GatewayAccount = require('./gatewayAccount.model')
@@ -36,7 +36,9 @@ const writeAccount = async function writeAccount (req, res, next) {
   const account = new GatewayAccount(req.body)
   const linkedService = req.body.systemLinkedService
 
-  jobs.account = await Connector.createAccount(account.formatPayload())
+  const createAccountMethod = account.isDirectDebit ? DirectDebitConnector.createAccount : Connector.createAccount
+  jobs.account = await createAccountMethod(account.formatPayload())
+
   logger.info(`Created new Gateway Account ${jobs.account.gateway_account_id}`)
 
   // connect system linked services to the created account

--- a/app/web/modules/gateway_accounts/index.js
+++ b/app/web/modules/gateway_accounts/index.js
@@ -3,6 +3,7 @@ const exceptions = require('./gateway_accounts.exceptions')
 
 module.exports = {
   overview: http.overview,
+  overviewDirectDebit: http.overviewDirectDebit,
   create: {
     http: http.create,
     exceptions: exceptions.create

--- a/app/web/modules/gateway_accounts/overview.njk
+++ b/app/web/modules/gateway_accounts/overview.njk
@@ -2,11 +2,11 @@
 
 {% block main %}
   <h1 class="govuk-heading-m">Gateway accounts</h1>
-  
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">ID</th>
+        <th class="govuk-table__header" scope="col">ID / External ID</th>
         <th class="govuk-table__header" scope="col">Type</th>
         <th class="govuk-table__header" scope="col">Service</th>
         <th class="govuk-table__header" scope="col">Provider</th>
@@ -16,11 +16,15 @@
     <tbody class="govuk-table__body">
       {% for account in accounts | sort(true, false, 'gateway_account_id') %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ account.gateway_account_id }}">{{ account.gateway_account_id }}</a></td>
-        <td class="govuk-table__cell">{{ account.type | capitalize }}</td> 
-        <td class="govuk-table__cell">{{ account.service_name | truncate(30) }}</td> 
-        <td class="govuk-table__cell">{{ account.payment_provider | capitalize }}</td> 
-        <td class="govuk-table__cell"><code>{{ account.analytics_id }}</code></td> 
+        <td class="govuk-table__cell">
+            <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{% if account.gateway_account_external_id %}{{ account.gateway_account_external_id }}{% else %}{{ account.gateway_account_id }}{% endif %}">
+                {% if account.gateway_account_external_id %}{{ account.gateway_account_external_id }}{% else %}{{ account.gateway_account_id }}{% endif %}
+            </a>
+        </td>
+        <td class="govuk-table__cell">{{ account.type | capitalize }}</td>
+        <td class="govuk-table__cell">{{ account.service_name | truncate(30) }}</td>
+        <td class="govuk-table__cell">{{ account.payment_provider | capitalize }}</td>
+        <td class="govuk-table__cell"><code>{{ account.analytics_id }}</code></td>
       </tr>
       {% else %}
       <tr class="govuk-table__row">

--- a/app/web/modules/layout/layout.njk
+++ b/app/web/modules/layout/layout.njk
@@ -51,7 +51,10 @@
           <h4 class="govuk-heading-s app-subnav__header">Gateway accounts</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts">Overview</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts">Card</a>
+            </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts/direct_debit">Direct debit</a>
             </li>
           </ul>
         

--- a/app/web/modules/services/gatewayAccountRequest.model.js
+++ b/app/web/modules/services/gatewayAccountRequest.model.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 const { ValidationError } = require('./../../../lib/errors')
 
 const schema = {
-  id: Joi.number().integer().required()
+  id: Joi.string().required()
 }
 
 // simplified gateway account model for processing valid request

--- a/app/web/modules/services/link_accounts.njk
+++ b/app/web/modules/services/link_accounts.njk
@@ -1,4 +1,5 @@
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "components/button/macro.njk" import govukButton %}
 {% from "components/input/macro.njk" import govukInput %}
 {% extends "layout/layout.njk" %} 
 
@@ -25,7 +26,11 @@
       label: { text: "Gateway account ID to add" }
       })
       }}
-      
-      <button type="submit">Submit</button>
+
+    {{ govukButton({
+          text: "Submit"
+      })
+    }}
+
   </form>
 {% endblock %}

--- a/app/web/router.js
+++ b/app/web/router.js
@@ -25,6 +25,7 @@ router.post('/statistics/compare/date', auth.secured, statistics.compareFilter)
 router.get('/statistics/services', auth.secured, statistics.byServices)
 
 router.get('/gateway_accounts', auth.secured, gatewayAccounts.overview)
+router.get('/gateway_accounts/direct_debit', auth.secured, gatewayAccounts.overviewDirectDebit)
 router.get('/gateway_accounts/create', auth.secured, gatewayAccounts.create.http, gatewayAccounts.create.exceptions)
 router.get('/gateway_accounts/:id', auth.secured, gatewayAccounts.detail.http, gatewayAccounts.detail.exceptions)
 router.get('/gateway_accounts/:id/api_keys', auth.secured, gatewayAccounts.apiKeys)


### PR DESCRIPTION
### WHAT

Adds functionality to

- `Create, View, List` Direct debit Gateway accounts
- Display `gateway_account_external_id`, `toggle_3ds` only if available (Gateway Account detail page)  as these are not applicable for both Card & Direct Debit payment types
- Gateway Account's sub menu has been changed to `Card` & `Direct debit`