### PR TITLE
PP-5405 admin permission roles

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -37,4 +37,9 @@ const revokeSession = function revokeSession(req, res) {
   res.redirect('/')
 }
 
-module.exports = { secured, administrative, unauthorised, revokeSession }
+module.exports = {
+  secured,
+  administrative,
+  unauthorised,
+  revokeSession
+}

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -12,6 +12,15 @@ const secured = function secured(req, res, next) {
   res.redirect('/auth')
 }
 
+const administrative = function administrative(req, res, next) {
+  if (req.user.admin) {
+    next()
+    return
+  }
+  logger.info(`Non admin user ${req.user.username} attempted to access administrative path`)
+  res.render('common/error', { message: 'Action requires admin role permissions' })
+}
+
 const unauthorised = function unauthorised(req, res) {
   if (req.isAuthenticated()) {
     res.redirect('/')
@@ -28,4 +37,4 @@ const revokeSession = function revokeSession(req, res) {
   res.redirect('/')
 }
 
-module.exports = { secured, unauthorised, revokeSession }
+module.exports = { secured, administrative, unauthorised, revokeSession }

--- a/src/lib/auth/github/githubStrategy.spec.js
+++ b/src/lib/auth/github/githubStrategy.spec.js
@@ -56,4 +56,24 @@ describe('GitHub OAuth strategy', () => {
     await handleGitHubOAuthSuccessResponse('some-access-token', 'some-refresh-token', profile, authCallbackSpy)
     expect(authCallbackSpy).to.have.been.called.once.with(null, false)
   })
+
+  it('invokes callback with admin flag set given admin permissions', async () => {
+    const authCallbackSpy = chai.spy()
+    mockery.registerMock('./permissions', { isAdminUser: validPermissions })
+    // eslint-disable-next-line prefer-destructuring
+    handleGitHubOAuthSuccessResponse = require('./strategy').handleGitHubOAuthSuccessResponse
+
+    await handleGitHubOAuthSuccessResponse('some-access-token', 'some-refresh-token', profile, authCallbackSpy)
+    expect(authCallbackSpy).to.have.been.called.once.with(
+      null,
+      {
+        username: profile.username,
+        displayName: profile.displayName,
+        admin: true,
+
+        // eslint-disable-next-line no-underscore-dangle
+        avatarUrl: profile._json.avatar_url
+      }
+    )
+  })
 })

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -3,7 +3,7 @@ const { Strategy } = require('passport-github')
 const config = require('../../../config')
 const logger = require('../../logger')
 
