### PR TITLE
BAU - Enable 3DS on new live accounts

### DIFF
--- a/src/lib/pay-request/types/connector.ts
+++ b/src/lib/pay-request/types/connector.ts
@@ -9,7 +9,7 @@ export interface GatewayAccountRequest {
 
   analytics_id: string;
 
-  requires_3ds: string;
+  requires_3ds?: string;
 
   credentials?: object;
 }

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -109,8 +109,13 @@ class GatewayAccount extends Validated {
       description: this.description,
       type: this.isLive() ? 'live' : 'test',
       service_name: this.serviceName,
-      analytics_id: this.analyticsId,
-      requires_3ds: this.provider === 'stripe' ? 'true' : 'false'
+      analytics_id: this.analyticsId
+    }
+
+    if (this.isLive() && this.provider !== 'stripe') {
+      payload.requires_3ds = 'true'
+    } else {
+      payload.requires_3ds = 'false'
     }
 
     if (this.provider === 'stripe' && this.credentials) {


### PR DESCRIPTION
## WHAT 
- Enable 3DS on live accounts for all payment providers (except Stripe)
- 3DS is enabled by default on Stripe and we don't use flag to control 3DS behaviour