### PR TITLE
BAU-Display-Google-Apply-Pay-In-Services

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -75,6 +75,18 @@
             <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
           </tr>
       {% endif %}
+      {% if account.allow_apple_pay != undefined %}
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Apple Pay Enabled</th>
+            <td class="govuk-table__cell">{{ account.allow_apple_pay | string | capitalize }}</td>
+          </tr>
+      {% endif %}
+      {% if account.allow_google_pay != undefined %}
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Google Pay Enabled</th>
+            <td class="govuk-table__cell">{{ account.allow_google_pay | string | capitalize }}</td>
+          </tr>
+      {% endif %}
       {% if account.email_collection_mode != undefined %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Email collection mode</th>

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -71,19 +71,19 @@
       </tr>
       {% if account.toggle_3ds != undefined %}
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Toggle 3DS</th>
+            <th class="govuk-table__header" scope="col">3DS enabled</th>
             <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
           </tr>
       {% endif %}
       {% if account.allow_apple_pay != undefined %}
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Apple Pay Enabled</th>
+            <th class="govuk-table__header" scope="col">Apple Pay enabled</th>
             <td class="govuk-table__cell">{{ account.allow_apple_pay | string | capitalize }}</td>
           </tr>
       {% endif %}
       {% if account.allow_google_pay != undefined %}
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Google Pay Enabled</th>
+            <th class="govuk-table__header" scope="col">Google Pay enabled</th>
             <td class="govuk-table__cell">{{ account.allow_google_pay | string | capitalize }}</td>
           </tr>
       {% endif %}


### PR DESCRIPTION
This PR surfaces to the user whether a service has Apple Pay or Google Pay enabled at /gateway_accounts/:id. This also renames 'Toggle 3DS' to '3DS enabled'

<img width="741" alt="Screenshot 2019-10-12 at 2 20 12 pm" src="https://user-images.githubusercontent.com/43585976/66702098-a45cc380-ecfb-11e9-9dae-92c5f30f3c56.png">
