### PR TITLE
PP-5322 Use https proxy agent if httpsProxy is set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,14 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -1314,7 +1322,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1575,6 +1582,19 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -3258,6 +3278,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "express": "4.17.1",
     "govuk-frontend": "2.12.0",
     "helmet": "3.18.0",
+    "https-proxy-agent": "2.2.1",
     "joi": "14.3.1",
     "lodash": "^4.17.11",
     "morgan": "1.9.1",

--- a/src/lib/auth/passport.js
+++ b/src/lib/auth/passport.js
@@ -1,5 +1,6 @@
 // configure app wide passport instance
 const passport = require('passport')
+const HTTPSProxyAgent = require('https-proxy-agent')
 const logger = require('../logger')
 
 const { Strategy, githubAuthCredentials, handleGitHubOAuthSuccessResponse } = require('./github/strategy')
@@ -15,6 +16,13 @@ const deserialiseAuthFromSession = function deserialiseAuthFromSession(profile, 
 passport.serializeUser(serialiseAuthForSession)
 passport.deserializeUser(deserialiseAuthFromSession)
 
-passport.use(new Strategy(githubAuthCredentials, handleGitHubOAuthSuccessResponse))
+const strategy = new Strategy(githubAuthCredentials, handleGitHubOAuthSuccessResponse)
+
+// temporarily force oauth2 strategy to use proxy agent until the library supports https proxy
+const httpsProxy = process.env.https_proxy
+// eslint-disable-next-line no-underscore-dangle
+if (httpsProxy) strategy._oauth2.setAgent(new HTTPSProxyAgent(httpsProxy))
+
+passport.use(strategy)
 
 module.exports = passport


### PR DESCRIPTION
Passport OAuth2 library doesn't support `https_proxy` environment
variable, override the agent until it is supported.