### PR TITLE
PP-6152 Toggle experimental features for a given service

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -165,6 +165,18 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.patch(path, payload).then(utilExtractData)
   }
 
+  const toggleExperimentalFeaturesEnabledFlag = async function toggleExperimentalFeaturesEnabledFlag(serviceId) {
+    const path = `v1/api/services/${serviceId}`
+    const targetService = await service(serviceId)
+
+    const payload = {
+      op: 'replace',
+      path: 'experimental_features_enabled',
+      value: !targetService.experimental_features_enabled
+    }
+    return axiosInstance.patch(path, payload).then(utilExtractData)
+  }
+
   return {
     user,
     findUser,
@@ -181,7 +193,8 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     toggleUserEnabled,
     removeUserFromService,
     resetUserSecondFactor,
-    toggleTerminalStateRedirectFlag
+    toggleTerminalStateRedirectFlag,
+    toggleExperimentalFeaturesEnabledFlag
   }
 }
 

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -40,6 +40,10 @@
         <th class="govuk-table__header" scope="col">Redirect to service on terminal state</th>
         <td class="govuk-table__cell">{{service.redirect_to_service_immediately_on_terminal_state | string | capitalize }}</td>
       </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Experimental features are enabled</th>
+        <td class="govuk-table__cell">{{service.experimental_features_enabled | string | capitalize }}</td>
+      </tr>
     </tbody>
   </table>
   </div>
@@ -144,6 +148,17 @@
       text: "Toggle redirect to service on terminal state flag",
       classes: "govuk-button--warning",
       href: "/services/" + serviceId + "/toggle_terminal_state_redirect"
+      })
+    }}
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s">Toggle experimental features enabled flag</h1>
+    <p class="govuk-body">Enabling this flag for a service will opt the service into any features checking for this flag to be set on the service.</p>
+    <p class="govuk-body">This flag should only be enabled while the service is testing functionality that will not be made available to all users/ services initially.</p>
+    {{ govukButton({
+      text: "Toggle experimental features flag",
+      href: "/services/" + serviceId + "/toggle_experimental_features_enabled"
       })
     }}
   </div>

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -16,5 +16,6 @@ export default {
   },
   search: http.search,
   searchRequest: http.searchRequest,
-  toggleTerminalStateRedirectFlag: http.toggleTerminalStateRedirectFlag
+  toggleTerminalStateRedirectFlag: http.toggleTerminalStateRedirectFlag,
+  toggleExperimentalFeaturesEnabled: http.toggleExperimentalFeaturesEnabledFlag
 }

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -110,6 +110,20 @@ const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedire
   res.redirect(`/services/${serviceId}`)
 }
 
+const toggleExperimentalFeaturesEnabledFlag = async function toggleExperimentalFeaturesEnabledFlag(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const serviceId = req.params.id
+
+  const serviceResult = await AdminUsers.toggleExperimentalFeaturesEnabledFlag(serviceId)
+  const { experimental_features_enabled: state } = serviceResult
+  logger.info(`Toggled experimental features enabled flag to ${state} for service ${serviceId}`, { externalId: serviceId })
+
+  req.flash('info', `Experimental features enabled flag set to ${state} for service`)
+  res.redirect(`/services/${serviceId}`)
+}
+
 export default {
   overview: wrapAsyncErrorHandler(overview),
   detail: wrapAsyncErrorHandler(detail),
@@ -119,5 +133,6 @@ export default {
   updateLinkAccounts: wrapAsyncErrorHandler(updateLinkAccounts),
   search: wrapAsyncErrorHandler(search),
   searchRequest: wrapAsyncErrorHandler(searchRequest),
-  toggleTerminalStateRedirectFlag: wrapAsyncErrorHandler(toggleTerminalStateRedirectFlag)
+  toggleTerminalStateRedirectFlag: wrapAsyncErrorHandler(toggleTerminalStateRedirectFlag),
+  toggleExperimentalFeaturesEnabledFlag: wrapAsyncErrorHandler(toggleExperimentalFeaturesEnabledFlag)
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -61,6 +61,7 @@ router.post('/services/:id/branding', auth.secured, auth.administrative, service
 router.get('/services/:id/link_accounts', auth.secured, auth.administrative, services.linkAccounts, services.detail.exceptions)
 router.post('/services/:id/link_accounts', auth.secured, auth.administrative, services.updateLinkAccounts.http, services.updateLinkAccounts.exceptions)
 router.get('/services/:id/toggle_terminal_state_redirect', auth.secured, services.toggleTerminalStateRedirectFlag)
+router.get('/services/:id/toggle_experimental_features_enabled', auth.secured, services.toggleExperimentalFeaturesEnabled)
 
 router.get('/services/:serviceId/gateway_account/:gatewayAccountId/payouts', auth.secured, payouts.show)
 router.get('/services/:serviceId/gateway_account/:gatewayAccountId/payouts/csv', auth.secured, payouts.listPayoutsCsv)


### PR DESCRIPTION
Small tool to allow support/ product to opt services in to experimental
features. These will most likely be gated/ prototype features in self
service that are not ready for all users but can be used by
participating services.

This is initially a simple toggle to opt in/ out but may be made more
granular in the future if more controls over prototype features are
required.

![Screenshot 2020-02-21 at 17 21 12](https://user-images.githubusercontent.com/2844572/75056286-9f402a00-54ce-11ea-82b0-cb62eddba193.png)
