### PR TITLE
RED-45: Reference base Docker images via digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10.15.0-alpine
+# node:10.15.0-alpine
+FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
 
 WORKDIR /app 
 


### PR DESCRIPTION
So that we can have confidence our base images aren't being changed without our
knowledge, reference them by digest instead of tag (as tags are not immutable).

Also, add a comment detailing the tag the digest corresponds to.