### PR TITLE
Allow more flexible node version specification for PaaS apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "description": "Internal administrative tools service for the GOV.UK Pay products.",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.1"
+    "node": "^12.14.1",
+    "npm": "^6.13.1"
   },
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
This ensures as PaaS updates available node buildpacks, the app
can continue to be deployed with minor node version updates.

i.e. 12.x.x

This matches configuration applied to other node apps.