### PR TITLE
PP-5324 Application production logging

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -31,9 +31,13 @@ const loggerMiddleware = function loggerMiddleware(
 ): void {
   session.run((): void => {
     const correlationHeader = 'x-request-id'
-    session.set(TOOLBOX_ID_KEY, crypto.randomBytes(4).toString('hex'))
+    const toolboxId = crypto.randomBytes(4).toString('hex')
+    session.set(TOOLBOX_ID_KEY, toolboxId)
     session.set(CORRELATION_ID_KEY, req.headers[correlationHeader])
     session.set(AUTHENTICATED_USER_ID_KEY, req.user && req.user.user)
+
+    // expose toolbox ID to template for debugging
+    res.locals.toolboxId = toolboxId
     next()
   })
 }
@@ -60,8 +64,8 @@ if (!config.common.development) {
 }
 
 const payLogsFormatter = printf((log) => {
-  const id = session.get('toolbox_id')
-  const user = session.get('authenticated_user_id')
+  const id = session.get(TOOLBOX_ID_KEY)
+  const user = session.get(AUTHENTICATED_USER_ID_KEY)
   return `${log.timestamp} [${id || '(none)'}] [${user || '(no_user)'}] ${log.level}: ${log.message}`
 })
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -71,9 +71,10 @@ if (config.common.development) {
   const developmentTransport = new transports.Console({
     level: 'debug',
     format: combine(
-      format.colorize(),
+      format(info => Object.assign(info, { toolboxId: session.get(TOOLBOX_ID_KEY) }))(),
       timestamp({ format: 'HH:mm:ss' }),
-      payLogsFormatter
+      format.colorize(),
+      format.simple()
     )
   })
   logger.add(developmentTransport)

--- a/src/lib/pay-request/client.js
+++ b/src/lib/pay-request/client.js
@@ -25,21 +25,35 @@ const timestampRequest = function timestampRequest(request) {
 }
 
 const logSuccessfulResponse = function logSuccessfulResponse(response) {
+  const logContext = {
+    service: this.metadata.serviceKey,
+    method: response.request.method,
+    url: response.config.url,
+    duration: response.config.metadata.duration
+  }
+
   response.config.metadata.end = new Date()
   response.config.metadata.duration = response.config.metadata.end - response.config.metadata.start
-  logger.debug(`[${this.metadata.serviceKey}] "${response.request.method}" success from ${response.config.url} (${response.config.metadata.duration}ms)`)
+  logger.info('Pay request: internal service success fulfilled', logContext)
   return response
 }
 
 const logFailureResponse = function logFailureResponse(error) {
   const code = (error.response && error.response.status) || error.code
+  const logContext = {
+    service: this.metadata.serviceKey,
+    method: error.config.method,
+    url: error.config.url,
+    duration: error.config.metadata.duration,
+    code
+  }
 
   // @TODO(sfount) review how errors are passed through axios stack, favour
   //               not disabling eslint rules
   error.config.metadata.end = new Date() // eslint-disable-line no-param-reassign
   // eslint-disable-next-line no-param-reassign
   error.config.metadata.duration = error.config.metadata.end - error.config.metadata.start
-  logger.debug(`[${this.metadata.serviceKey}] "${error.config.method}" failed with ${code} from ${error.config.url} (${error.config.metadata.duration}ms)`)
+  logger.warn('Pay request: internal service request failed', logContext)
   return Promise.reject(
     new RESTClientError(error, this.metadata.serviceKey, this.metadata.serviceName)
   )

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -92,6 +92,7 @@
           </div>
           <div class="govuk-footer__meta-custom">
             <span>alphagov/pay-toolbox ({{ manifest.version }})</span>
+            <span>π ({{ toolboxId }})</span>
           </div>
         </div>
       </div>

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -89,10 +89,8 @@ const configureTemplateRendering = function configureTemplateRendering(instance)
   instance.set('view engine', 'njk')
 }
 
-// @TODO(sfount) double check that errors thrown by CSRF prevention etc. have enough information to log
-// -- putting this so late in the stack might mean those logs fail
 const configureRouting = function configureRouting(instance) {
-  const httpRequestLoggingFormat = common.development ? 'dev' : 'common'
+  const httpRequestLoggingFormat = common.development ? 'dev' : 'short'
 
   // logger middleware included after flash and body parsing middleware as they
   // alter the call stack (it should ideally be placed just before routes)

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -38,8 +38,6 @@ const configureSecureHeaders = function configureSecureHeaders(instance) {
 }
 
 const configureRequestParsing = function configureRequestParsing(instance) {
-  const httpRequestLoggingFormat = common.production ? 'short' : 'dev'
-
   if (!common.development) {
     // service is behind a front-facing proxy - set req IP values accordinglyi
     instance.enable('trust proxy')
@@ -48,11 +46,6 @@ const configureRequestParsing = function configureRequestParsing(instance) {
   instance.use(bodyParser.urlencoded({ extended: false }))
   instance.use(bodyParser.json({ strict: true, limit: '15kb' }))
   instance.use(flash())
-
-  // logger middleware included after flash and body parsing middleware as they
-  // alter the call stack (it should ideally be placed just before routes)
-  instance.use(logger.middleware)
-  instance.use(morgan(httpRequestLoggingFormat, { stream: logger.stream }))
 }
 
 const configureServingPublicStaticFiles = function configureServingPublicStaticFiles(instance) {
@@ -96,7 +89,16 @@ const configureTemplateRendering = function configureTemplateRendering(instance)
   instance.set('view engine', 'njk')
 }
 
+// @TODO(sfount) double check that errors thrown by CSRF prevention etc. have enough information to log
+// -- putting this so late in the stack might mean those logs fail
 const configureRouting = function configureRouting(instance) {
+  const httpRequestLoggingFormat = common.development ? 'dev' : 'common'
+
+  // logger middleware included after flash and body parsing middleware as they
+  // alter the call stack (it should ideally be placed just before routes)
+  instance.use(logger.middleware)
+  instance.use(morgan(httpRequestLoggingFormat, { stream: logger.stream }))
+
   instance.use('/', router)
   instance.use(errors.handleNotFound)
 }


### PR DESCRIPTION
Default all logs recorded by Toolbox service to include the authenticated user ID - anything HTTP request or internal service API that is accessed with include the session user (ref: security ticket).

* configure JSON production logging
* supplement production logs with request meta data: 
  * current authenticated GitHub username (user id) 
  * correlation ID to track requests through all micro services 
  * toolbox ID to track requests through Toolbox service 
* format development logs to include meta details
* simplify logging in `pay-request` to leverage meta details in favour of custom strings

Micro service tracing: 
* propagate correlation ID through to other microservices, populate the `x-request-id` header if received