### PR TITLE
PP-JFDI Allow gateway accounts to update statement descriptors

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -156,6 +156,11 @@
     href: "/services/" + services.external_id + "/gateway_account/" + gatewayAccountId + "/payouts"
     })
     }}
+    {{ govukButton({
+    text: "Update statement descriptor",
+    href: "/gateway_accounts/" + gatewayAccountId + "/stripe_statement_descriptor"
+    })
+    }}
     {% endif %}
     {% if account.payment_method !== "DIRECT_DEBIT" %}
       {{ govukButton({

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -27,5 +27,7 @@ export default {
   emailBranding: http.emailBranding,
   updateEmailBranding: http.updateEmailBranding,
   toggleBlockPrepaidCards: http.toggleBlockPrepaidCards,
-  toggleMotoPayments: http.toggleMotoPayments
+  toggleMotoPayments: http.toggleMotoPayments,
+  updateStripeStatementDescriptorPage: http.updateStripeStatementDescriptorPage,
+  updateStripeStatementDescriptor: http.updateStripeStatementDescriptor
 }

--- a/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
+++ b/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+  <span class="govuk-caption-m">Update gateway account</span>
+  <h1 class="govuk-heading-m">Stripe statement descriptor</h1>
+
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Gateway account ({{ account.gateway_account_id }})</a>
+  </div>
+
+  <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/stripe_statement_descriptor">
+    {{ govukInput({
+      id: "statement_descriptor",
+      name: "statement_descriptor",
+      label: { text: "Stripe statement descriptor" },
+      autocomplete: "off"
+    })
+    }}
+
+    {{ govukButton({
+    text: "Update Stripe statement descriptor"
+    })
+    }}
+
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+  </form>
+{% endblock %}

--- a/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
+++ b/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
@@ -10,11 +10,27 @@
     <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Gateway account ({{ account.gateway_account_id }})</a>
   </div>
 
+  <p class="govuk-body">
+    The Stripe statement descriptor is what the user paying a service will see in their bank account. It's important that this
+    correctly identifies the service to avoid chargebacks from confused users. This tool will update the Stripe Connect account.
+  </p>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://stripe.com/docs/connect/statement-descriptors">Statement descriptors with Connect</a>
+  </p>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://stripe.com/docs/statement-descriptors#requirements">Statement descriptor requirements</a>
+  </p>
+
   <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/stripe_statement_descriptor">
     {{ govukInput({
       id: "statement_descriptor",
       name: "statement_descriptor",
       label: { text: "Stripe statement descriptor" },
+      hint: {
+        text: "Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
+      },
       autocomplete: "off"
     })
     }}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -53,6 +53,8 @@ router.post('/gateway_accounts/:id/surcharge', auth.secured, gatewayAccounts.upd
 router.get('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.emailBranding)
 router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.updateEmailBranding)
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
+router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
+router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 
 router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)


### PR DESCRIPTION
Support often have requests to update what paying users get on bank
statements for Stripe services. Allow them to do this through Toolbox.

<img width="759" alt="Screenshot 2020-04-02 at 13 07 23" src="https://user-images.githubusercontent.com/2844572/78247734-4909d200-74e3-11ea-948c-c6b68ed277a7.png">

