### PR TITLE
BAU Support docker package manager in config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,3 +11,6 @@ update_configs:
       - match:
           dependency_type: "production"
           update_type: "all"
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# node:10.15.0-alpine
 FROM node@sha256:409726705cd454a527af5032f67ef068556f10d3c40bb4cc5c6ed875e686b00e
 
 WORKDIR /app


### PR DESCRIPTION
* remove source version to meet Pay Dockerfile best practices (recently
updated by RE-D)
* add docker package manager to dependabot config