### PR TITLE
PP-5329 Add health check endpoint for ECS

### DIFF
--- a/src/lib/healthcheck.js
+++ b/src/lib/healthcheck.js
@@ -1,0 +1,9 @@
+const response = function response(req, res) {
+  // dropwizard like application ping response
+  const context = {
+    ping: { healthy: true, message: 'Healthy' }
+  }
+  res.status(200).json(context)
+}
+
+module.exports = { response }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -3,6 +3,7 @@
 const express = require('express')
 
 const auth = require('./../lib/auth')
+const healthcheck = require('./../lib/healthcheck')
 
 // module HTTP controllers
 const landing = require('./modules/landing/landing.http')
@@ -54,4 +55,7 @@ router.post('/stripe/create', auth.secured, stripe.createAccount.http, stripe.cr
 
 router.get('/stripe/basic/create', auth.secured, stripe.basic)
 router.post('/stripe/basic/create', auth.secured, stripe.basicCreate)
+
+router.get('/healthcheck', healthcheck.response)
+
 module.exports = router


### PR DESCRIPTION
`/healthcheck` route, response parity with other DropWizard micro services. No further services downstream so just respond as directly healthy.