### PR TITLE
PP-6058 Use the proposed stream route internally

### DIFF
--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -283,7 +283,7 @@ export async function streamCsv(req: Request, res: Response, next: NextFunction)
     res.write('')
 
     const metricStart = Date.now()
-    const target = `${services.LEDGER_URL}/v1/transaction?${query}`
+    const target = `${services.LEDGER_URL}/v1/transaction/stream?${query}`
     const parsed = url.parse(target)
     const options = {
       path: `${parsed.pathname}${parsed.search}`,


### PR DESCRIPTION
Updates stream comparison tool to use `v1/transaction/stream`
internally, this will be consolidated into `/v1/transaction` once this
strategy is fully implemented.