### PR TITLE
PP-6325 Payment links across all services

### DIFF
--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,3 +1,5 @@
+const moment = require('moment')
+
 const currencyFormatter = new Intl.NumberFormat('en-GB', {
   style: 'currency',
   currency: 'GBP'
@@ -40,10 +42,15 @@ const toISODateString = function toISODateString(timestamp) {
   return date.toISOString().split('T')[0]
 }
 
+const toFormattedDateSince = function toFormattedDateSince(date) {
+  return moment(date).fromNow()
+}
+
 module.exports = {
   toFormattedDate,
   toCurrencyString,
   toFormattedDateLong,
   toUnixDate,
-  toISODateString
+  toISODateString,
+  toFormattedDateSince
 }

--- a/src/lib/pay-request/api_utils/products.js
+++ b/src/lib/pay-request/api_utils/products.js
@@ -9,8 +9,19 @@ const productsMethods = function productsMethods(instance) {
       .then(utilExtractData)
   }
 
+  const paymentLinksWithUsage = function paymentLinksWithUsage(gatewayAccountId) {
+    const queryParams = {
+      params: {
+        ...gatewayAccountId && { gatewayAccountId }
+      }
+    }
+    return axiosInstance.get('/v1/api/stats/products', queryParams)
+      .then(utilExtractData)
+  }
+
   return {
-    paymentLinksByGatewayAccount
+    paymentLinksByGatewayAccount,
+    paymentLinksWithUsage
   }
 }
 

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -57,7 +57,7 @@
           <h4 class="govuk-heading-s app-subnav__header">Services</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services">Overview</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services">Platform services</a>
             </li>
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services/search">Find a service</a>
@@ -78,6 +78,13 @@
             </li>
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts/direct_debit">Direct debit</a>
+            </li>
+          </ul>
+
+          <h4 class="govuk-heading-s app-subnav__header">Payment links</h4>
+          <ul class="govuk-list app-subnav__section">
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payment_links">Platform payment links</a>
             </li>
           </ul>
 

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -2,61 +2,83 @@
 {% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
 
+{% set serviceName = serviceGatewayAccountIndex[accountId] if accountId else "" %}
+
 {% block main %}
   <span class="govuk-caption-m">
-    {% if service %}
-      <span>{{ service.name }}</span>
+    {% if accountId %}
+      <span>{{ serviceName }}</span>
     {% else %}
       <span>GOV.UK Pay platform</span>
     {% endif %}
   </span>
-
   <h1 class="govuk-heading-m">Payment links</h1>
 
-  {% if filters.reference %}
-  <div class="govuk-body">
-    <span>Filtered by reference</span>
-    <span><strong class="govuk-tag">{{ filters.reference }}</strong></span>
-  </div>
-  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  {% if accountId %}
+    <div>
+      <a href="/gateway_accounts/{{ accountId }}" class="govuk-back-link">Associated gateway account {{serviceName}} ({{ accountId }})</a>
+    </div>
   {% endif %}
 
   <div>
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col">ID</th>
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">Status</th>
+          <th class="govuk-table__header" scope="col">
+            <a class="govuk-link govuk-link--no-visited-state" href="?sort=payment_count">
+              Payments created
+            </a>
+          </th>
+          <th class="govuk-table__header" scope="col">
+            <a class="govuk-link govuk-link--no-visited-state" href="?sort=last_payment_date">
+              Last used
+            </a>
+          </th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for link in paymentLinks %}
-        <tr class="govuk-table__row" onclick="local.href='/transactions'">
-          <td class="govuk-table__cell">
-            <span class="govuk-caption-m">{{ link.external_id | truncate(6) }}</span>
-          </td>
-          <td class="govuk-table__cell">
-            <span>{{ link.name or "(No name)" }}</span>
-          </td>
-          <td class="govuk-table__cell">
-            <strong class="govuk-tag">{{ link.status }}</strong>
-          </td>
-        </tr>
-        <tr class="govuk-table__row" onclick="local.href='/transactions'">
-          <td class="govuk-table__cell" colspan="3">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ link._indexedLinks.friendly or link._indexedLinks.pay }}">
-                {{ link._indexedLinks.friendly or link._indexedLinks.pay }}
+        {% for group in groupedPaymentLinks %}
+          {% if not accountId %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" colspan="4">
+              <strong>{{ serviceGatewayAccountIndex[group.key] }}</strong>  <a class="govuk-link govuk-link--no-visited-state" href="/transactions?account_id={{ group.key }}">Transactions</a>
+            </td>
+          </tr>
+          {% endif %}
+          {% for link in group.links %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <span>{{ (link.product.name or "(No name)") | truncate(30) }}</span>
+            </td>
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag">{{ link.product.status }}</strong>
+            </td>
+            <td class="govuk-table__cell">
+              <span>{{ link.payment_count }}</span>
+            </td>
+            <td class="govuk-table__cell">
+              <span>{{ link.last_payment_date | formatDateSince }}</span>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" colspan="4">
+              {% set linkHref = link.product._indexedLinks.friendly or link.product._indexedLinks.pay %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ linkHref }}">
+                {{ linkHref | truncate(80) }}
               </a>
-        </tr>
-        {% else %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell center" colspan="3"><span><i>No payment links found.</i></span></td>
-        </tr>
+          </tr>
+          {% endfor %}
+
+          {% else %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell center" colspan="4"><span><i>No payment links found.</i></span></td>
+          </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
 
-  {{ json("Payment links list source", paymentLinks) }}
+  {{ json("Payment links list source", groupedPaymentLinks) }}
 {% endblock %}

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -43,7 +43,7 @@
           {% if not accountId %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" colspan="4">
-              <strong>{{ serviceGatewayAccountIndex[group.key] }}</strong>  <a class="govuk-link govuk-link--no-visited-state" href="/transactions?account_id={{ group.key }}">Transactions</a>
+              <strong class="govuk-!-margin-right-2">{{ serviceGatewayAccountIndex[group.key] }}</strong>  <a class="govuk-link govuk-link--no-visited-state" href="/transactions?account_id={{ group.key }}">Transactions</a>
             </td>
           </tr>
           {% endif %}

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -1,31 +1,59 @@
+import _ from 'lodash'
 import { Request, Response, NextFunction } from 'express'
 import { Products, AdminUsers } from '../../../lib/pay-request'
 
 function indexPaymentLinksByType(paymentLink: any): any {
-  const index = paymentLink._links.reduce((aggregate: any, linkDetails: any) => {
+  const index = paymentLink.product._links.reduce((aggregate: any, linkDetails: any) => {
     aggregate[linkDetails.rel] = linkDetails.href
     return aggregate
   }, {})
-  paymentLink._indexedLinks = index
+  paymentLink.product._indexedLinks = index
   return paymentLink
 }
 
 export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    let service
+    let serviceRequest, paymentLinksRequest
     const { accountId } = req.params
-
-    const paymentLinksRepsonse = await Products.paymentLinksByGatewayAccount(accountId)
-    const paymentLinks = paymentLinksRepsonse
-      .filter((link: any) => link.type === 'ADHOC')
-      .map(indexPaymentLinksByType)
+    const sort = req.query.sort || 'last_payment_date'
 
     if (accountId) {
-      service = await AdminUsers.gatewayAccountServices(accountId)
+      serviceRequest = AdminUsers.gatewayAccountServices(accountId)
+        .then((service: any) => [ service ])
+    } else {
+      serviceRequest = AdminUsers.services()
     }
+    paymentLinksRequest = Products.paymentLinksWithUsage(accountId)
+
+    const [serviceResponse, paymentLinksResponse] = await Promise.all([serviceRequest, paymentLinksRequest])
+
+    const serviceGatewayAccountIndex = serviceResponse
+      .reduce((aggregate: any, service: any) => {
+        service.gateway_account_ids.forEach((accountId: string) => {
+          aggregate[accountId] = service.service_name && service.service_name.en
+        })
+        return aggregate
+      }, {})
+
+    const paymentLinks = paymentLinksResponse.map(indexPaymentLinksByType)
+    const groupedLinks = _.groupBy(paymentLinks, 'product.gateway_account_id')
+    const orderedGroups = _.orderBy(
+      Object.keys(groupedLinks)
+        .map((key: any) => {
+          const group = groupedLinks[key]
+          return {
+            key,
+            links: _.orderBy(group, sort, 'desc'),
+            payment_count: _.sumBy(group, 'payment_count'),
+            last_payment_date: _.orderBy(group, 'last_payment_date', 'desc')[0].last_payment_date
+          }
+        }),
+      sort,
+      'desc'
+    )
 
     res.render('payment_links/overview', {
-      service, paymentLinks
+      groupedPaymentLinks: orderedGroups, accountId, serviceGatewayAccountIndex, sort
     })
   } catch (error) {
     next(error)

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -109,6 +109,8 @@ router.get('/transactions/:id/parity', auth.secured, parity.validateLedgerTransa
 
 router.get('/transactions', auth.secured, transactions.list)
 
+router.get('/payment_links', auth.secured, paymentLinks.list)
+
 router.get('/platform/dashboard', auth.secured, platform.dashboard)
 router.get('/platform/dashboard/live', platform.live)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -26,7 +26,8 @@ const {
   toFormattedDate,
   toFormattedDateLong,
   toCurrencyString,
-  toUnixDate
+  toUnixDate,
+  toFormattedDateSince
 } = require('./../lib/format')
 
 // @FIXME(sfount) errors should be thrown and this should be properly handled if
@@ -106,6 +107,7 @@ const configureTemplateRendering = function configureTemplateRendering(instance)
   templaterEnvironment.addGlobal('manifest', { ...staticResourceManifest, ...browserManifest })
   templaterEnvironment.addFilter('formatDate', (date) => toFormattedDate(new Date(date)))
   templaterEnvironment.addFilter('formatDateLong', (date) => toFormattedDateLong(new Date(date)))
+  templaterEnvironment.addFilter('formatDateSince', (date) => toFormattedDateSince(new Date(date)))
   templaterEnvironment.addFilter('unixDate', (timestamp) => toUnixDate(timestamp))
   templaterEnvironment.addFilter('currency', (currencyInPence) => toCurrencyString(currencyInPence / 100))
   templaterEnvironment.addFilter('isObject', (value) => typeof value === 'object')


### PR DESCRIPTION
Support showing payment links across all services, includes usage info on total number of payments created against the payment link and when it was last used. 

Depends on https://github.com/alphagov/pay-products/pull/450.

* products client helper method for payment link usage report
* grouping and ordering for last payment made against payment link and
total payments
* platfrom vs. individual gateway account links
* group payment links by gateway account