### PR TITLE
BAU Show account credentials for card accounts

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -14,6 +14,10 @@ const connectorMethods = function connectorMethods(instance) {
     return axiosInstance.get(`/v1/api/accounts/${id}`).then(utilExtractData)
   }
 
+  const accountWithCredentials = function accountWithCredentials(id) {
+    return axiosInstance.get(`/v1/frontend/accounts/${id}`).then(utilExtractData)
+  }
+
   const createAccount = function createAccount(accountDetails) {
     return axiosInstance.post('/v1/api/accounts', accountDetails).then(utilExtractData)
   }
@@ -98,6 +102,7 @@ const connectorMethods = function connectorMethods(instance) {
     gatewayAccountPerformanceReport,
     account,
     accounts,
+    accountWithCredentials,
     createAccount,
     searchTransactionsByChargeId,
     searchTransactionsByReference,

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -55,6 +55,18 @@
         <th class="govuk-table__header" scope="col">Payment provider</th>
         <td class="govuk-table__cell">{{ account.payment_provider | capitalize }}</td>
       </tr>
+      {% if account.credentials and account.credentials.merchant_id %}
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">PSP merchant ID</th>
+        <td class="govuk-table__cell">{{ account.credentials.merchant_id }}</td>
+      </tr>
+      {% endif %}
+      {% if account.credentials and account.credentials.stripe_account_id %}
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Connected Stripe account</th>
+        <td class="govuk-table__cell">{{ account.credentials.stripe_account_id }}</td>
+      </tr>
+      {% endif %}
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Service</th>
         <td class="govuk-table__cell">{{ account.service_name }}</td>

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -120,7 +120,9 @@ const detail = async function detail(req: Request, res: Response): Promise<void>
   const { id } = req.params
   let services = {}
   const isDirectDebitID = id.match(/^DIRECT_DEBIT:/)
-  const readAccountMethod = isDirectDebitID ? DirectDebitConnector.account : Connector.account
+  const readAccountMethod = isDirectDebitID
+    ? DirectDebitConnector.account
+    : Connector.accountWithCredentials
 
   const account = await readAccountMethod(id)
 


### PR DESCRIPTION
* For Worldpay, Smartpay and EPDQ show `merchant_id`
* For Stripe show `stripe_connected_account_id`

Closes https://github.com/alphagov/pay-toolbox/issues/237