### PR TITLE
BAU: Display organisation name

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -29,6 +29,10 @@
         <td class="govuk-table__cell">{{service.name}}</td>
       </tr>
       <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Organisation</th>
+        <td class="govuk-table__cell">{{(service.merchant_details.name or "(Not set)")}}</td>
+      </tr>
+      <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Go live status</th>
         <td class="govuk-table__cell">{{service.current_go_live_stage | upper }}</td>
       </tr>

--- a/src/web/modules/services/overview.njk
+++ b/src/web/modules/services/overview.njk
@@ -9,6 +9,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">ID</th>
         <th class="govuk-table__header" scope="col">Name</th>
+        <th class="govuk-table__header" scope="col">Organisation</th>
         <th class="govuk-table__header" scope="col">Go live status</th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">{{ service.id }}</td>
         <td class="govuk-table__cell"><a class="govuk-link govuk-link--no-visited-state" href="/services/{{ service.external_id }}">{{ service.name }}</a></td>
+        <td class="govuk-table__cell">{{ (service.merchant_details.name or "(Not set)") }}</td>
         <td class="govuk-table__cell">{{ service.current_go_live_stage }}</td>
       </tr>
       {% else %}


### PR DESCRIPTION
Add "Organisation" column to the "Services" "Overview" page which contains the organisation name of the service if it is set.

Add a row to the service detail page to display the "Organisation" if the organisation name is set.