### PR TITLE
PP-5669 Add types and fixtures for ledger report contracts

### DIFF
--- a/src/tests/fixtures/reports.ts
+++ b/src/tests/fixtures/reports.ts
@@ -1,0 +1,24 @@
+import { PaymentsByStatusReport, PaymentsReport } from 'reports'
+
+const paymentsByStatusReport: PaymentsByStatusReport = {
+  success: 1,
+  declined: 1,
+  timedout: 1,
+  cancelled: 1,
+  error: 1,
+  created: 1,
+  started: 1,
+  submitted: 1,
+  capturable: 1
+}
+
+const paymentsReport: PaymentsReport = {
+  count: 100,
+  gross_amount: 10000
+}
+
+module.exports = {
+  paymentsByStatusReport,
+  paymentsReport
+}
+

--- a/src/web/modules/transactions/@types/reports.d.ts
+++ b/src/web/modules/transactions/@types/reports.d.ts
@@ -1,0 +1,19 @@
+declare module 'reports' {
+
+  export interface PaymentsByStatusReport {
+    success: number;
+    declined: number;
+    timedout: number;
+    cancelled: number;
+    error: number;
+    created: number;
+    started: number;
+    submitted: number;
+    capturable: number;
+  }
+
+  export interface PaymentsReport {
+    count: number;
+    gross_amount: number;
+  }
+}


### PR DESCRIPTION
Add types and fixtures that use these for the following report contracts
which will be produced by ledger endpoints:
- Get payments by state report. This will return the count of payments
  with each state for the parameters specified.
- Get payments report. This will return some high level aggregate
  statistics for payments. Initially this will be the total payment
  count and the gross amount.