### PR TITLE
BAU Cleanup production headers

### DIFF
--- a/src/@types/https-proxy-agent.d.ts
+++ b/src/@types/https-proxy-agent.d.ts
@@ -1,0 +1,21 @@
+declare module 'https-proxy-agent' {
+  import * as https from 'https'
+
+  namespace HttpsProxyAgent {
+      interface HttpsProxyAgentOptions {
+          host: string
+          port: number
+          secureProxy?: boolean
+          headers?: {
+              [key: string]: string
+          }
+          [key: string]: any
+      }
+  }
+
+  class HttpsProxyAgent extends https.Agent {
+      constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions)
+  }
+
+  export = HttpsProxyAgent
+}

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -2,7 +2,8 @@ const Joi = require('joi')
 
 const expectedServerEnvironmentValues = {
   PORT: Joi.number().integer().required(),
-  COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required()
+  COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required(),
+  HTTP_PROXY: Joi.string()
 }
 
 const { error, value: validatedServerEnvironmentValues } = Joi.validate(

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -3,7 +3,8 @@ const Joi = require('joi')
 const expectedServerEnvironmentValues = {
   PORT: Joi.number().integer().required(),
   COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required(),
-  HTTP_PROXY: Joi.string()
+  HTTP_PROXY: Joi.string(),
+  HTTPS_PROXY: Joi.string()
 }
 
 const { error, value: validatedServerEnvironmentValues } = Joi.validate(

--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -1,7 +1,9 @@
 import * as Stripe from 'stripe'
+import * as HTTPSProxyAgent from 'https-proxy-agent'
 import { Request, Response } from 'express'
 
 import * as logger from '../../../../lib/logger'
+import * as config from '../../../../config'
 import { AdminUsers } from '../../../../lib/pay-request'
 import { ValidationError as CustomValidationError, IOValidationError } from '../../../../lib/errors'
 import { wrapAsyncErrorHandler } from '../../../../lib/routes'
@@ -13,6 +15,10 @@ const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
 const stripe = new Stripe(STRIPE_ACCOUNT_API_KEY)
 const { StripeError } = Stripe.errors
 
+if (config.server.HTTPS_PROXY) {
+  // @ts-ignore
+  stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+}
 stripe.setApiVersion('2018-09-24')
 
 const createAccountForm = async function createAccountForm(

--- a/src/web/modules/stripe/stripe.http.js
+++ b/src/web/modules/stripe/stripe.http.js
@@ -1,8 +1,13 @@
 const { STRIPE_ACCOUNT_API_KEY } = process.env
+const HTTPSProxyAgent = require('https-proxy-agent')
 const stripe = require('stripe')(STRIPE_ACCOUNT_API_KEY)
 
+const { server } = require('./../../../config')
 const logger = require('./../../../lib/logger')
 
+if (server.HTTPS_PROXY) {
+  stripe.setHttpAgent(new HTTPSProxyAgent(server.HTTPS_PROXY))
+}
 stripe.setApiVersion('2018-09-24')
 
 const { AdminUsers } = require('./../../../lib/pay-request')

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -26,7 +26,15 @@ const staticResourceManifest = require('./../public/manifest')
 const app = express()
 
 const configureSecureHeaders = function configureSecureHeaders(instance) {
-  instance.use(helmet())
+  const serverBehindProxy = server.HTTP_PROXY
+
+  // only set certain proxy configured headers if not behind a proxy
+  instance.use(helmet({
+    noSniff: !serverBehindProxy,
+    framegaurd: !serverBehindProxy,
+    hsts: !serverBehindProxy,
+    xssFilter: !serverBehindProxy
+  }))
   instance.use(helmet.contentSecurityPolicy({
     directives: {
       defaultSrc: [ '\'self\'' ],


### PR DESCRIPTION
* don't (double)  set certain security headers if they are already set by proxy 
* explicitly set the https proxy agent for stripe client for production environment