### PR TITLE
PP-6325 List payment links for gateway account

### DIFF
--- a/src/lib/pay-request/api_utils/index.js
+++ b/src/lib/pay-request/api_utils/index.js
@@ -8,5 +8,6 @@ index[serviceStore.CONNECTOR.key] = require('./connector')
 index[serviceStore.PUBLICAUTH.key] = require('./publicAuth')
 index[serviceStore.DIRECTDEBITCONNECTOR.key] = require('./directDebitConnector')
 index[serviceStore.LEDGER.key] = require('./ledger')
+index[serviceStore.PRODUCTS.key] = require('./products')
 
 module.exports = index

--- a/src/lib/pay-request/api_utils/products.js
+++ b/src/lib/pay-request/api_utils/products.js
@@ -1,0 +1,17 @@
+import { EntityNotFoundError } from '../../errors'
+
+const productsMethods = function productsMethods(instance) {
+  const axiosInstance = instance || this
+  const utilExtractData = (response) => response.data
+
+  const paymentLinksByGatewayAccount = function paymentLinksByGatewayAccount(id) {
+    return axiosInstance.get(`/v1/api/gateway-account/${id}/products`)
+      .then(utilExtractData)
+  }
+
+  return {
+    paymentLinksByGatewayAccount
+  }
+}
+
+module.exports = productsMethods

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -162,6 +162,11 @@
       })
       }}
       {{ govukButton({
+        text: "View payment links",
+        href: "/gateway_accounts/" + gatewayAccountId + "/payment_links"
+      })
+      }}
+      {{ govukButton({
       text: "Download transaction CSV reports",
       href: "/transactions/csv?account=" + gatewayAccountId
       })

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -1,0 +1,64 @@
+{% from "transactions/status.macro.njk" import status %}
+
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+  <span class="govuk-caption-m">
+    {% if account %}
+      <span>{{ account.name }}</span>
+    {% else %}
+      <span>GOV.UK Pay platform</span>
+    {% endif %}
+  </span>
+
+  <h1 class="govuk-heading-m">Payment links</h1>
+
+  {% if filters.reference %}
+  <div class="govuk-body">
+    <span>Filtered by reference</span>
+    <span><strong class="govuk-tag">{{ filters.reference }}</strong></span>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  {% endif %}
+
+  <div>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">ID</th>
+          <th class="govuk-table__header" scope="col">Name</th>
+          <th class="govuk-table__header" scope="col">Type</th>
+          <th class="govuk-table__header" scope="col">Status</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for link in paymentLinks %}
+        <tr class="govuk-table__row" onclick="local.href='/transactions'">
+          <td class="govuk-table__cell">
+            <span class="govuk-caption-m">{{ link.external_id | truncate(6) }}</span>
+          </td>
+          <td class="govuk-table__cell">
+            <span>{{ link.name or "(No name)" }}</span>
+          </td>
+          <td class="govuk-table__cell">
+            <span>{{ link.type }}</span>
+          </td>
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag">{{ link.status }}</strong>
+          </td>
+        </tr>
+        <tr class="govuk-table__row" onclick="local.href='/transactions'">
+          <td class="govuk-table__cell" colspan="4">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ link._indexedLinks.friendly or link._indexedLinks.pay }}">
+                {{ link._indexedLinks.friendly or link._indexedLinks.pay }}
+              </a>
+        </tr>
+        {% else %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell center" colspan="4"><span><i>No payment links found.</i></span></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -1,5 +1,5 @@
 {% from "transactions/status.macro.njk" import status %}
-
+{% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
 
 {% block main %}
@@ -61,4 +61,6 @@
       </tbody>
     </table>
   </div>
+
+  {{ json("Payment links list source", paymentLinks) }}
 {% endblock %}

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -4,8 +4,8 @@
 
 {% block main %}
   <span class="govuk-caption-m">
-    {% if account %}
-      <span>{{ account.name }}</span>
+    {% if service %}
+      <span>{{ service.name }}</span>
     {% else %}
       <span>GOV.UK Pay platform</span>
     {% endif %}
@@ -27,7 +27,6 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">ID</th>
           <th class="govuk-table__header" scope="col">Name</th>
-          <th class="govuk-table__header" scope="col">Type</th>
           <th class="govuk-table__header" scope="col">Status</th>
         </tr>
       </thead>
@@ -41,21 +40,18 @@
             <span>{{ link.name or "(No name)" }}</span>
           </td>
           <td class="govuk-table__cell">
-            <span>{{ link.type }}</span>
-          </td>
-          <td class="govuk-table__cell">
             <strong class="govuk-tag">{{ link.status }}</strong>
           </td>
         </tr>
         <tr class="govuk-table__row" onclick="local.href='/transactions'">
-          <td class="govuk-table__cell" colspan="4">
+          <td class="govuk-table__cell" colspan="3">
             <a class="govuk-link govuk-link--no-visited-state" href="{{ link._indexedLinks.friendly or link._indexedLinks.pay }}">
                 {{ link._indexedLinks.friendly or link._indexedLinks.pay }}
               </a>
         </tr>
         {% else %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell center" colspan="4"><span><i>No payment links found.</i></span></td>
+          <td class="govuk-table__cell center" colspan="3"><span><i>No payment links found.</i></span></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -1,5 +1,14 @@
 import { Request, Response, NextFunction } from 'express'
-import { Products, Connector, AdminUsers } from '../../../lib/pay-request'
+import { Products, AdminUsers } from '../../../lib/pay-request'
+
+function indexPaymentLinksByType(paymentLink: any): any {
+  const index = paymentLink._links.reduce((aggregate: any, linkDetails: any) => {
+    aggregate[linkDetails.rel] = linkDetails.href
+    return aggregate
+  }, {})
+  paymentLink._indexedLinks = index
+  return paymentLink
+}
 
 export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
@@ -9,14 +18,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
     const paymentLinksRepsonse = await Products.paymentLinksByGatewayAccount(accountId)
     const paymentLinks = paymentLinksRepsonse
       .filter((link: any) => !(link.type === 'PROTOTYPE'))
-      .map((link: any) => {
-        const index = link._links.reduce((aggregate: any, linkDetails: any) => {
-          aggregate[linkDetails.rel] = linkDetails.href
-          return aggregate
-        }, {})
-        link._indexedLinks = index
-        return link
-      })
+      .map(indexPaymentLinksByType)
 
     if (accountId) {
       account = await AdminUsers.gatewayAccountServices(accountId)

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express'
+import { Products, Connector, AdminUsers } from '../../../lib/pay-request'
+
+export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    let account
+    const { accountId } = req.params
+
+    const paymentLinksRepsonse = await Products.paymentLinksByGatewayAccount(accountId)
+    const paymentLinks = paymentLinksRepsonse
+      .filter((link: any) => !(link.type === 'PROTOTYPE'))
+      .map((link: any) => {
+        const index = link._links.reduce((aggregate: any, linkDetails: any) => {
+          aggregate[linkDetails.rel] = linkDetails.href
+          return aggregate
+        }, {})
+        link._indexedLinks = index
+        return link
+      })
+
+    if (accountId) {
+      account = await AdminUsers.gatewayAccountServices(accountId)
+    }
+
+    res.render('payment_links/overview', {
+      account, paymentLinks
+    })
+  } catch (error) {
+    next(error)
+  }
+}

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -12,20 +12,20 @@ function indexPaymentLinksByType(paymentLink: any): any {
 
 export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    let account
+    let service
     const { accountId } = req.params
 
     const paymentLinksRepsonse = await Products.paymentLinksByGatewayAccount(accountId)
     const paymentLinks = paymentLinksRepsonse
-      .filter((link: any) => !(link.type === 'PROTOTYPE'))
+      .filter((link: any) => link.type === 'ADHOC')
       .map(indexPaymentLinksByType)
 
     if (accountId) {
-      account = await AdminUsers.gatewayAccountServices(accountId)
+      service = await AdminUsers.gatewayAccountServices(accountId)
     }
 
     res.render('payment_links/overview', {
-      account, paymentLinks
+      service, paymentLinks
     })
   } catch (error) {
     next(error)

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -18,6 +18,7 @@ const payouts = require('./modules/payouts/payouts.http')
 const transactions = require('./modules/transactions/transactions.http')
 const parity = require('./modules/transactions/discrepancies/validateLedger.http')
 const platform = require('./modules/platform/dashboard.http')
+const paymentLinks = require('./modules/payment_links/payment_links.http')
 
 // @TODO(sfount) remove `default`s on update to import export syntax
 const users = require('./modules/users/users.http').default
@@ -52,6 +53,8 @@ router.post('/gateway_accounts/:id/surcharge', auth.secured, gatewayAccounts.upd
 router.get('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.emailBranding)
 router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.updateEmailBranding)
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
+
+router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
 
 router.get('/services', auth.secured, services.overview)
 router.get('/services/search', auth.secured, services.search)


### PR DESCRIPTION
Add products helper methods for talking to the products service. Use
existing backend route for getting payment links for a gateway account.

With payment links: 
<img width="783" alt="Screenshot 2020-03-30 at 13 26 21" src="https://user-images.githubusercontent.com/2844572/77912469-8a537500-728a-11ea-9b85-7334b703e991.png">

Without payment links:
<img width="775" alt="Screenshot 2020-03-30 at 13 25 29" src="https://user-images.githubusercontent.com/2844572/77912475-8c1d3880-728a-11ea-9cbe-31b81e8a7ba0.png">
