### PR TITLE
BAU Fix 0p payments marked as "full" in refund status

### DIFF
--- a/src/web/modules/transactions/status.macro.njk
+++ b/src/web/modules/transactions/status.macro.njk
@@ -10,7 +10,10 @@
     {% if not final %} status-in-progress {% endif %}
      status-tag">
 
-  {% if success.includes(state) and refundedStatus === 'full' %}
+  {# 0p payments are supported and will be flagged as 'full' even though they are not refunded #}
+  {% set isFullyRefunded = success.includes(state) and refundedStatus === 'full' and refundedAmount > 0 %}
+
+  {% if isFullyRefunded %}
   <span>Refunded</span>
   {% elif success.includes(state) and refundedAmount > 0 %}
   <span>Partial refund</span>


### PR DESCRIPTION
The `refundStatus` is used to show an appropriate status badge for
payments. Currently Connector marks 0p payments as "full" (amount
refunded = amount avaialble to refund) -- this doesn't mean the payment
is refunded in this case.

Follows on from https://github.com/alphagov/pay-toolbox/pull/262