### PR TITLE
Revert "Bump https-proxy-agent from 2.2.1 to 2.2.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3238,11 +3238,11 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "^4.3.0",
+        "agent-base": "^4.1.0",
         "debug": "^3.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "4.17.1",
     "govuk-frontend": "2.13.0",
     "helmet": "3.18.0",
-    "https-proxy-agent": "2.2.2",
+    "https-proxy-agent": "2.2.1",
     "joi": "14.3.1",
     "lodash": "4.17.13",
     "morgan": "1.9.1",

--- a/src/@types/https-proxy-agent.d.ts
+++ b/src/@types/https-proxy-agent.d.ts
@@ -1,0 +1,21 @@
+declare module 'https-proxy-agent' {
+  import * as https from 'https'
+
+  namespace HttpsProxyAgent {
+      interface HttpsProxyAgentOptions {
+          host: string
+          port: number
+          secureProxy?: boolean
+          headers?: {
+              [key: string]: string
+          }
+          [key: string]: any
+      }
+  }
+
+  class HttpsProxyAgent extends https.Agent {
+      constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions)
+  }
+
+  export = HttpsProxyAgent
+}

--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -1,5 +1,5 @@
 import * as Stripe from 'stripe'
-import HTTPSProxyAgent from 'https-proxy-agent'
+import * as HTTPSProxyAgent from 'https-proxy-agent'
 import { Request, Response } from 'express'
 
 import * as logger from '../../../../lib/logger'


### PR DESCRIPTION
Failing to build in test environment, revert to see if production environment isn't happy with this change. 

Reverts alphagov/pay-toolbox#142