### PR TITLE
PP-6085: Add env-map Cloudfoundry buildpack

### DIFF
--- a/envmap.yml
+++ b/envmap.yml
@@ -1,0 +1,7 @@
+env_vars:
+  ADMINUSERS_URL: '."user-provided"[0].credentials.adminusers_url'
+  CONNECTOR_URL: '."user-provided"[0].credentials.card_connector_url'
+  DIRECT_DEBIT_CONNECTOR_URL: '."user-provided"[0].credentials.directdebit_connector_url'
+  PRODUCTS_URL: '."user-provided"[0].credentials.products_url'
+  PUBLIC_AUTH_URL: '."user-provided"[0].credentials.publicauth_url'
+  LEDGER_URL: '."user-provided"[0].credentials.ledger_url'

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,22 +2,27 @@
 applications:
 - name: toolbox
   buildpacks:
+  - https://github.com/alphagov/env-map-buildpack.git#v1
   - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.9
   health-check-type: http
   health-check-http-endpoint: '/healthcheck'
   health-check-invocation-timeout: 5
   memory: ((memory))
   disk_quota: ((disk_quota))
+  services:
+    - app-catalog
   command: npm start
   env:
     NODE_ENV: production
     ENVIRONMENT: ((space))
-    ADMINUSERS_URL: ((adminusers_url))
-    CONNECTOR_URL: ((card_connector_url))
-    DIRECT_DEBIT_CONNECTOR_URL: ((direct_debit_connector_url))
-    PRODUCTS_URL: ((products_url))
-    PUBLIC_AUTH_URL: ((publicauth_url))
-    LEDGER_URL: ((ledger_url))
+    
+    # The following URLs are provisioned by the `app-catalog` user-provided service 
+    ADMINUSERS_URL: ""
+    CONNECTOR_URL: ""
+    DIRECT_DEBIT_CONNECTOR_URL: ""
+    PRODUCTS_URL: ""
+    PUBLIC_AUTH_URL: ""
+    LEDGER_URL: ""
 
     DISABLE_REQUEST_LOGGING: ((toolbox_disable_request_logging))
     COOKIE_SESSION_ENCRYPTION_SECRET: ((toolbox_cookie_session_encryption_secret))


### PR DESCRIPTION
Adds an `env-map` buildpack allowing data provided by bound user-provided services to be mapped to application environment variables. The mapping is configured via the `env-map.yml` file. 

https://github.com/alphagov/env-map-buildpack

Using this buildpack means we do not need to alter how our app works, but rather provide a mapping from the VCAP_SERVICES var to its current name.