### PR TITLE
Show errors when authentication is disabled

### DIFF
--- a/src/web/errorHandler.ts
+++ b/src/web/errorHandler.ts
@@ -77,7 +77,7 @@ const handleDefault = function handleDefault(
   if (res.headersSent) {
     return next(error)
   }
-  if (!req.isAuthenticated()) {
+  if (!req.isAuthenticated() && !config.disableAuth) {
     // don't render application structure for non authenticated issues
     return res.redirect('/auth/unauthorised?default_throw')
   }


### PR DESCRIPTION
We hide showing errors if a user isn't authenticated to prevent from
leaking information an unauthenticated user shouldn't see.

When authentication is disabled for local testing, we always want to be
able to see these errors.