### PR TITLE
PP-6139 - View MOTO Transactions per gateway

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -93,12 +93,13 @@ const ledgerMethods = function ledgerMethods(instance) {
       .then(utilExtractData)
   }
 
-  const paymentStatistics = function paymentStatistics(account, fromDate, toDate) {
+  const paymentStatistics = function paymentStatistics(account, fromDate, toDate, include_moto_statistics) {
     const params = {
       ...account && { account_id: account },
       ...fromDate && { from_date: fromDate },
       ...toDate && { to_date: toDate },
-      override_from_date_validation: true
+      override_from_date_validation: true,
+      include_moto_statistics: include_moto_statistics
     }
 
     if (!account) {

--- a/src/web/modules/transactions/statistics.njk
+++ b/src/web/modules/transactions/statistics.njk
@@ -8,7 +8,7 @@
       <span>GOV.UK Pay platform</span>
     {% endif %}
   </span>
-  <h1 class="govuk-heading-m">Statistics</h1>
+  <h1 class="govuk-heading-m">Payments</h1>
   <div class="transactions-filter__container govuk-body">
     {% for period in ["today", "week", "month"] %}
       <a
@@ -19,21 +19,6 @@
     {% endfor %}
   </div>
   <div class="govuk-body">
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class = "center">
-          <h1>{{results.payments}}</h1>
-          <span>Total Payments</span>
-        </div>
-      </div>
-      <div class="govuk-grid-column-one-half">
-        <div class = "center">
-          <h1>{{results.gross | currency}}</h1>
-          <span>Gross</span>
-        </div>
-      </div>
-    </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <div class = "center">
@@ -53,6 +38,55 @@
           <span>In Progress</span>
         </div>
       </div>
+    </div>
+
+    <div class="govuk-!-margin-top-9">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"></th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row">Payments</th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{results.payments}}</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row">Total amount</th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{results.gross | currency}}</td>
+          </tr>
+       
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row">Refunds</th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{results.refunds}}</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row">Net income</th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{results.netIncome | currency}}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {% if results.include_moto_statistics %}
+      <h2 class="govuk-heading-m">Additional statistics</h2>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"></th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="row">Moto payments</th>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{results.motoPayments}}</td>
+            </tr>
+        </tbody>
+      </table>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Description:
- Moto payment statistics only appear for gateway accounts which have moto enabled
- Refunds and net income are also surfaced

Gateway account with moto enabled:
![Screenshot 2020-02-13 at 3 06 55 pm](https://user-images.githubusercontent.com/43585976/74448277-94541c80-4e72-11ea-9bf9-7180cb59b9af.png)

Gateway account with moto disabled:
![Screenshot 2020-02-13 at 3 06 55 pm](https://user-images.githubusercontent.com/43585976/74448282-97e7a380-4e72-11ea-802d-2d4fb7b5dfd6.png)


