### PR TITLE
BAU - Make the new Stripe account creation the main button

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -49,13 +49,13 @@
 
     {{ govukButton({
       text: "Setup live Stripe account",
-      href: "/stripe/create?service=" + service.external_id
+      href: "/stripe/basic/create?service=" + service.external_id
       })
     }}
 
     <p>
-      <a class="govuk-link" href="/stripe/basic/create?service={{ service.external_id }}">
-        Create live Stripe account using stored details (do not use yet)
+      <a class="govuk-link" href="/stripe/create?service={{ service.external_id }}">
+        Create live Stripe account with all details (the old way)
       </a>
     </p>
     <br/>


### PR DESCRIPTION
Swap the buttons around so the "Setup live Stripe account" will create the Stripe account using the details stored in the go live flow, and there is a link below to create an account the old way with all the details provided up front.