### PR TITLE
BAU Set failure redirect flag for services

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -126,6 +126,21 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.patch(path, payload).then(utilExtractData)
   }
 
+  const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedirectFlag(
+    id,
+    status
+  ) {
+    const path = `v1/api/services/${id}`
+    const targetService = await service(id)
+
+    const payload = {
+      op: 'replace',
+      path: 'redirect_to_service_immediately_on_terminal_state',
+      value: !targetService.redirect_to_service_immediately_on_terminal_state
+    }
+    return axiosInstance.patch(path, payload).then(utilExtractData)
+  }
+
   return {
     user,
     service,
@@ -140,7 +155,8 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     updateUserEmail,
     toggleUserEnabled,
     removeUserFromService,
-    resetUserSecondFactor
+    resetUserSecondFactor,
+    toggleTerminalStateRedirectFlag
   }
 }
 

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -29,7 +29,13 @@
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Description</th>
-        <td class="govuk-table__cell">{{ account.description }}</td>
+        <td class="govuk-table__cell">
+          {% if account.description %}
+          {{ account.description }}
+          {% else %}
+          <i>(None set)</i>
+          {% endif %}
+        </td>
       </tr>
       <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Payment method</th>
@@ -47,7 +53,13 @@
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Analytics</th>
-        <td class="govuk-table__cell"><code>{{ account.analytics_id }}</code></td>
+        <td class="govuk-table__cell">
+          {% if account.analytics_id %}
+          <code>{{ account.analytics_id }}</code>
+          {% else %}
+          <i>(None set)</i>
+          {% endif %}
+        </td>
       </tr>
       {% if account.toggle_3ds != undefined %}
           <tr class="govuk-table__row">

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -114,6 +114,12 @@
       href: "/services/" + serviceId + "/link_accounts"
       })
     }}
+    {{ govukButton({
+      text: "Toggle redirect to service on terminal state flag",
+      classes: "govuk-button--warning",
+      href: "/services/" + serviceId + "/toggle_terminal_state_redirect"
+      })
+    }}
   </div>
 
   <div>

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -114,14 +114,18 @@
       href: "/services/" + serviceId + "/link_accounts"
       })
     }}
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s">Toggle redirect to service on terminal state flag</h1>
+    <p class="govuk-body">Enabling this flag for a service will change the payment flow across all gateway accounts, this should never be done without consulting the service.</p>
+    <p class="govuk-body">Reference the <a <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/use_your_own_error_pages/#use-your-own-payment-failure-pages">use your own error pages</a> documentation for more details.</p>
     {{ govukButton({
       text: "Toggle redirect to service on terminal state flag",
       classes: "govuk-button--warning",
       href: "/services/" + serviceId + "/toggle_terminal_state_redirect"
       })
     }}
-  </div>
-
   <div>
     <pre><code>{{ service | dump('\t') }}</code></pre>
     <pre><code>{{ users | dump('\t') }}</code></pre>

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -29,6 +29,10 @@
         <td class="govuk-table__cell">{{service.current_go_live_stage | upper }}</td>
       </tr>
       <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Redirect to service on terminal state</th>
+        <td class="govuk-table__cell">{{service.redirect_to_service_immediately_on_terminal_state | string | capitalize }}</td>
+      </tr>
+      <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Gateway accounts</th>
         <td class="govuk-table__cell">
           {% for id in service.gateway_account_ids %}

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -15,5 +15,6 @@ export default {
     exceptions: exceptions.updateLinkAccounts
   },
   search: http.search,
-  searchRequest: http.searchRequest
+  searchRequest: http.searchRequest,
+  toggleTerminalStateRedirectFlag: http.toggleTerminalStateRedirectFlag
 }

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -84,6 +84,20 @@ const searchRequest = async function searchRequest(req: Request, res: Response):
   res.redirect(`/services/${req.body.id}`)
 }
 
+const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedirectFlag(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const serviceId = req.params.id
+
+  const serviceResult = await AdminUsers.toggleTerminalStateRedirectFlag(serviceId)
+  const { redirect_to_service_immediately_on_terminal_state: state } = serviceResult
+  logger.info(`Toggled redirect to service on terminal state flag to ${state} for service ${serviceId}`, { externalId: serviceId })
+
+  req.flash('info', `Redirect to service on terminal state flag set to ${state} for service`)
+  res.redirect(`/services/${serviceId}`)
+}
+
 export default {
   overview: wrapAsyncErrorHandler(overview),
   detail: wrapAsyncErrorHandler(detail),
@@ -92,5 +106,6 @@ export default {
   linkAccounts: wrapAsyncErrorHandler(linkAccounts),
   updateLinkAccounts: wrapAsyncErrorHandler(updateLinkAccounts),
   search: wrapAsyncErrorHandler(search),
-  searchRequest: wrapAsyncErrorHandler(searchRequest)
+  searchRequest: wrapAsyncErrorHandler(searchRequest),
+  toggleTerminalStateRedirectFlag: wrapAsyncErrorHandler(toggleTerminalStateRedirectFlag)
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -52,6 +52,7 @@ router.get('/services/:id/branding', auth.secured, services.branding, services.d
 router.post('/services/:id/branding', auth.secured, services.updateBranding)
 router.get('/services/:id/link_accounts', auth.secured, services.linkAccounts, services.detail.exceptions)
 router.post('/services/:id/link_accounts', auth.secured, services.updateLinkAccounts.http, services.updateLinkAccounts.exceptions)
+router.get('/services/:id/toggle_terminal_state_redirect', auth.secured, services.toggleTerminalStateRedirectFlag)
 
 router.get('/services/:serviceId/gateway_account/:gatewayAccountId/payouts', auth.secured, payouts.show)
 router.get('/services/:serviceId/gateway_account/:gatewayAccountId/payouts/csv', auth.secured, payouts.listPayoutsCsv)


### PR DESCRIPTION
Allow toggling of `redirect_to_service_immediately_on_terminal_state` flag on services

* avoid manually doing it in the database 
* audit-able trail of which Pay user toggled it and when

Added service action 

![Screen Shot 2019-07-30 at 12 54 28](https://user-images.githubusercontent.com/2844572/62127120-34789880-b2c9-11e9-891b-71c86b06ae50.png)


Expose information on service detail page 

![Screen Shot 2019-07-30 at 12 43 34](https://user-images.githubusercontent.com/2844572/62126506-b49dfe80-b2c7-11e9-9f01-153812396d9f.png)
