### PR TITLE
PP-5295 Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "security"
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
## WHAT
Based on the options available https://dependabot.com/docs/config-file
- Configured security only updates for development libraries
- Allowed all updates for production libraries
- Scheduled dependabot updates to weekly

No options found to configure major/minor/patch versions. It is all / security only config as of now. So development libraries only receives `security` updates and to be upgraded manually.