### PR TITLE
PP-6072 Remove id field from gateway account filter

### DIFF
--- a/src/web/modules/gateway_accounts/filter.njk
+++ b/src/web/modules/gateway_accounts/filter.njk
@@ -4,18 +4,6 @@
 
 <div class="filter govuk-grid-row">
   <form clas="govuk-clearfix" method="GET" action="/gateway_accounts" novalidate="novalidate">
-    <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukInput({
-        id: "id",
-        name: "id",
-        label: { text: "Account ID" },
-        value: filters.id,
-        attributes: {
-          autocomplete: 'off'
-        }
-      })
-    }}
-    </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
@@ -37,7 +25,7 @@
     }}
     </div>
 
-    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+    <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
         id: "requires-3ds",
         name: "requires_3ds",
@@ -47,7 +35,7 @@
     }}
     </div>
 
-    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+    <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
         id: "apple-pay-enabled",
         name: "apple_pay_enabled",
@@ -57,7 +45,7 @@
     }}
     </div>
 
-    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+    <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
         id: "google-pay-enabled",
         name: "google_pay_enabled",
@@ -67,7 +55,7 @@
     }}
     </div>
 
-    <div class="govuk-grid-column-one-quarter inputs-less-margin">
+    <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
         id: "moto-enabled",
         name: "moto_enabled",

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -19,7 +19,6 @@ import { getSelectOptions, getEnabledDisabledSelectOptions } from '../common/sel
 const overview = async function overview(req: Request, res: Response): Promise<void> {
   const filters = parse(req.query)
   const params = {
-    accountIds: filters.id,
     type: filters.type,
     payment_provider: filters.payment_provider,
     requires_3ds: filters.requires_3ds,


### PR DESCRIPTION
The id field doesn't really belong here and should probably be on a separate "Find an account" page like for services/users. Remove to make it a little less confusing

![Screenshot 2020-02-12 at 11 13 43](https://user-images.githubusercontent.com/5648592/74329990-c0936e80-4d88-11ea-92ac-d54434084128.png)
