### PR TITLE
BAU Fix consistent logging middleware handler

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -116,7 +116,7 @@ const configureRouting = function configureRouting(instance) {
   // logger middleware included after flash and body parsing middleware as they
   // alter the call stack (it should ideally be placed just before routes)
   instance.use(logger.middleware)
-  instance.use(requestLoggingMiddleware)
+  instance.use(requestLoggingMiddleware())
 
   instance.use('/', router)
   instance.use(errors.handleNotFound)


### PR DESCRIPTION
* request logging middleware (morgan configuration) returns a
RequestHandler -- this wasn't being called meaning all HTTP requests
couldn't continue past this point
* return the RequestHandler so that the middleware stack continues

Will allow release of https://github.com/alphagov/pay-toolbox/pull/267