### PR TITLE
BAU - Display timezone for transaction/event dates

### DIFF
--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -5,14 +5,18 @@ const currencyFormatter = new Intl.NumberFormat('en-GB', {
   currency: 'GBP'
 })
 
-const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+const dateFormatterOptions = {
   month: 'short',
   day: 'numeric',
   hour: 'numeric',
   minute: 'numeric',
   second: 'numeric',
-  hour12: false
-})
+  hour12: false,
+  timeZoneName: 'short'
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en-GB', { ...dateFormatterOptions, 'timeZone': 'UTC' })
+const dateFormatterLocalTimeZone = new Intl.DateTimeFormat('en-GB', dateFormatterOptions)
 
 const unixDateFormatter = new Intl.DateTimeFormat('en-GB', {
   weekday: 'short',
@@ -20,34 +24,39 @@ const unixDateFormatter = new Intl.DateTimeFormat('en-GB', {
   day: '2-digit'
 })
 
-const toFormattedDate = function toFormattedDate(date) {
+const toFormattedDate = function toFormattedDate (date) {
   return dateFormatter.format(date)
 }
 
-const toFormattedDateLong = function toFormattedDateLong(date) {
+const toFormattedDateLocalTimeZone = function toFormattedDate (date) {
+  return dateFormatterLocalTimeZone.format(date)
+}
+
+const toFormattedDateLong = function toFormattedDateLong (date) {
   return date.toDateString()
 }
 
-const toCurrencyString = function toCurrencyString(total) {
+const toCurrencyString = function toCurrencyString (total) {
   return currencyFormatter.format(total)
 }
 
-const toUnixDate = function toUnixDate(timestamp) {
+const toUnixDate = function toUnixDate (timestamp) {
   const date = new Date(timestamp * 1000)
   return unixDateFormatter.format(date)
 }
 
-const toISODateString = function toISODateString(timestamp) {
+const toISODateString = function toISODateString (timestamp) {
   const date = new Date(timestamp * 1000)
   return date.toISOString().split('T')[0]
 }
 
-const toFormattedDateSince = function toFormattedDateSince(date) {
+const toFormattedDateSince = function toFormattedDateSince (date) {
   return moment(date).fromNow()
 }
 
 module.exports = {
   toFormattedDate,
+  toFormattedDateLocalTimeZone,
   toCurrencyString,
   toFormattedDateLong,
   toUnixDate,

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -66,7 +66,7 @@
             <span class="govuk-caption-m">{{ payment.description | truncate(20) }}</span>
           </td>
           <td class="govuk-table__cell">
-            <span class="govuk-caption-m">{{ payment.created_date | formatDate }}</span>
+            <span class="govuk-caption-m">{{ payment.created_date | formatDateLocalTimeZone }}</span>
           </td>
         </tr>
         {% else %}

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -48,8 +48,8 @@
           <td class="govuk-table__cell payment__cell">{{ transaction.description }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date</span></th>
-          <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLong }}</td>
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date (local date & time)</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLocalTimeZone }}</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Amount</span></th>

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -24,6 +24,7 @@ const router = require('./router')
 // @FIXME(sfount) move this out of server configuration
 const {
   toFormattedDate,
+  toFormattedDateLocalTimeZone,
   toFormattedDateLong,
   toCurrencyString,
   toUnixDate,
@@ -106,6 +107,7 @@ const configureTemplateRendering = function configureTemplateRendering(instance)
   // make static manifest details available to all templates
   templaterEnvironment.addGlobal('manifest', { ...staticResourceManifest, ...browserManifest })
   templaterEnvironment.addFilter('formatDate', (date) => toFormattedDate(new Date(date)))
+  templaterEnvironment.addFilter('formatDateLocalTimeZone', (date) => toFormattedDateLocalTimeZone(new Date(date)))
   templaterEnvironment.addFilter('formatDateLong', (date) => toFormattedDateLong(new Date(date)))
   templaterEnvironment.addFilter('formatDateSince', (date) => toFormattedDateSince(new Date(date)))
   templaterEnvironment.addFilter('unixDate', (timestamp) => toUnixDate(timestamp))


### PR DESCRIPTION
Display timezone for date to avoid confusion with UTC vs local time zone


### Date and time in UTC in paymemt header row (top of the page)
<img width="437" alt="Screenshot 2020-04-07 at 21 12 16" src="https://user-images.githubusercontent.com/40598480/78718801-d05ba900-791a-11ea-9654-dcee1aa6d6d7.png">

### Date & time in server timezone within payments details
<img width="509" alt="Screenshot 2020-04-07 at 21 57 21" src="https://user-images.githubusercontent.com/40598480/78718824-d94c7a80-791a-11ea-9f84-1192cb529c59.png">

### Date & time in server timezone platform transactions list
<img width="576" alt="Screenshot 2020-04-07 at 21 28 06" src="https://user-images.githubusercontent.com/40598480/78718889-f2edc200-791a-11ea-9ad0-713758ea39e3.png">


