### PR TITLE
BAU User profile header

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build:copy": "copyfiles --up 1 src/**/*.njk dist/",
     "preinstall": "echo \"Preinstall hook\" && exit 0",
     "prepare": "npm run build:sass",
-    "postinstall": "echo \"postinstall set to run with prepare (only in dev)\" && exit 0"
+    "postinstall": "echo \"postinstall set to run with prepare (only in dev)\" && exit 0",
+    "version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",

--- a/scripts/compile-assets
+++ b/scripts/compile-assets
@@ -3,7 +3,7 @@
 # Ensure structure for writing file exists
 mkdir -p dist/public
 
-# Cleanup previous builds for SASS 
+# Cleanup previous builds for SASS
 rm -f app/public/payuk-toolbox*
 
 # Build CSS from SASS root document
@@ -11,6 +11,7 @@ APPLICATION_SASS="src/assets/payuk-toolbox.scss"
 BUILD_FOLDER="dist/public"
 BUILD_TARGET="payuk-toolbox"
 MANIFEST_TARGET="$BUILD_FOLDER/manifest.json"
+VERSION=$(npm run version --silent)
 
 TEMP_FILE="$BUILD_FOLDER/$BUILD_TARGET.tmp"
 node-sass --output-style compressed $APPLICATION_SASS > $TEMP_FILE
@@ -23,5 +24,8 @@ mv "$TEMP_FILE" "$OUT_FILE"
 echo "Application styles compiled ($OUT_FILE)"
 
 # Write a manifest to be used by templating libraries pointing to this resource
-echo "{ \"payuk-toolbox.css\": \"/public/$BUILD_TARGET-$HASH.css\" }" > $MANIFEST_TARGET
+echo "{
+  \"payuk-toolbox.css\": \"/public/$BUILD_TARGET-$HASH.css\",
+  \"version\": \"$VERSION\"
+  }" > $MANIFEST_TARGET
 echo "Asset manifest written ($MANIFEST_TARGET)"

--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -1,16 +1,16 @@
 /*  @TODO(sfount) only import scss from frontend that is required */
-@import "node_modules/govuk-frontend/all"; 
+@import "node_modules/govuk-frontend/all";
 
