### PR TITLE
RED-80 Toolbox build/ deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,4 @@
 pipeline {
-  // use the repository Dockerfile for building the environment image
-  // agent { dockerfile true }
   agent any
   options { timestamps() }
   parameters {
@@ -23,7 +21,6 @@ pipeline {
       agent { docker { image "govukpay/toolbox:${env.image}" } }
       stages {
         stage('Setup') {
-          // agent { docker { image "govukpay/toolbox:${env.GIT_COMMIT}-${env.BUILD_NUMBER}" } }
           steps {
             sh 'node --version'
             sh 'npm --version'
@@ -34,7 +31,6 @@ pipeline {
           }
         }
         stage('Security audit') {
-          // agent { docker { image "govukpay/toolbox:${env.GIT_COMMIT}-${env.BUILD_NUMBER}" } }
           when {
             not { expression { return params.SKIP_NPM_AUDIT } }
           }
@@ -43,31 +39,18 @@ pipeline {
           }
         }
         stage('Lint') {
-          // agent { docker { image "govukpay/toolbox:${env.GIT_COMMIT}-${env.BUILD_NUMBER}" } }
           steps {
             sh 'npm run lint'
           }
         }
         stage('Unit tests') {
-          // agent { docker { image "govukpay/toolbox:${env.GIT_COMMIT}-${env.BUILD_NUMBER}" } }
           steps {
             sh 'npm run test:unit'
           }
         }
       }
     }
-    // stage('Build') {
-    //   steps {
-    //     script {
-    //       env.GIT_COMMIT = gitCommit()
-    //       buildAppWithMetrics {
-    //         app = "toolbox"
-    //       }
-    //     }
-    //   }
-    // }
-
-    stage('Build and deploy') {
+   stage('Build and deploy') {
       stages {
         // @TODO(sfount) investigate using built-in Jenkins `docker.build()` and
         //               `docker.push()` commands in steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
     }
     // @TODO(sfount) investigate using built-in Jenkins `docker.build()` and
     //               `docker.push()` commands in steps
-    stage('DockerHub tag/push') {
+    stage('Docker push') {
       steps {
         script {
           /* image = docker.build "govukpay/toolbox" */
@@ -64,6 +64,22 @@ pipeline {
             app = "toolbox"
           }
         }
+      }
+    }
+    stage('Deploy') {
+      // when {
+        // branch 'master'
+      // }
+      steps {
+        deployEcs("toolbox")
+      }
+    }
+    stage('Tag deployment') {
+      // when {
+        // branch 'master'
+      // }
+      steps {
+        tagDeployment("toolbox")
       }
     }
   }


### PR DESCRIPTION
* add pay Jenkins library
* dockerhub tag step

Temporary middle-ground between aiming to use `agent { dockerfile true }` to ensure all stages are built with the repositories configuration and making use of the `pay-jenkins-library` -- uses the manually built and tagged docker container to run each step, allowing the library steps to access the main jenkins box.

Depends on infra#2198