### PR TITLE
BAU Update 3DS enabled key for gateway account display

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -81,10 +81,10 @@
           {% endif %}
         </td>
       </tr>
-      {% if account.toggle_3ds != undefined %}
+      {% if account.requires3ds != undefined %}
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">3DS enabled</th>
-            <td class="govuk-table__cell">{{ account.toggle_3ds | string | capitalize }}</td>
+            <td class="govuk-table__cell">{{ account.requires3ds | string | capitalize }}</td>
           </tr>
       {% endif %}
       {% if account.allow_apple_pay != undefined %}


### PR DESCRIPTION
* The gateway account details request was updated to use `v1/frontend`
in favour of `v1/api` to also fetch the PSP credentials. This was in #239
* It looks like the frontend resource uses `requires3ds` instead of
`toggle_3ds`
* Update the template to reflect that