### PR TITLE
BAU convert Stripe support phone number to E164

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,7 +634,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-from": {
@@ -986,7 +986,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1770,7 +1770,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -2473,7 +2473,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -4169,12 +4169,12 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4364,7 +4364,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5199,13 +5199,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -5213,7 +5213,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -5346,7 +5346,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -5555,7 +5555,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -5775,7 +5775,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "optional": true,
       "requires": {
@@ -6332,7 +6332,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -6425,7 +6425,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -6447,7 +6447,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6572,7 +6572,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -7033,7 +7033,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "deep-diff": "1.0.2",
     "dotenv": "8.2.0",
     "express": "4.17.1",
+    "google-libphonenumber": "3.2.6",
     "govuk-frontend": "3.4.0",
     "helmet": "3.21.2",
     "https-proxy-agent": "3.0.1",

--- a/src/web/modules/stripe/stripe.model.js
+++ b/src/web/modules/stripe/stripe.model.js
@@ -1,4 +1,6 @@
 const Joi = require('joi')
+const { PhoneNumberFormat } = require('google-libphonenumber')
+const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance()
 
 const { ValidationError } = require('./../../../lib/errors')
 const { addModelIfValid, stripEmpty } = require('./../../../lib/validation')
@@ -14,6 +16,15 @@ const schema = {
   org_phone_number: Joi.string().required()
 }
 
+const toE164InternationalFormat = function toE164InternationalFormat(rawNumber) {
+  if (rawNumber) {
+    const phoneNumber = phoneUtil.parse(rawNumber, 'GB')
+    return phoneUtil.format(phoneNumber, PhoneNumberFormat.E164)
+  }
+
+  return ''
+}
+
 const build = function build(params) {
   const core = {
     type: 'custom',
@@ -25,7 +36,7 @@ const build = function build(params) {
     },
     payout_statement_descriptor: params.org_statement_descriptor,
     statement_descriptor: params.org_statement_descriptor,
-    support_phone: params.org_phone_number
+    support_phone: toE164InternationalFormat(params.org_phone_number)
   }
 
   let withSubModels = addModelIfValid(core, params, StripeLegalEntity, 'legal_entity')

--- a/src/web/modules/stripe/stripe.model.spec.js
+++ b/src/web/modules/stripe/stripe.model.spec.js
@@ -10,7 +10,7 @@ describe('Stripe Account model', () => {
         org_name: 'org_name',
         org_ip_address: 'org_ip_address',
         org_statement_descriptor: 'org_statement_descriptor',
-        org_phone_number: 'org_phone_number'
+        org_phone_number: '01234567890'
       })
       expect(stripeAccount1).to.be.an('object')
     }).to.not.throw()
@@ -22,7 +22,7 @@ describe('Stripe Account model', () => {
       org_name: 'org_name',
       org_ip_address: 'org_ip_address',
       org_statement_descriptor: 'org_statement_descriptor',
-      org_phone_number: 'org_phone_number',
+      org_phone_number: '01234567890',
       bank_account_number: '12345678'
     })
     expect(stripeAccount2).to.not.have.property('external_account')
@@ -34,7 +34,7 @@ describe('Stripe Account model', () => {
       org_name: 'org_name',
       org_ip_address: 'org_ip_address',
       org_statement_descriptor: 'org_statement_descriptor',
-      org_phone_number: 'org_phone_number',
+      org_phone_number: '01234567890',
       bank_account_number: '12345678',
       bank_account_sort_code: '123456'
     })
@@ -48,7 +48,7 @@ describe('Stripe Account model', () => {
       org_name: 'org_name',
       org_ip_address: 'org_ip_address',
       org_statement_descriptor: 'org_statement_descriptor',
-      org_phone_number: 'org_phone_number',
+      org_phone_number: '01234567890',
       bank_account_number: '12345678',
       bank_account_sort_code: '123456',
       person_dob_year: 2018,
@@ -69,7 +69,7 @@ describe('Stripe Account model', () => {
       org_name: 'org_name',
       org_ip_address: 'org_ip_address',
       org_statement_descriptor: 'org_statement_descriptor',
-      org_phone_number: 'org_phone_number',
+      org_phone_number: '01234567890',
       bank_account_number: '12345678',
       bank_account_sort_code: '123456',
       person_dob_year: 2018,
@@ -85,5 +85,29 @@ describe('Stripe Account model', () => {
     expect(stripeAccount5).to.have.property('legal_entity')
     expect(stripeAccount5).to.have.property('external_account')
     expect(stripeAccount5.legal_entity).to.have.property('personal_address')
+  })
+  it('handles support phone already in international format', () => {
+    expect(() => {
+      const stripeAccount6 = new StripeAccount({
+        org_id: 'org_id',
+        org_name: 'org_name',
+        org_ip_address: 'org_ip_address',
+        org_statement_descriptor: 'org_statement_descriptor',
+        org_phone_number: '+441234567890'
+      })
+      expect(stripeAccount6.support_phone).to.equal('+441234567890')
+    }).to.not.throw()
+  })
+  it('converts domestic GB number to international format', () => {
+    expect(() => {
+      const stripeAccount7 = new StripeAccount({
+        org_id: 'org_id',
+        org_name: 'org_name',
+        org_ip_address: 'org_ip_address',
+        org_statement_descriptor: 'org_statement_descriptor',
+        org_phone_number: '01234567890'
+      })
+      expect(stripeAccount7.support_phone).to.equal('+441234567890')
+    }).to.not.throw()
   })
 })


### PR DESCRIPTION
Stripe expects the support phone number to be in E164 format, (e.g.
leading 0 becomes +44).

Reference this zen desk ticket for conversation with Stripe support confirming format.
https://govuk.zendesk.com/agent/tickets/3887613