### PR TITLE
BAU Dependabot live security updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,13 +4,16 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
     allowed_updates:
       - match:
           dependency_type: "development"
           update_type: "security"
       - match:
           dependency_type: "production"
-          update_type: "all"
+          update_type: "security"
   - package_manager: "docker"
     directory: "/"
     update_schedule: "daily"


### PR DESCRIPTION
Not 100% if Dependabot will respect multiple entries for the same package manager, this configuration would work well for us though. 
* Patch security issues as soon as they come up (stopping Snyk/ `npm audit` from complaining) 
* Patch other updates on a weekly basis 