### PR TITLE
BAU Dashboard data endpoints security rules

### DIFF
--- a/src/web/router.js
+++ b/src/web/router.js
@@ -108,10 +108,10 @@ router.get('/transactions', auth.secured, transactions.list)
 router.get('/platform/dashboard', auth.secured, platform.dashboard)
 router.get('/platform/dashboard/live', platform.live)
 
-router.get('/api/platform/timeseries', auth.secured, platform.timeseries)
-router.get('/api/platform/aggregate', auth.secured, platform.aggregate)
-router.get('/api/platform/ticker', auth.secured, platform.ticker)
-router.get('/api/platform/services', auth.secured, platform.services)
+router.get('/api/platform/timeseries', platform.timeseries)
+router.get('/api/platform/aggregate', platform.aggregate)
+router.get('/api/platform/ticker', platform.ticker)
+router.get('/api/platform/services', platform.services)
 
 router.get('/logout', auth.secured, auth.revokeSession)
 


### PR DESCRIPTION
Relates to https://github.com/alphagov/pay-toolbox/pull/304

Should have been included in
https://github.com/alphagov/pay-toolbox/pull/304, the data that actually
makes up the dashboard will also need to be available to pages that are
loaded without GitHub session.