-.success-summary { 
+.success-summary {
   border-color: govuk-colour("green");
 }
 
-.success-summary > .govuk-error-summary__title { 
+.success-summary > .govuk-error-summary__title {
   margin-bottom: 0px;
 }
 
-.circle { 
-  width: 15px; 
+.circle {
+  width: 15px;
   height: 15px;
   background-color: govuk-colour("grey-3");
   border-radius: 50%;
@@ -18,11 +18,11 @@
   display: inline-block;
 }
 
-.status-connected { 
+.status-connected {
   background-color: govuk-colour("green");
 }
 
-.status-disconnected { 
+.status-disconnected {
   background-color: govuk-colour("red");
 }
 
@@ -41,4 +41,26 @@
       margin-top: 0;
     }
   }
+}
+
+.user-profile {
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.user-profile__container {
+  @include govuk-font($size: 16);
+  @include govuk-text-colour;
+
+  display: flex;
+  flex-direction: row;
+}
+
+.user-profile__item {
+  margin-right: 5px;
+}
+
+.avatar {
+  border-radius: 3px;
 }

--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -58,7 +58,16 @@
 }
 
 .user-profile__item {
-  margin-right: 5px;
+  line-height: normal;
+}
+.user-profile__item:not(:last-child) {
+  margin-right: govuk-spacing(1);
+}
+.user-profile__item.right {
+  margin-left: auto;
+}
+.user-profile__item img {
+  vertical-align: middle;
 }
 
 .avatar {

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -23,4 +23,10 @@ const unauthorised = function unauthorised(req, res, next) {
   res.status(403).send('User does not have permissions to access the resource')
 }
 
-module.exports = { secured, unauthorised }
+const revokeSession = function revokeSession(req, res, next) {
+  logger.info(`Revoking session for user ${req.user.username}`)
+  req.logout()
+  res.redirect('/')
+}
+
+module.exports = { secured, unauthorised, revokeSession }

--- a/src/lib/auth/github/githubStrategy.spec.js
+++ b/src/lib/auth/github/githubStrategy.spec.js
@@ -14,7 +14,8 @@ const invalidPermissions = async (username, token) => {
 }
 
 describe('GitHub OAuth strategy', () => {
-  const profile = { username: 'some-test-user', displayName: 'Some User', avaterUrl: 'some-url' }
+  // eslint-disable-next-line key-spacing
+  const profile = { username: 'some-test-user', displayName: 'Some User', _json: { avatar_url : 'some-url' } }
   let handleGitHubOAuthSuccessResponse
 
   beforeEach(() => {
@@ -36,7 +37,13 @@ describe('GitHub OAuth strategy', () => {
 
     expect(authCallbackSpy).to.have.been.called.once.with(
       null,
-      { user: profile.username, fullName: profile.displayName, avatarUrl: profile.avatarUrl }
+      {
+        username: profile.username,
+        displayName: profile.displayName,
+
+        // eslint-disable-next-line no-underscore-dangle
+        avatarUrl: profile._json.avatar_url
+      }
     )
   })
 

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -21,11 +21,7 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
   try {
     // eslint-disable-next-line no-underscore-dangle
     const avatarUrl = profile._json && profile._json.avatar_url
-    const sessionProfile = {
-      user: username,
-      fullName: displayName,
-      avatarUrl
-    }
+    const sessionProfile = { username, displayName, avatarUrl }
 
     logger.info(`Successful account auth from GitHub for user ${username}`)
     await isPermittedUser(username, accessToken)

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -94,7 +94,7 @@
             <a class="govuk-footer__link" href="https://github.com/alphagov/pay-toolbox">alphagov/pay-toolbox</a>
           </div>
           <div class="govuk-footer__meta-custom">
-            <!-- span>pay-toolbox-revised(1.0.4)</span -->
+            <span>alphagov/pay-toolbox ({{ manifest.version }})</span>
           </div>
         </div>
       </div>

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Toolbox</title>
   <link rel="stylesheet" href="{{ manifest['payuk-toolbox.css'] }}">
+  <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon">
 </html>
 
 <body class="govuk-template__body js-enabled">
@@ -21,6 +22,7 @@
   </header>
 
   <div class="govuk-width-container">
+    {% include "layout/user_banner.njk" %}
 		{{
 			govukPhaseBanner({
 				tag: { text: 'alpha' },
@@ -31,7 +33,7 @@
     <div class="govuk-main-wrapper govuk-!-padding-top-4">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
-          
+
           <h4 class="govuk-heading-s app-subnav__header">Statistics</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
@@ -57,7 +59,7 @@
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts/direct_debit">Direct debit</a>
             </li>
           </ul>
-        
+
           <h4 class="govuk-heading-s app-subnav__header">Services</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
@@ -67,7 +69,7 @@
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services/search">Find a service</a>
             </li>
           </ul>
-        
+
           <h4 class="govuk-heading-s app-subnav__header">Transactions</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -23,12 +23,6 @@
 
   <div class="govuk-width-container">
     {% include "layout/user_banner.njk" %}
-		{{
-			govukPhaseBanner({
-				tag: { text: 'alpha' },
-				html: 'This tool is in active development. It should not be used in production.'
-			})
-		}}
 
     <div class="govuk-main-wrapper govuk-!-padding-top-4">
       <div class="govuk-grid-row">
@@ -97,11 +91,10 @@
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <div class="govuk-footer__meta-custom">
             <span>To contribute or request features please refer to </span>
-            <a class="govuk-footer__link" href="https://github.com/alphagov/pay-toolbox-revised">alphagov/pay-toolbox-revised</a>
+            <a class="govuk-footer__link" href="https://github.com/alphagov/pay-toolbox">alphagov/pay-toolbox</a>
           </div>
           <div class="govuk-footer__meta-custom">
             <!-- span>pay-toolbox-revised(1.0.4)</span -->
-            <!-- span>pay-toolbox-revised(1.0.4) served <code>er32523</code></span -->
           </div>
         </div>
       </div>

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -39,9 +39,6 @@
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/compare/date">Compare two days</a>
             </li>
-            <li class="app-subnav__section-item">
-              <span class="app-subnav__link"><s>For a service</s></span>
-            </li>
           </ul>
 
           <h4 class="govuk-heading-s app-subnav__header">Gateway accounts</h4>

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -9,7 +9,7 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/signout">Clear session</a></span>
+      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
     </div>
   </div>
 </div>

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -5,7 +5,11 @@
     </div>
 
     <div class="user-profile__item">
-      {{ user.displayName or user.username }}
+      <span>{{ user.displayName or user.username }}</span>
+    </div>
+
+    <div class="user-profile__item right">
+      <span><a class="govuk-link govuk-link--no-visited-state" href="/signout">Clear session</a></span>
     </div>
   </div>
 </div>

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -1,0 +1,11 @@
+<div class="user-profile">
+  <div class="user-profile__container">
+    <div class="user-profile__item">
+      <img class="avatar" height="20" width="20" src="{{ user.avatarUrl }}">
+    </div>
+
+    <div class="user-profile__item">
+      {{ user.displayName or user.username }}
+    </div>
+  </div>
+</div>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -61,6 +61,8 @@ router.post('/stripe/create', auth.secured, stripe.createAccount.http, stripe.cr
 router.get('/stripe/basic/create', auth.secured, stripe.basic)
 router.post('/stripe/basic/create', auth.secured, stripe.basicCreate)
 
+router.get('/logout', auth.secured, auth.revokeSession)
+
 router.get('/healthcheck', healthcheck.response)
 
 module.exports = router

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -28,7 +28,10 @@ const app = express()
 const configureSecureHeaders = function configureSecureHeaders(instance) {
   instance.use(helmet())
   instance.use(helmet.contentSecurityPolicy({
-    directives: { defaultSrc: [ '\'self\'' ] }
+    directives: {
+      defaultSrc: [ '\'self\'' ],
+      imgSrc: [ 'avatars3.githubusercontent.com', '\'self\'' ]
+    }
   }))
 
   instance.use(csurf())
@@ -56,20 +59,26 @@ const configureServingPublicStaticFiles = function configureServingPublicStaticF
   const cache = { maxage: '1y' }
   instance.use('/public', express.static(path.join(__dirname, '../public'), cache))
   instance.use('/assets/fonts', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/assets/fonts'), cache))
-  instance.use('/favicon.ico', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/assets/images/', 'favicon.ico')))
+  instance.use('/images/favicon.ico', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/assets/images/', 'favicon.ico'), cache))
 }
 
 const configureClientSessions = function configureClientSessions(instance) {
   instance.use(cookieSession({
-    name: 'pay-toolbox-service-cookies',
+    name: 'tbx',
     keys: [ server.COOKIE_SESSION_ENCRYPTION_SECRET ],
     maxAge: '24h'
   }))
 }
 
 const configureAuth = function configureAuth(instance) {
+  const exposeAuthenticatedUserToTemplate = (req, res, next) => {
+    res.locals.user = req.user
+    next()
+  }
+
   instance.use(passport.initialize())
   instance.use(passport.session())
+  instance.use(exposeAuthenticatedUserToTemplate)
 }
 
 const configureTemplateRendering = function configureTemplateRendering(instance) {


### PR DESCRIPTION
User banner to give visual indication of currently authenticated user -- this is the user that will be authorising all actions/ requests and this should be made clear. 

On desktop: 
![Screen Shot 2019-06-15 at 18 46 55](https://user-images.githubusercontent.com/2844572/59554675-6abeba80-8f9e-11e9-89eb-87870c16b06b.png)

On mobile: 
![Screen Shot 2019-06-15 at 18 47 19](https://user-images.githubusercontent.com/2844572/59554677-6db9ab00-8f9e-11e9-8518-425e7aac1d9f.png)

Minor layout tweaks: 
* include application version in layout template 
* remove unused links 
* explicitly define and cache favicon
* remove alpha software banner

(recommend ignoring whitespace on file diff as older files cleaned up)