### PR TITLE
Allow local testing with auth disabled

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -15,7 +15,7 @@ const secured = function secured(req, res, next) {
 }
 
 const administrative = function administrative(req, res, next) {
-  if (req.user.admin || disableAuth) {
+  if (disableAuth || req.user.admin) {
     next()
     return
   }


### PR DESCRIPTION
Check if auth is disabled before looking for the user in the req as when
testing locally with auth disabled, the user does not exist