### PR TITLE
BAU: Fix Stripe API version for compatability

### DIFF
--- a/app/web/modules/stripe/stripe.http.js
+++ b/app/web/modules/stripe/stripe.http.js
@@ -2,6 +2,7 @@ const logger = require('./../../../lib/logger')
 
 const STRIPE_API_KEY = process.env.STRIPE_API_KEY
 const stripe = require('stripe')(STRIPE_API_KEY)
+stripe.setApiVersion('2018-09-24')
 
 const { AdminUsers } = require('./../../../lib/pay-request')
 const StripeAccount = require('./stripe.model')


### PR DESCRIPTION
Fixes the Stripe API version to the release closest to when this code
was written, these API calls are no longer valid and the version should
be updated when possible, this ensures the code continues to work and
requests an older API.