### PR TITLE
BAU Show related refunds on payment page

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -50,6 +50,13 @@ const ledgerMethods = function ledgerMethods(instance) {
   const transactionsByReference = async function transactionsByReference(reference, limit = 2) {
     return transactions(null, null, null, { reference, display_size: limit })
   }
+  const relatedTransactions = async function relatedTransactions(id, accountId) {
+    const params = {
+      gateway_account_id: accountId
+    }
+    return axiosInstance.get(`/v1/transaction/${id}/transaction`, { params })
+      .then(utilExtractData)
+  }
 
   const events = function events(transactionId, accountId) {
     return axiosInstance.get(`/v1/transaction/${transactionId}/event?gateway_account_id=${accountId}&${includeAllEventsQuery}`)
@@ -101,7 +108,8 @@ const ledgerMethods = function ledgerMethods(instance) {
     events,
     getPaymentsByState,
     paymentStatistics,
-    transactionsByReference
+    transactionsByReference,
+    relatedTransactions
   }
 }
 

--- a/src/tests/fixtures/payment.ts
+++ b/src/tests/fixtures/payment.ts
@@ -43,7 +43,8 @@ const transaction: Transaction = {
     amount_available: 0,
     amount_submitted: 0
   },
-  transaction_id: 'rs7l0c6ka8b0hr2ho7omkpo6ot'
+  transaction_id: 'rs7l0c6ka8b0hr2ho7omkpo6ot',
+  transaction_type: 'PAYMENT'
 }
 
 export default transaction

--- a/src/web/modules/transactions/@types/transactions.d.ts
+++ b/src/web/modules/transactions/@types/transactions.d.ts
@@ -58,5 +58,6 @@ declare module 'ledger' {
     gateway_transaction_id: string;
     refund_summary: RefundSummary;
     transaction_id: string;
+    transaction_type: string;
   }
 }

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -77,19 +77,19 @@
     </table>
   </div>
 
-{% if transaction.refund_summary.status %}
+{% if relatedTransactions.length %}
   <div>
     <h1 class="govuk-heading-s payment__header">Related transactions</h1>
     <table class="govuk-table">
       <tbody class="govuk-table__body">
-        {% for transaction in refunds %}
+        {% for transaction in relatedTransactions %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell payment__cell" scope="row">
-            <a class="govuk-link govuk-link--no-visited-state" href="/transactions/{{refund.transaction_id}}">{{ refund.transaction_id }}
+            <a class="govuk-link govuk-link--no-visited-state" href="/transactions/{{transaction.transaction_id}}">{{ transaction.transaction_id }}
           </td>
           <td class="govuk-table__cell payment__cell">
             <th class="govuk-table__cell payment__cell text-right" scope="row">
-              <span class="govuk-caption-m">{{ refund.date | formatDateLong }}</span>
+              <span class="govuk-caption-m">{{ transaction.created_date | formatDateLong }}</span>
             </th>
           </td>
         </tr>

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -1,0 +1,108 @@
+{% from "common/json.njk" import json %}
+
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+  <h1 class="govuk-heading-m">Refund</h1>
+
+  {% if transaction.parent_transaction_id %}
+  <div class="govuk-body govuk-!-margin-bottom-4">
+    <a href="/transactions/{{ transaction.parent_transaction_id }}" class="govuk-back-link">Refunds payment {{ transaction.parent_transaction_id }}</a>
+  </div>
+  {% endif %}
+
+  <div class="status-inline-spacer">
+    <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
+  </div>
+
+  <div class="govuk-grid-row status-spacer payment-detail-row">
+    <div class="govuk-grid-column-one-quarter">
+      <span class="govuk-caption-m">Date</span>
+      <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
+    </div>
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s payment__header">Payment details</h1>
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Status</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.state and transaction.state.status | capitalize }}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Reference</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.reference }}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLong }}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Amount</span></th>
+          <td class="govuk-table__cell payment__cell">
+            <span>{{ (transaction.total_amount or transaction.amount) | currency }} </span>
+          </td>
+        </tr>
+    </table>
+  </div>
+
+
+  <div>
+    <h1 class="govuk-heading-s payment__header">Processing details</h1>
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Gateway account</span></th>
+          <td class="govuk-table__cell payment__cell">
+            <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{transaction.gateway_account_id}}">{{ transaction.gateway_account_id }}
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Service</span></th>
+          <td class="govuk-table__cell payment__cell">
+          <a class="govuk-link govuk-link--no-visited-state" href="/services/{{service.external_id}}">{{ service.external_id }}
+          </td>
+        </tr>
+      </tobdy>
+    </table>
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s payment__header">Ledger events</h1>
+
+    <table class="govuk-table">
+          <tbody class="govuk-table__body">
+    {% for event in events %}
+
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ event.event_type }}</td>
+          <td class="govuk-table__cell">{{ event.timestamp | formatDate}}</td>
+        </tr>
+
+        {% if event.data %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell" colspan="2">
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Event details
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <pre><code>{{ event.data | dump('\t') }}</code></pre>
+              </div>
+            </details>
+          </td>
+        </tr>
+        {% endif %}
+    {% else %}
+      <!-- @TODO(sfount) use a row here -->
+      <div class="center bottom-spacer"><span class="govuk-caption-m">No events</span></div>
+    {% endfor %}
+    </tbody>
+    </table>
+  </div>
+
+  {{ json("Transaction source", transaction) }}
+{% endblock %}

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -91,7 +91,8 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
       relatedTransactions.push(...relatedResult.transactions)
     }
 
-    res.render('transactions/payment', {
+    const renderKey = transaction.transaction_type.toLowerCase()
+    res.render(`transactions/${renderKey}`, {
       transaction,
       relatedTransactions,
       account,


### PR DESCRIPTION
If a payment has been refunded, surface related transactions on the payment page. 

![Screen Shot 2019-12-08 at 15 39 06](https://user-images.githubusercontent.com/2844572/70453916-78fb1880-1aa1-11ea-8559-ea0acfaafa1d.png)

Show transaction template based on the transaction type, use newly added refund template if this is a refund.

![Screen Shot 2019-12-08 at 15 39 12](https://user-images.githubusercontent.com/2844572/70453931-857f7100-1aa1-11ea-96e8-86085ecd8bc0.png)
