### PR TITLE
BAU Fix services vs. transactions search page crossover

### DIFF
--- a/src/web/modules/services/search.njk
+++ b/src/web/modules/services/search.njk
@@ -9,8 +9,7 @@
     {{ govukInput({
       id: "id",
       name: "id",
-      label: { text: "Identifier" }
-      hint: { text: "Supports: ledger transaction ID, gateway ID, payment reference, ledger event ID." },
+      label: { text: "Service external ID" }
       })
     }}
 

--- a/src/web/modules/transactions/search.njk
+++ b/src/web/modules/transactions/search.njk
@@ -10,6 +10,7 @@
     {{ govukInput({
       id: "id",
       name: "id",
+      hint: { text: "Supports: ledger transaction ID, gateway ID, payment reference, ledger event ID." },
       label: { text: "Search" }
       })
       }}


### PR DESCRIPTION
* fix syntax error introduced on servie search page
* move description `hint` to the correct search page