### PR TITLE
BAU: Make exception for known dependency fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 pipeline { 
   // use the repository Dockerfile for building the environment image
   agent { dockerfile true }
+  parameters { 
+    booleanParam(name: 'SKIP_NPM_AUDIT', defaultValue: false, description: 'Run npm security audit. This should only ever be set to false if a known fix is not yet merged on a dependency.')
+  }
   environment { 
     npm_config_cache = 'npm-cache'
     HOME="${env.WORKSPACE}"
@@ -17,6 +20,9 @@ pipeline {
       }
     }
     stage('Security audit') { 
+      when { 
+        not { expression { return params.SKIP_NPM_AUDIT } }
+      }
       steps { 
         sh 'npm audit'
       }


### PR DESCRIPTION
If an upstream dependency has a known fix that is not yet merged, all
PRs into this repo will be blocked by CI. By adding a parameter that is
discouraged we can continue working while waiting for the fix.