### PR TITLE
BAU Standard GDS Way @timestamp log attribute

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -43,11 +43,14 @@ const loggerMiddleware = function loggerMiddleware(
 }
 
 const supplementProductionInfo = format((info) => {
-  const productionContext = {
-    toolboxId: session.get(TOOLBOX_ID_KEY),
-    correlationId: session.get(CORRELATION_ID_KEY),
-    userId: session.get(AUTHENTICATED_USER_ID_KEY)
+  // LOGSTASH 675 versioning https://gds-way.cloudapps.digital/manuals/logging.html
+  const LOG_VERSION = 1
+  const productionContext: any = {
+    toolbox_id: session.get(TOOLBOX_ID_KEY),
+    correlation_id: session.get(CORRELATION_ID_KEY),
+    user_id: session.get(AUTHENTICATED_USER_ID_KEY)
   }
+  productionContext['@version'] = LOG_VERSION
   return Object.assign(info, productionContext)
 })
 
@@ -55,7 +58,7 @@ if (!config.common.development) {
   const productionTransport = new transports.Console({
     format: combine(
       supplementProductionInfo(),
-      timestamp({ format: 'HH:mm:ss' }),
+      timestamp({ format: 'YYYY-MM-DDTHH:mm:ss.sssZ', alias: '@timestamp' }),
       format.json()
     ),
     level: 'info'


### PR DESCRIPTION
* alias log timestamps with `@timestamp` to line up with other Pay
services and the GDS Way
* camelCase -> snake_case

Interpretation depends on rules set in https://github.com/alphagov/pay-cloudwatch-logs-s3-export/pull/143