### PR TITLE
BAU Fix empty custom branding case

### DIFF
--- a/src/web/modules/services/branding.spec.ts
+++ b/src/web/modules/services/branding.spec.ts
@@ -11,4 +11,9 @@ describe('Custom branding utilities', () => {
     const url = '/some/absolute/url'
     expect(sanitiseCustomBrandingURL(url)).to.equal(url)
   })
+
+  it('Just returns nothing if no values are passed, no preceding \/ added', () => {
+    const url = ''
+    expect(sanitiseCustomBrandingURL(url)).to.equal('')
+  })
 })

--- a/src/web/modules/services/branding.ts
+++ b/src/web/modules/services/branding.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export function sanitiseCustomBrandingURL(url: string): string {
-  return url.startsWith('/') ? url : `/${url}`
+  const urlIsAbsolute = url.startsWith('/') || url.length === 0
+  return urlIsAbsolute ? url : `/${url}`
 }


### PR DESCRIPTION
Setting a URL of `/` doesn't make our frontend apps happy -- allow empty strings.