-const { isPermittedUser } = require('./permissions')
+const { isPermittedUser, isAdminUser } = require('./permissions')
 
 const githubAuthCredentials = {
   clientID: config.auth.AUTH_GITHUB_CLIENT_ID,
@@ -18,19 +18,29 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
   callback
 ) {
   const { username, displayName } = profile
+  // eslint-disable-next-line no-underscore-dangle
+  const avatarUrl = profile._json && profile._json.avatar_url
+  const sessionProfile = { username, displayName, avatarUrl }
+
+  logger.info(`Successful account auth from GitHub for user ${username}`)
+
   try {
-    // eslint-disable-next-line no-underscore-dangle
-    const avatarUrl = profile._json && profile._json.avatar_url
-    const sessionProfile = { username, displayName, avatarUrl }
+    await isAdminUser(username, accessToken)
 
-    logger.info(`Successful account auth from GitHub for user ${username}`)
-    await isPermittedUser(username, accessToken)
-
-    logger.info(`Permissions valid for user, setting session for ${username}`)
+    sessionProfile.admin = true
+    logger.info(`Administrator checks passed, setting session for ${username}`)
     callback(null, sessionProfile)
-  } catch (e) {
-    logger.warn(`Permissions rejected for user ${username} [${e.message}]`)
-    callback(null, false, e)
+  } catch (adminUserFailure) {
+
+    try {
+      await isPermittedUser(username, accessToken)
+
+      logger.info(`Valid non-admin permissions, setting session for ${username}`)
+      callback(null, sessionProfile)
+    } catch (permittedUserFailure) {
+      logger.warn(`Permissions rejected for user ${username} [${permittedUserFailure.message}]`)
+      callback(null, false, permittedUserFailure)
+    }
   }
 }
 

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -31,7 +31,6 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
     logger.info(`Administrator checks passed, setting session for ${username}`)
     callback(null, sessionProfile)
   } catch (adminUserFailure) {
-
     try {
       await isPermittedUser(username, accessToken)
 

--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -3,11 +3,17 @@ const { EntityNotFoundError } = require('../../errors')
 const adminUsersMethods = function adminUsersMethods(instance) {
   const axiosInstance = instance || this
   const utilExtractData = response => response.data
+  const redactOtp = (service) => {
+    // eslint-disable-next-line no-param-reassign
+    delete service.otp_key
+    return service
+  }
 
   const user = function user(id) {
     const path = `/v1/api/users/${id}`
     return axiosInstance.get(path)
       .then(utilExtractData)
+      .then(redactOtp)
       .catch((error) => {
         if (error.data.response && error.data.response.status === 404) throw new EntityNotFoundError('User', id)
         throw error
@@ -78,7 +84,9 @@ const adminUsersMethods = function adminUsersMethods(instance) {
 
   const serviceUsers = function serviceUsers(id) {
     const path = `/v1/api/services/${id}/users`
-    return axiosInstance.get(path).then(utilExtractData)
+    return axiosInstance.get(path)
+      .then(utilExtractData)
+      .then(users => users.map(redactOtp))
   }
 
   const gatewayAccountServices = function gatewayAccountServices(id) {
@@ -127,8 +135,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
   }
 
   const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedirectFlag(
-    id,
-    status
+    id
   ) {
     const path = `v1/api/services/${id}`
     const targetService = await service(id)

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -5,7 +5,10 @@
     </div>
 
     <div class="user-profile__item">
-      <span>{{ user.displayName or user.username }}</span>
+      <span>
+        {{ user.displayName or user.username }}
+        {% if user.admin %}(Admin){% endif %}
+      </span>
     </div>
 
     <div class="user-profile__item right">

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -51,9 +51,9 @@ router.get('/services/search', auth.secured, services.search)
 router.post('/services/search', auth.secured, services.searchRequest)
 router.get('/services/:id', auth.secured, services.detail.http, services.detail.exceptions)
 router.get('/services/:id/branding', auth.secured, services.branding, services.detail.exceptions)
-router.post('/services/:id/branding', auth.secured, services.updateBranding)
-router.get('/services/:id/link_accounts', auth.secured, services.linkAccounts, services.detail.exceptions)
-router.post('/services/:id/link_accounts', auth.secured, services.updateLinkAccounts.http, services.updateLinkAccounts.exceptions)
+router.post('/services/:id/branding', auth.secured, auth.administrative, services.updateBranding)
+router.get('/services/:id/link_accounts', auth.secured, auth.administrative, services.linkAccounts, services.detail.exceptions)
+router.post('/services/:id/link_accounts', auth.secured, auth.administrative, services.updateLinkAccounts.http, services.updateLinkAccounts.exceptions)
 router.get('/services/:id/toggle_terminal_state_redirect', auth.secured, services.toggleTerminalStateRedirectFlag)
 
 router.get('/services/:serviceId/gateway_account/:gatewayAccountId/payouts', auth.secured, payouts.show)
@@ -67,8 +67,8 @@ router.post('/discrepancies/resolve/:id', auth.secured, discrepancies.resolveDis
 router.get('/charges/search', auth.secured, charges.search)
 router.post('/charges/search', auth.secured, charges.searchTransaction.http, charges.searchTransaction.exceptions)
 
-router.get('/stripe/create', auth.secured, stripe.create)
-router.post('/stripe/create', auth.secured, stripe.createAccount.http, stripe.createAccount.exceptions)
+router.get('/stripe/create', auth.secured, auth.administrative, stripe.create)
+router.post('/stripe/create', auth.secured, auth.administrative, stripe.createAccount.http, stripe.createAccount.exceptions)
 
 router.get('/stripe/basic/create', auth.secured, stripe.basic)
 router.post('/stripe/basic/create', auth.secured, stripe.basicCreate)


### PR DESCRIPTION
* amend github strategy
  * first check if user is in administrative group 
  * if not check if user has base level permissions 
  * if not reject
* middleware to block requests on a router level, checks for truthful admin role to have been set on a profile at authorisation (HTTPS cookie, set only)
* block routes according to ticket reference `PP-5405`

---

* OTP codes shouldn't be served by self service user route
* until they are removed, filter them out from appearing anywhere upstream of the `GET` request