### PR TITLE
Make service search trim whitespace from input service external ID

### DIFF
--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -81,7 +81,8 @@ const search = async function search(req: Request, res: Response): Promise<void>
 }
 
 const searchRequest = async function searchRequest(req: Request, res: Response): Promise<void> {
-  res.redirect(`/services/${req.body.id}`)
+  const serviceId = req.body.id.trim()
+  res.redirect(`/services/${serviceId}`)
 }
 
 const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedirectFlag(


### PR DESCRIPTION
Because it annoys me when I copy and paste an ID from elsewhere and it doesn’t find anything because the clipboard brought along some rogue whitespace.