### PR TITLE
BAU Show user role on service detail page

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -59,12 +59,12 @@
     </table>
   </div>
 
-
   <div>
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Email</th>
+          <th class="govuk-table__header" scope="col">Role</th>
           <th class="govuk-table__header" scope="col">Disabled</th>
         </tr>
       </thead>
@@ -74,6 +74,7 @@
             <td class="govuk-table__cell">
               <a href="/users/{{ user.external_id }}" class="govuk-link govuk-link--no-visited-state">{{ user.email }}
             </td>
+            <td class="govuk-table__cell">{{ user.role | capitalize }}</td>
             <td class="govuk-table__cell">{{ user.disabled | string | capitalize }}</td>
           </tr>
         {% endfor %}

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -20,6 +20,13 @@ const detail = async function detail(req: Request, res: Response): Promise<void>
     AdminUsers.service(serviceId),
     AdminUsers.serviceUsers(serviceId)
   ])
+
+  users.forEach((user: any) => {
+    const currentServicesRole = user.service_roles
+      .find((serviceRole: any) => serviceRole.service && serviceRole.service.external_id === serviceId)
+    user.role = currentServicesRole.role && currentServicesRole.role.name
+  })
+
   res.render('services/detail', {
     service, users, serviceId, messages
   })


### PR DESCRIPTION
* surfacing access rights for users is useful for engagement to see at a
glance
* filter this information out of the service roles object

<img width="740" alt="Screen Shot 2019-08-30 at 12 54 30" src="https://user-images.githubusercontent.com/2844572/64018809-58780580-cb25-11e9-8ebc-d44de3f8862e.png">
