### PR TITLE
BAU-Adds-Nock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4658,6 +4658,37 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
+    "nock": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.3.5.tgz",
+      "integrity": "sha512-6WGeZcWc3RExkBcMSYSrUm/5YukDo52m/jhwniQyrnuiCnKRljBwwje9vTwJyEi4J6m2bq0Aj6C1vzuM6iuaeg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
@@ -5313,6 +5344,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "main": "dist/index.js",
   "scripts": {
-    "start": "node dist/test_runner.js",
+    "start": "node dist/index.js",
     "dev": "tsc-watch --noClear --onSuccess \"./scripts/run-dev\"",
     "lint": "eslint src",
     "test": "npm run test:unit",
@@ -78,6 +78,7 @@
     "eslint-plugin-import": "2.17.3",
     "mocha": "6.1.4",
     "mockery": "2.1.0",
+    "nock": "11.3.5",
     "node-sass": "4.12.0",
     "nodemon": "1.19.1",
     "ts-node": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "main": "dist/index.js",
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "node dist/test_runner.js",
     "dev": "tsc-watch --noClear --onSuccess \"./scripts/run-dev\"",
     "lint": "eslint src",
     "test": "npm run test:unit",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src",
     "test": "npm run test:unit",
     "test:unit": "AUTH_GITHUB_ENABLED=true mocha -r ts-node/register --recursive \"./src/**/*.spec.{js,ts}\"",
+    "test:runner": "node dist/testRunner.js",
     "test:cypress": "./scripts/run-cypress",
     "build": "scripts/build && npm run build:typescript && npm run build:copy && npm run build:sass",
     "build:typescript": "tsc",

--- a/src/testRunner.js
+++ b/src/testRunner.js
@@ -1,0 +1,15 @@
+const http = require('http')
+
+const { server } = require('./config')
+const logger = require('./lib/logger')
+const app = require('./web/server')
+
+/*
+Put nock files in separate .js then require them in here
+*/
+
+const logHTTPServerStarted = function logHTTPServerStarted() {
+  logger.info(`Toolbox HTTP server listening on port ${server.PORT}`)
+}
+
+http.createServer(app).listen(server.PORT, logHTTPServerStarted)


### PR DESCRIPTION
This PR adds a testRunner.js which serves as the entry point to spin up Toolbox with mocked out server responses using Nock. It adds an npm script called test:Runner which does this.

The restRunner.js will require other files which contain the mocked out responses. This will then allow us to run Cypress tests.