### PR TITLE
Add CSV download of gateway accounts

### DIFF
--- a/src/web/modules/gateway_accounts/csv.ts
+++ b/src/web/modules/gateway_accounts/csv.ts
@@ -1,0 +1,86 @@
+import { Parser } from 'json2csv'
+
+const fields = [{
+  label: 'Gateway account ID',
+  value: 'account.gateway_account_id'
+}, {
+  label: 'Service ID',
+  value: 'service.id'
+}, {
+  label: 'Service external ID',
+  value: 'service.external_id'
+}, {
+  label: 'Type',
+  value: 'account.type'
+}, {
+  label: 'Description',
+  value: 'account.description'
+}, {
+  label: 'Payment provider',
+  value: 'account.payment_provider'
+}, {
+  label: 'Service name (en)',
+  value: 'service.service_name.en'
+}, {
+  label: 'Service name (cy)',
+  value: 'service.service_name.cy'
+}, {
+  label: 'Organisation',
+  value: 'service.merchant_details.name'
+}, {
+  label: 'Analytics ID',
+  value: 'account.analytics_id'
+}, {
+  label: '3DS enabled',
+  value: 'account.toggle_3ds'
+}, {
+  label: '3DS version',
+  value: 'account.integration_version_3ds'
+}, {
+  label: 'Collect billing address',
+  value: 'service.collect_billing_address'
+}, {
+  label: 'Email collection mode',
+  value: 'account.email_collection_mode'
+}, {
+  label: 'Payment email enabled',
+  value: 'payment_email_enabled'
+}, {
+  label: 'Refund email enabled',
+  value: 'refund_email_emailed'
+}, {
+  label: 'Apple pay enabled',
+  value: 'account.allow_apple_pay'
+}, {
+  label: 'Google pay enabled',
+  value: 'account.allow_google_pay'
+}, {
+  label: 'Block prepaid cards',
+  value: 'account.block_prepaid_cards'
+}, {
+  label: 'MOTO enabled',
+  value: 'account.allow_moto'
+}, {
+  label: 'Allow zero amount',
+  value: 'account.allow_zero_amount'
+}, {
+  label: 'Experimental features enabled',
+  value: 'service.experimental_features_enabled'
+}, {
+  label: 'Uses own error pages',
+  value: 'service.redirect_to_service_immediately_on_terminal_state'
+}, {
+  label: 'Has payment page custom branding',
+  value: 'custom_branding'
+}, {
+  label: 'Has email custom branding',
+  value: 'email_branding'
+}, {
+  label: 'Has corporate card surcharge',
+  value: 'corporate_surcharge'
+}]
+
+export function format(linksUsage: any): string {
+  const parser = new Parser({ fields })
+  return parser.parse(linksUsage)
+}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -70,8 +70,8 @@ const listCSV = async function listCSV(req: Request, res: Response): Promise<voi
         service,
         payment_email_enabled: account.email_notifications['PAYMENT_CONFIRMED'] && account.email_notifications['PAYMENT_CONFIRMED'].enabled || false,
         refund_email_emailed: account.email_notifications['REFUND_ISSUED'] && account.email_notifications['REFUND_ISSUED'].enabled || false,
-        custom_branding: service.custom_branding != undefined,
-        email_branding: account.notify_settings != undefined,
+        custom_branding: service.custom_branding !== undefined,
+        email_branding: account.notify_settings !== undefined,
         corporate_surcharge: account.corporate_prepaid_credit_card_surcharge_amount
           + account.corporate_prepaid_debit_card_surcharge_amount
           + account.corporate_credit_card_surcharge_amount

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -3,6 +3,7 @@ import exceptions from './gateway_accounts.exceptions'
 
 export default {
   overview: http.overview,
+  listCSV: http.listCSV,
   overviewDirectDebit: http.overviewDirectDebit,
   create: {
     http: http.create,

--- a/src/web/modules/gateway_accounts/overview.njk
+++ b/src/web/modules/gateway_accounts/overview.njk
@@ -5,6 +5,14 @@
   <h1 class="govuk-heading-m">Gateway accounts</h1>
 
   {% if card %}
+    <div>
+      <a href="gateway_accounts/csv"
+        class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
+        Export all as CSV
+      </a>
+    </div>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
     {% include "gateway_accounts/filter.njk" %}
 
     <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3">

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -40,6 +40,7 @@ router.get('/statistics/services', auth.secured, statistics.csvServices)
 router.post('/statistics/services', auth.secured, statistics.byServices)
 
 router.get('/gateway_accounts', auth.secured, gatewayAccounts.overview)
+router.get('/gateway_accounts/csv', auth.secured, gatewayAccounts.listCSV)
 router.get('/gateway_accounts/direct_debit', auth.secured, gatewayAccounts.overviewDirectDebit)
 router.get('/gateway_accounts/create', auth.secured, gatewayAccounts.create.http, gatewayAccounts.create.exceptions)
 router.get('/gateway_accounts/:id', auth.secured, gatewayAccounts.detail.http, gatewayAccounts.detail.exceptions)


### PR DESCRIPTION
Add a button to the "Gateway accounts -> Card" page to download all
gateway accounts as a CSV.

This CSV combines service and gateway account details for each gateway
account.