### PR TITLE
BAU Remove OAuth requirement from live dashboard route

### DIFF
--- a/src/web/router.js
+++ b/src/web/router.js
@@ -106,7 +106,7 @@ router.get('/transactions/:id/parity', auth.secured, parity.validateLedgerTransa
 router.get('/transactions', auth.secured, transactions.list)
 
 router.get('/platform/dashboard', auth.secured, platform.dashboard)
-router.get('/platform/dashboard/live', auth.secured, platform.live)
+router.get('/platform/dashboard/live', platform.live)
 
 router.get('/api/platform/timeseries', auth.secured, platform.timeseries)
 router.get('/api/platform/aggregate', auth.secured, platform.aggregate)


### PR DESCRIPTION
The live payments dashboard is currently behind the secure middleware
which requires the session to have validated with GitHub OAuth before
serving the page. This requires the display machines to have access
to the other functionality provided in Toolbox. As this is served as in
internal service requiring strict internal IP access we can remove this
and allow the displays in the office to access this resource without an
OAuth session.