### PR TITLE
PP-6325 Payment links export CSV route

### DIFF
--- a/src/web/modules/payment_links/csv.ts
+++ b/src/web/modules/payment_links/csv.ts
@@ -1,0 +1,62 @@
+import { Parser } from 'json2csv'
+
+const fields = [{
+  label: 'ID',
+  value: 'product.external_id'
+}, {
+  label: 'Gateway account is live',
+  value: 'is_live_account'
+}, {
+  label: 'Gateway account ID',
+  value: 'product.gateway_account_id'
+}, {
+  label: 'Number of payments',
+  value: 'payment_count'
+}, {
+  label: 'Date last used',
+  value: 'last_payment_date'
+},{
+  label: 'Payment link name',
+  value: 'product.name'
+}, {
+  label: 'Payment link description',
+  value: 'product.description'
+},{
+  label: 'Payment link URL',
+  value: 'url'
+},{
+  label: 'Service name',
+  value: 'service_name'
+},{
+  label: 'Organisation name',
+  value: 'organisation_name'
+},{
+  label: 'Sector',
+  value: 'sector'
+},{
+  label: 'Is fixed price',
+  value: 'is_fixed_price'
+},{
+  label: 'Fixed price',
+  value: 'product.price'
+},{
+  label: 'Custom reference entered',
+  value: 'product.reference_enabled'
+},{
+  label: 'Reference label',
+  value: 'product.reference_label'
+},{
+  label: 'Language',
+  value: 'product.language'
+},{
+  label: 'Has metadata',
+  value: 'has_metadata'
+},{
+  label: 'Metadata',
+  value: 'product.metadata'
+}]
+
+export function format(linksUsage: any): string {
+  const parser = new Parser({ fields })
+  return parser.parse(linksUsage)
+}

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -2,7 +2,10 @@
 {% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
 
-{% set serviceName = serviceGatewayAccountIndex[accountId] if accountId else "" %}
+{% set serviceName =
+  (serviceGatewayAccountIndex[accountId] and
+  serviceGatewayAccountIndex[accountId].service_name and
+  serviceGatewayAccountIndex[accountId].service_name.en) if accountId else "" %}
 
 {% block main %}
   <span class="govuk-caption-m">
@@ -41,12 +44,14 @@
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">Status</th>
           <th class="govuk-table__header" scope="col">
-            <a class="govuk-link govuk-link--no-visited-state" href="?sort=payment_count">
+            {% set sortByCreated = "?sort=payment_count" if filterLiveAccounts else "?sort=payment_count&live=false" %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ sortByCreated }}">
               Payments created
             </a>
           </th>
           <th class="govuk-table__header" scope="col">
-            <a class="govuk-link govuk-link--no-visited-state" href="?sort=last_payment_date">
+            {% set sortByLastPaid = "?sort=last_payment_date" if filterLiveAccounts else "?sort=last_payment_date&live=false" %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ sortByLastPaid }}">
               Last used
             </a>
           </th>
@@ -57,7 +62,7 @@
           {% if not accountId %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" colspan="4">
-              <strong class="govuk-!-margin-right-2">{{ serviceGatewayAccountIndex[group.key] }}</strong>  <a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ group.key }}">Transactions</a>
+              <strong class="govuk-!-margin-right-2">{{ serviceGatewayAccountIndex[group.key].service_name and serviceGatewayAccountIndex[group.key].service_name.en }}</strong>  <a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ group.key }}">Transactions</a>
             </td>
           </tr>
           {% endif %}
