### PR TITLE
BAU - Remove transaction_type query param

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -30,7 +30,6 @@ const ledgerMethods = function ledgerMethods(instance) {
       override_account_id_restriction: true,
       display_size: pageSize,
       payment_states: externalStatusMap[currentStatus].join(','),
-      transaction_type: 'PAYMENT',
       ...account && { account_id: account }
     }
 


### PR DESCRIPTION
## WHAT
- transaction_type='PAYMENT' is implicit (according to ledger) when `payment_states` query parameter is used.

https://github.com/alphagov/pay-ledger/blob/65453c326bca602c26c34fc6d7f0bf764b3a8315/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java#L413