### PR TITLE
BAU Fix live payments dashboard left axis overflow

### DIFF
--- a/browser/src/dashboard/Chart.tsx
+++ b/browser/src/dashboard/Chart.tsx
@@ -21,7 +21,7 @@ export const VolumesByHourChart = (props: VolumesByHourChart) => <ResponsiveLine
   data={props.data}
   xScale={{ type: 'time', format: '%Y-%m-%dT%H:%M:%S.000000Z', precision: 'hour' }}
   xFormat='time:%Y-%m-%dT%H:%M:%S.000000Z'
-  margin={{ top: 10, right: 30, bottom: 60, left: 30 }}
+  margin={{ top: 10, right: 30, bottom: 60, left: 38 }}
   yScale={{
     type: 'linear',
     stacked: false,


### PR DESCRIPTION
As our payment volume significantly increases we often go >= 1000
payments in a given hour bucket. At the moment this overflows off the
left axis of the graph.

Increase the margin to accommodate this.

**Sad with broken overflow**
![Screenshot 2020-04-06 at 15 15 55](https://user-images.githubusercontent.com/2844572/78569910-2c8bd380-781c-11ea-95d1-ee02ad81b73a.png)

**Happy with enough room**
![Screenshot 2020-04-06 at 15 30 04](https://user-images.githubusercontent.com/2844572/78569958-39a8c280-781c-11ea-98f8-648dd482387f.png)
