### PR TITLE
BAU - Display email options for gateway account

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -55,6 +55,24 @@
             <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
           </tr>
       {% endif %}
+      {% if account.email_collection_mode != undefined %}
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Email collection mode</th>
+          <td class="govuk-table__cell">{{ account.email_collection_mode }}</td>
+        </tr>
+      {% endif %}
+      {% if account.email_notifications != undefined %}
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Payment confirmation email</th>
+          <td class="govuk-table__cell">{{ 'Enabled' if (account.email_notifications.PAYMENT_CONFIRMED 
+            and account.email_notifications.PAYMENT_CONFIRMED.enabled) else 'Disabled' }}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Refund issued email</th>
+          <td class="govuk-table__cell">{{ 'Enabled' if (account.email_notifications.REFUND_ISSUED 
+            and account.email_notifications.REFUND_ISSUED.enabled) else 'Disabled' }}</td>
+        </tr>
+      {% endif %}
 
     </tbody>
   </table>


### PR DESCRIPTION
For CARD gateway accounts display the following details in table:
- 'Email collection mode', will be 'MANDATORY', 'OPTIONAL' or 'OFF' as
  returned by adminusers
- 'Payment confirmation email', will be 'Enabled' or 'Disabled'
- 'Refund issued email', will be 'Enabled' or 'Disabled'

Should resolve issue https://github.com/alphagov/pay-toolbox/issues/45