### PR TITLE
Add compile command alias to build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit": "AUTH_GITHUB_ENABLED=true mocha -r ts-node/register -r dotenv/config --recursive \"./src/**/*.spec.{js,ts}\" dotenv_config_path=src/tests/.env",
     "test:cypress": "./scripts/run-cypress",
     "build": "scripts/build && npm run build:typescript && npm run build:copy && npm run build:sass",
+    "compile": "npm run build",
     "build:typescript": "tsc",
     "build:sass": "scripts/compile-assets",
     "build:copy": "copyfiles --up 1 src/**/*.njk dist/",


### PR DESCRIPTION
All pay node apps use "compile" as the build command. Adding an alias to the toolbox project saves adding complexity futher down the build pipleine and promotes reusability of shared build code.