### PR TITLE
BAU Use Ledger data source in payout reporting tool

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -144,6 +144,12 @@ const ledgerMethods = function ledgerMethods(instance) {
       .then(utilExtractData)
   }
 
+  const transactionByGatewayTransactionId = function transactionByGatewayTransactionId(id, paymentProvider) {
+    return axiosInstance.get(`/v1/transaction/gateway-transaction/${id}?payment_provider=${paymentProvider}`)
+      .then(utilExtractData)
+      .catch(handleNotFound('Transaction', id))
+  }
+
   return {
     transaction,
     transactions,
@@ -155,7 +161,8 @@ const ledgerMethods = function ledgerMethods(instance) {
     paymentVolumesByHour,
     paymentVolumesAggregate,
     eventTicker,
-    gatewayMonthlyPerformanceReport
+    gatewayMonthlyPerformanceReport,
+    transactionByGatewayTransactionId
   }
 }
 


### PR DESCRIPTION
As we are now expunging historic payments from Connector, Connector
should be considered a source for only live payments currently being
processed.

This has caused the payout reporting tool to `404` if it is processing
any payment or refund older than a certain age (as these payments will
have now been expunged from Connector's database).

Point the payout tool to Ledger for all transaction lookups, this data
source will guarantee the transaction (payment/ refund) is available.