### PR TITLE
BAU Explicitly copy source folder in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ COPY package*.json ./
 # prepare build process modules
 RUN npm ci --no-progress
 
-COPY . .
+# ideally command is COPY scr/ scripts/ tsconfig.json ./
+# COPY flattens file structures so this is not possible inline right now
+# ref: https://github.com/moby/moby/issues/15858
+COPY src/ src
+COPY scripts/ scripts
+COPY tsconfig.json tsconfig.json
 
 # questionable method of setting build defaults - this should be removed when
 # tunneling is no longer required


### PR DESCRIPTION
Favour individual copies in favour of `COPY . .`

CI can take up to 2 minutes to run `COPY . .` command

```
15:51:01  Step 5/10 : COPY . .
15:51:57   ---> 56f51277ba45
```
https://build.ci.pymnt.uk/job/pay-toolbox/job/master/41/

```
12:09:49  Step 5/10 : COPY . .
12:10:45   ---> b293647d2ed2
```
https://build.ci.pymnt.uk/job/pay-toolbox/job/master/40/

```
17:12:42  Step 5/10 : COPY . .
17:13:38   ---> 67e58d1c8ae9
```
https://build.ci.pymnt.uk/job/pay-toolbox/job/master/38/