@@ -78,9 +83,9 @@
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" colspan="4">
-              {% set linkHref = link.product._indexedLinks.friendly or link.product._indexedLinks.pay %}
+              {# {% set linkHref = link.product._indexedLinks.friendly or link.product._indexedLinks.pay %} #}
               <a class="govuk-link govuk-link--no-visited-state" href="{{ linkHref }}">
-                {{ linkHref | truncate(80) }}
+                {{ link.url | truncate(80) }}
               </a>
           </tr>
           {% endfor %}

--- a/src/web/modules/payment_links/overview.njk
+++ b/src/web/modules/payment_links/overview.njk
@@ -38,6 +38,18 @@
   {% endif %}
 
   <div>
+    {% set csvHref =
+      ("/gateway_accounts/" + accountId + "/payment_links/csv?live=" + filterLiveAccounts + "&sort=" + sort)
+      if accountId else
+      ("/payment_links/csv?live=" + filterLiveAccounts + "&sort=" + sort) %}
+    <a href="{{ csvHref }}"
+      class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
+      Export page as CSV
+    </a>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+  <div>
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -83,8 +95,7 @@
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" colspan="4">
-              {# {% set linkHref = link.product._indexedLinks.friendly or link.product._indexedLinks.pay %} #}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ linkHref }}">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ link.url }}">
                 {{ link.url | truncate(80) }}
               </a>
           </tr>

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -1,8 +1,7 @@
 import _ from 'lodash'
 import { Request, Response, NextFunction } from 'express'
 import { Products, AdminUsers, Connector } from '../../../lib/pay-request'
-import { Parser } from 'json2csv'
-
+import { format } from './csv'
 function indexPaymentLinksByType(paymentLink: any): any {
   const index = paymentLink.product._links.reduce((aggregate: any, linkDetails: any) => {
     aggregate[linkDetails.rel] = linkDetails.href
@@ -40,79 +39,18 @@ export async function listCSV(req: Request, res: Response, next: NextFunction): 
     const { accountId } = req.params
     const sort = req.query.sort || 'last_payment_date'
     const live = req.query.live === undefined ? true : req.query.live && req.query.live !== "false"
-
-    // we're only going to filter live gateway accounts if we're at the whole platform level
     const filterLiveAccounts = live && !accountId
     const usageReportResults = await fetchUsageContext(sort, filterLiveAccounts, accountId)
-
     const flatLinksList = usageReportResults.groupedPaymentLinks
       .reduce((aggregate: any, groupedList: any) => {
         aggregate = [ ...aggregate, ...groupedList.links ]
         return aggregate
       }, [])
 
-    const fields = [{
-      label: 'ID',
-      value: 'product.external_id'
-    }, {
-      label: 'Gateway account is live',
-      value: 'is_live_account'
-    }, {
-      label: 'Gateway account ID',
-      value: 'product.gateway_account_id'
-    }, {
-      label: 'Number of payments',
-      value: 'payment_count'
-    }, {
-      label: 'Date last used',
-      value: 'last_payment_date'
-    },{
-      label: 'Payment link name',
-      value: 'product.name'
-    }, {
-      label: 'Payment link description',
-      value: 'product.description'
-    },{
-      label: 'Payment link URL',
-      value: 'url'
-    },{
-      label: 'Service name',
-      value: 'service_name'
-    },{
-      label: 'Organisation name',
-      value: 'organisation_name'
-    },{
-      label: 'Sector',
-      value: 'sector'
-    },{
-      label: 'Is fixed price',
-      value: 'is_fixed_price'
-    },{
-      label: 'Fixed price',
-      value: 'product.price'
-    },{
-      label: 'Custom reference entered',
-      value: 'product.reference_enabled'
-    },{
-      label: 'Reference label',
-      value: 'product.reference_label'
-    },{
-      label: 'Language',
-      value: 'product.language'
-    },{
-      label: 'Has metadata',
-      value: 'has_metadata'
-    },{
-      label: 'Metadata',
-      value: 'product.metadata'
-    }]
-
-    const parser = new Parser({ fields })
-    const csv = parser.parse(flatLinksList)
     const name = accountId || 'platform'
     res.set('Content-Type', 'text/csv')
     res.set('Content-Disposition', `attachment; filename="GOVUK_Pay_payment_links_usage_${ name }.csv"`)
-    res.status(200).send(csv)
+    res.status(200).send(format(flatLinksList))
    } catch(error) {
      next(error)
    }

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import { Request, Response, NextFunction } from 'express'
 import { Products, AdminUsers, Connector } from '../../../lib/pay-request'
+import { Parser } from 'json2csv'
 
 function indexPaymentLinksByType(paymentLink: any): any {
   const index = paymentLink.product._links.reduce((aggregate: any, linkDetails: any) => {
@@ -13,66 +14,175 @@ function indexPaymentLinksByType(paymentLink: any): any {
 
 export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    let serviceRequest, paymentLinksRequest, liveAccountsRequest
     const { accountId } = req.params
     const sort = req.query.sort || 'last_payment_date'
     const live = req.query.live === undefined ? true : req.query.live && req.query.live !== "false"
 
     // we're only going to filter live gateway accounts if we're at the whole platform level
     const filterLiveAccounts = live && !accountId
+    const usageReportResults = await fetchUsageContext(sort, filterLiveAccounts, accountId)
 
-    if (accountId) {
-      serviceRequest = AdminUsers.gatewayAccountServices(accountId)
-        .then((service: any) => [ service ])
-    } else {
-      serviceRequest = AdminUsers.services()
-    }
-
-    if (filterLiveAccounts) {
-      liveAccountsRequest = Connector.accounts({ type: 'live' })
-        .then((response: any) => response.accounts)
-    } else {
-      liveAccountsRequest = Promise.resolve([])
-    }
-
-    paymentLinksRequest = Products.paymentLinksWithUsage(accountId)
-
-    const [serviceResponse, paymentLinksResponse, liveAccountsResponse] = await Promise.all([serviceRequest, paymentLinksRequest, liveAccountsRequest])
-
-    const serviceGatewayAccountIndex = serviceResponse
-      .reduce((aggregate: any, service: any) => {
-        service.gateway_account_ids.forEach((accountId: string) => {
-          aggregate[accountId] = service.service_name && service.service_name.en
-        })
-        return aggregate
-      }, {})
-
-    const liveAccounts = liveAccountsResponse.map((account: any) => account.gateway_account_id)
-
-    const paymentLinks = paymentLinksResponse
-      .map(indexPaymentLinksByType)
-      .filter((link: any) => !filterLiveAccounts || liveAccounts.includes(link.product.gateway_account_id))
-
-    const groupedLinks = _.groupBy(paymentLinks, 'product.gateway_account_id')
-    const orderedGroups = _.orderBy(
-      Object.keys(groupedLinks)
-        .map((key: any) => {
-          const group = groupedLinks[key]
-          return {
-            key,
-            links: _.orderBy(group, sort, 'desc'),
-            payment_count: _.sumBy(group, 'payment_count'),
-            last_payment_date: _.orderBy(group, 'last_payment_date', 'desc')[0].last_payment_date
-          }
-        }),
+    const context = {
+      filterLiveAccounts,
       sort,
-      'desc'
-    )
+      accountId,
+      ...usageReportResults
+    }
 
-    res.render('payment_links/overview', {
-      groupedPaymentLinks: orderedGroups, accountId, serviceGatewayAccountIndex, sort, filterLiveAccounts
-    })
+    res.render('payment_links/overview', context)
   } catch (error) {
     next(error)
+  }
+}
+
+export async function listCSV(req: Request, res: Response, next: NextFunction): Promise<void> {
+   try {
+    const { accountId } = req.params
+    const sort = req.query.sort || 'last_payment_date'
+    const live = req.query.live === undefined ? true : req.query.live && req.query.live !== "false"
+
+    // we're only going to filter live gateway accounts if we're at the whole platform level
+    const filterLiveAccounts = live && !accountId
+    const usageReportResults = await fetchUsageContext(sort, filterLiveAccounts, accountId)
+
+    const flatLinksList = usageReportResults.groupedPaymentLinks
+      .reduce((aggregate: any, groupedList: any) => {
+        aggregate = [ ...aggregate, ...groupedList.links ]
+        return aggregate
+      }, [])
+
+    const fields = [{
+      label: 'ID',
+      value: 'product.external_id'
+    }, {
+      label: 'Gateway account is live',
+      value: 'is_live_account'
+    }, {
+      label: 'Gateway account ID',
+      value: 'product.gateway_account_id'
+    }, {
+      label: 'Number of payments',
+      value: 'payment_count'
+    }, {
+      label: 'Date last used',
+      value: 'last_payment_date'
+    },{
+      label: 'Payment link name',
+      value: 'product.name'
+    }, {
+      label: 'Payment link description',
+      value: 'product.description'
+    },{
+      label: 'Payment link URL',
+      value: 'url'
+    },{
+      label: 'Service name',
+      value: 'service_name'
+    },{
+      label: 'Organisation name',
+      value: 'organisation_name'
+    },{
+      label: 'Sector',
+      value: 'sector'
+    },{
+      label: 'Is fixed price',
+      value: 'is_fixed_price'
+    },{
+      label: 'Fixed price',
+      value: 'product.price'
+    },{
+      label: 'Custom reference entered',
+      value: 'product.reference_enabled'
+    },{
+      label: 'Reference label',
+      value: 'product.reference_label'
+    },{
+      label: 'Language',
+      value: 'product.language'
+    },{
+      label: 'Has metadata',
+      value: 'has_metadata'
+    },{
+      label: 'Metadata',
+      value: 'product.metadata'
+    }]
+
+    const parser = new Parser({ fields })
+    const csv = parser.parse(flatLinksList)
+    const name = accountId || 'platform'
+    res.set('Content-Type', 'text/csv')
+    res.set('Content-Disposition', `attachment; filename="GOVUK_Pay_payment_links_usage_${ name }.csv"`)
+    res.status(200).send(csv)
+   } catch(error) {
+     next(error)
+   }
+}
+
+interface PaymentLinkUsageContext {
+  groupedPaymentLinks: any
+  serviceGatewayAccountIndex: any
+}
+async function fetchUsageContext(sortKey: string, filterLiveAccounts: Boolean, accountId?: string): Promise<PaymentLinkUsageContext> {
+  let serviceRequest, paymentLinksRequest, liveAccountsRequest
+  if (accountId) {
+    serviceRequest = AdminUsers.gatewayAccountServices(accountId)
+      .then((service: any) => [ service ])
+    liveAccountsRequest = Connector.account(accountId)
+    .then((account: any) => [ account ])
+  } else {
+    serviceRequest = AdminUsers.services()
+    liveAccountsRequest = Connector.accounts({ type: 'live' })
+      .then((response: any) => response.accounts)
+  }
+
+  paymentLinksRequest = Products.paymentLinksWithUsage(accountId)
+
+  const [serviceResponse, paymentLinksResponse, liveAccountsResponse] = await Promise.all([serviceRequest, paymentLinksRequest, liveAccountsRequest])
+
+  const serviceGatewayAccountIndex = serviceResponse
+    .reduce((aggregate: any, service: any) => {
+      service.gateway_account_ids.forEach((accountId: string) => {
+        aggregate[accountId] = service
+      })
+      return aggregate
+    }, {})
+
+  const liveAccounts = liveAccountsResponse.map((account: any) => account.gateway_account_id)
+
+  const paymentLinks = paymentLinksResponse
+    .map(indexPaymentLinksByType)
+    .filter((link: any) => !filterLiveAccounts || liveAccounts.includes(link.product.gateway_account_id))
+    .map((link: any) => {
+      const service = serviceGatewayAccountIndex[link.product.gateway_account_id]
+      return {
+        ...link,
+        is_live_account: liveAccounts.includes(link.product.gateway_account_id),
+        url: link.product._indexedLinks.friendly || link.product._indexedLinks.pay,
+        service_name: service && service.service_name && service.service_name.en,
+        organisation_name: service && service.merchant_details && service.merchant_details.name,
+        is_fixed_price: Boolean(link.product.price),
+        has_metadata: Boolean(link.product.metadata)
+      }
+    })
+
+  const groupedLinks = _.groupBy(paymentLinks, 'product.gateway_account_id')
+  const orderedGroups = _.orderBy(
+    Object.keys(groupedLinks)
+      .map((key: any) => {
+        const group = groupedLinks[key]
+        return {
+          key,
+          links: _.orderBy(group, sortKey, 'desc'),
+          payment_count: _.sumBy(group, 'payment_count'),
+          last_payment_date: _.orderBy(group, 'last_payment_date', 'desc')[0].last_payment_date,
+          is_live_account: liveAccounts.includes(key)
+        }
+      }),
+    sortKey,
+    'desc'
+  )
+  return {
+    groupedPaymentLinks: orderedGroups,
+    serviceGatewayAccountIndex
   }
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -55,6 +55,7 @@ router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccount
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
 
 router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
+router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)
 
 router.get('/services', auth.secured, services.overview)
 router.get('/services/search', auth.secured, services.search)
@@ -110,6 +111,7 @@ router.get('/transactions/:id/parity', auth.secured, parity.validateLedgerTransa
 router.get('/transactions', auth.secured, transactions.list)
 
 router.get('/payment_links', auth.secured, paymentLinks.list)
+router.get('/payment_links/csv', auth.secured, paymentLinks.listCSV)
 
 router.get('/platform/dashboard', auth.secured, platform.dashboard)
 router.get('/platform/dashboard/live', platform.live)


### PR DESCRIPTION
Allow payment links usage page to export CSV, this applies to both
individual gateway account views and the entire platform.

CSV generation should respect live account only filters and sorting on
payment date and total payments.