### PR TITLE
BAU Trim top level search inputs

### DIFF
--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -12,9 +12,9 @@ export async function searchPage(req: Request, res: Response): Promise<void> {
 }
 
 export async function search(req: Request, res: Response, next: NextFunction): Promise<void> {
-  try {
-    const { id } = req.body
+  const id = req.body.id && req.body.id.trim()
 
+  try {
     // most basic search implementation - just forward to transactions route
     res.redirect(`/transactions/${id}`)
   } catch (error) {

--- a/src/web/modules/users/users.http.ts
+++ b/src/web/modules/users/users.http.ts
@@ -173,7 +173,7 @@ const search = async function search(
   req: Request,
   res: Response
 ): Promise<void> {
-  const { email } = req.body
+  const email = req.body.email && req.body.email.trim()
   const user = await AdminUsers.findUser(email)
   res.redirect(`/users/${user.external_id}`)
 }


### PR DESCRIPTION
User, transaction and service searches are often copied and pasted from
tables with padded whitespace.

Trim this before searching.