### PR TITLE
PP-6072 Add filter on gateway accounts search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,6 +494,11 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
+    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -1408,6 +1413,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -3335,6 +3345,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         },
         "safe-buffer": {
           "version": "5.1.2",
@@ -7402,9 +7417,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@govuk-pay/pay-js-commons": "2.20.1",
     "@sentry/node": "5.9.0",
     "@types/morgan": "1.7.37",
+    "@types/qs": "6.9.1",
     "axios": "0.19.0",
     "body-parser": "1.19.0",
     "class-validator": "0.11.0",
@@ -60,6 +61,7 @@
     "nunjucks": "3.2.0",
     "passport": "0.4.0",
     "passport-github": "1.1.0",
+    "qs": "6.9.1",
     "stripe": "7.15.0",
     "winston": "3.2.1",
     "winston-transport": "4.3.0"

--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
+const lodash = require('lodash')
+
 const connectorMethods = function connectorMethods(instance) {
   const axiosInstance = instance || this
 
@@ -6,8 +8,9 @@ const connectorMethods = function connectorMethods(instance) {
   // repeat this over and over
   const utilExtractData = (response) => response.data
 
-  const accounts = function accounts() {
-    return axiosInstance.get('/v1/api/accounts').then(utilExtractData)
+  const accounts = function accounts(params) {
+    params = lodash.omitBy(params, lodash.isEmpty)
+    return axiosInstance.get('/v1/api/accounts', {params}).then(utilExtractData)
   }
 
   const account = function account(id) {

--- a/src/web/modules/gateway_accounts/filter.njk
+++ b/src/web/modules/gateway_accounts/filter.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+<div class="govuk-grid-row">
+  <form clas="govuk-clearfix" method="GET" action="/gateway_accounts" novalidate>
+    <div class="govuk-grid-column-one-third inputs-less-margin">
+      {{ govukInput({
+        id: "id",
+        name: "id",
+        label: { text: "Account ID" },
+        value: filters.id,
+        attributes: {
+          autocomplete: 'off'
+        }
+      })
+    }}
+    </div>
+
+    <div class="govuk-grid-column-one-third inputs-less-margin">
+      {{ govukSelect({
+        id: "moto-enabled",
+        name: "moto_enabled",
+        label: { text: "MOTO enabled" },
+        items: motoEnabledOptions
+      })
+    }}
+    </div>
+
+    <div class="govuk-grid-column-one-third inputs-less-margin"></div>
+
+    <div class="govuk-grid-column-full inputs-less-margin">
+      {{ govukButton({
+        text: "Filter"
+      })
+    }}
+    </div>
+  </form>
+</div>

--- a/src/web/modules/gateway_accounts/overview.njk
+++ b/src/web/modules/gateway_accounts/overview.njk
@@ -4,6 +4,12 @@
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Gateway accounts</h1>
 
+  {% include "gateway_accounts/filter.njk" %}
+
+  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3">
+    {{total}} accounts
+  </h3>
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">


### PR DESCRIPTION
Add a filter control to the gateway accounts search to allow filtering by id and whether or not MOTO payments are enabled for the account.

The idea is that this can be extended to allow filtering the gateway account list by more properties of the gateway account.

![Screenshot 2020-02-11 at 14 11 48](https://user-images.githubusercontent.com/5648592/74243934-879bc100-4cd8-11ea-8e73-b94468fa3d8d.png)