### PR TITLE
PP-5060 Production dependencies only Dockerfile; include Typescript build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,48 @@
 # node:10.15.0-alpine
-FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
+FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e as base
 
-WORKDIR /app 
+WORKDIR /cache
 
-# also take package.lock? 
-# copies packages first for docker caching mechanisms
+# takes both package and package-lock for CI
 COPY package*.json ./
 
-RUN npm install
+FROM base AS dependencies
 
+# ensure removed dependencies are cleaned up 
+RUN npm prune
+
+# prepare production build modules
+RUN npm install --only=production --no-progress
+RUN cp -R node_modules production_node_modules
+
+# prepare build process modules
+RUN npm ci --no-progress
+
+FROM dependencies as build
+
+COPY --from=dependencies /cache/node_modules ./node_modules
 # current folder assets into working directory
 COPY . .
 
 # questionable method of setting build defaults - this should be removed when
 # tunneling is no longer required
-RUN apk add bash
 RUN ./scripts/generate-dev-environment docker
+
+RUN npm run build:sass
+
+# FROM base AS release - aliasing this triggers a bug in Jenkins pipeline, it cannot inspect 
+# an aliased multi-stage, extend the original image as a temporary workaround
+FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
+
+WORKDIR /app
+COPY --from=dependencies /cache/production_node_modules ./node_modules
+
+#TODO(sfount) source will not be needed when a final /dist folder is created
+#             with Typescript integration
+COPY . . 
+
+COPY --from=build /cache/.env .
+COPY --from=build /cache/app/public ./app/public
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,14 @@
 # node:10.15.0-alpine
-FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e as base
+FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
 
-WORKDIR /cache
+WORKDIR /app
 
 # takes both package and package-lock for CI
 COPY package*.json ./
 
-FROM base AS dependencies
-
-# ensure removed dependencies are cleaned up - RUN npm prune
-# prepare production build modules
-RUN npm install --only=production --no-progress
-RUN cp -R node_modules production_node_modules
-
 # prepare build process modules
 RUN npm ci --no-progress
 
-FROM dependencies as build
-
-WORKDIR /app
-
-COPY --from=dependencies /cache/node_modules ./node_modules
-
-# current folder assets into working directory
 COPY . .
 
 # questionable method of setting build defaults - this should be removed when
@@ -30,18 +16,7 @@ COPY . .
 RUN ./scripts/generate-dev-environment docker
 
 RUN npm run build
-
-# FROM base AS release - aliasing this triggers a bug in Jenkins pipeline, it cannot inspect 
-# an aliased multi-stage, extend the original image as a temporary workaround
-FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
-
-WORKDIR /app
-
-COPY --from=dependencies /cache/production_node_modules node_modules
-COPY --from=build /app/dist dist
-
-COPY --from=build /app/package.json .
-COPY --from=build /app/.env .
+RUN npm prune --production
 
 EXPOSE 3000
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:sass": "scripts/compile-assets",
     "build:copy": "copyfiles --up 1 src/**/*.njk dist/",
     "preinstall": "echo \"Preinstall hook\" && exit 0",
-    "postinstall": "npm run build"
+    "prepare": "npm run build:sass",
+    "postinstall": "echo \"postinstall set to run with prepare (only in dev)\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # source .env
 
 # Prepare build environment

--- a/scripts/compile-assets
+++ b/scripts/compile-assets
@@ -1,5 +1,4 @@
-#!/bin/bash
-# source .env
+#!/bin/sh
 
 # Ensure structure for writing file exists
 mkdir -p dist/public
@@ -9,7 +8,6 @@ rm -f app/public/payuk-toolbox*
 
 # Build CSS from SASS root document
 APPLICATION_SASS="src/assets/payuk-toolbox.scss"
-# BUILD_FOLDER="$BUILD_FOLDER_ROOT/public"
 BUILD_FOLDER="dist/public"
 BUILD_TARGET="payuk-toolbox"
 MANIFEST_TARGET="$BUILD_FOLDER/manifest.json"
@@ -18,7 +16,7 @@ TEMP_FILE="$BUILD_FOLDER/$BUILD_TARGET.tmp"
 node-sass --output-style compressed $APPLICATION_SASS > $TEMP_FILE
 
 # Version file based on file hash
-HASH=$(md5 -q $TEMP_FILE)
+HASH=$(sha1sum $TEMP_FILE | awk '{ print $1 }')
 OUT_FILE="$BUILD_FOLDER/$BUILD_TARGET-$HASH.css"
 
 mv "$TEMP_FILE" "$OUT_FILE"

--- a/scripts/generate-dev-environment
+++ b/scripts/generate-dev-environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ENV_FILE=.env
 


### PR DESCRIPTION
* Update package scripts to only run postinstall when dev dependencies
are installed
* Split build into stages
* Favour `sh` vs. `bash` - one less build step