### PR TITLE
BAU - Provide additional owners for stripe account

### DIFF
--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -106,7 +106,8 @@ const submitAccountCreate = async function submitAccountCreate(
           city: service.merchant_details.address_city,
           postal_code: service.merchant_details.address_postcode,
           country: service.merchant_details.address_country
-        }
+        },
+        additional_owners: ''
       },
       tos_acceptance: {
         ip: stripeAgreement.ip_address,


### PR DESCRIPTION
- Provide an empty string for legal_entity.additional_owners when a Stripe account is created using the basic Stripe account creation page. This is recognised by Stripe as the organisation having nobody who owns over 25% of the business.