### PR TITLE
PP-6219 Add default for event_date if not provided

### DIFF
--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import { parseString } from 'fast-csv'
+import { Parser } from 'json2csv'
 import { S3 } from 'aws-sdk'
 import moment from 'moment'
 import logger from '../../../../lib/logger'
@@ -7,6 +8,7 @@ import { aws } from '../../../../config'
 
 type TransactionRow = {
   transaction_id: string;
+  event_type: string;
   event_date: string;
 }
 
@@ -18,53 +20,83 @@ export async function fileUpload(req: Request, res: Response): Promise<void> {
   })
 }
 
-const uploadToS3 = async function uploadToS3(fileBuffer: Buffer, user: any): Promise<void> {
+const uploadToS3 = async function uploadToS3(content: string, user: any): Promise<void> {
   // The AWS SDK automatically uses the AWS credentials from the environment when deployed.
   // For local testing, set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
-  const s3 = new S3()
-  const key = (user && user.username || '') + moment().format('x')
-  logger.info(`Uploading transactions file to S3 with key ${key}`)
-  const response = await s3.putObject({
-    Bucket: aws.AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME,
-    Body: fileBuffer,
-    Key: key
-  }).promise();
-  logger.info('S3 upload response: ' + JSON.stringify(response))
+  try {
+    const s3 = new S3()
+    const key = (user && user.username || '') + moment().format('x')
+    logger.info(`Uploading transactions file to S3 with key ${key}`)
+    const response = await s3.putObject({
+      Bucket: aws.AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME,
+      Body: content,
+      Key: key
+    }).promise();
+    logger.info('S3 upload response: ' + JSON.stringify(response))
+  } catch (err) {
+    logger.error(`Error uploading to s3: ${err.message}`)
+    throw new Error('There was an error uploading the file to S3')
+  }
+}
+
+const validateAndAddDefaults = async function validateAndAddDefaults(csv: string): Promise<Object[]> {
+  let validationError = false
+  const data: Object[] = []
+
+  return new Promise((resolve, reject) => {
+    parseString<TransactionRow, TransactionRow>(csv, { headers: true })
+      .transform((row: TransactionRow) => {
+        if (!row.event_date) {
+          row.event_date = moment().utc().format()
+        }
+        return row
+      })
+      .validate((row, cb) => {
+        if (!row.transaction_id) {
+          return cb(null, false, 'transaction_id is missing')
+        }
+        if (!row.event_type) {
+          return cb(null, false, 'event_type is missing')
+        }
+        if (!moment(row.event_date, moment.ISO_8601).isValid()) {
+          return cb(null, false, 'event_date is not a valid ISO_8601 string')
+        }
+        return cb(null, true)
+      })
+      .on('error', error => {
+        reject(new Error(`There was an error parsing the csv: ${error.message}`))
+      })
+      .on('data', row => {
+        data.push(row)
+      })
+      .on('data-invalid', (row, rowNumber, reason) => {
+        validationError = true
+        reject(new Error(`CSV invalid on row ${rowNumber}: ${reason}`))
+      })
+      .on('end', (rowCount: number) => {
+        if (!validationError) {
+          logger.info(`Successfully parsed transactions update CSV: ${rowCount} rows`)
+          resolve(data)
+        }
+      })
+  })
 }
 
 export async function update(req: Request, res: Response): Promise<void> {
-  let validationError = false
-  parseString<TransactionRow, TransactionRow>(req.file.buffer.toLocaleString(), { headers: true })
-    .validate((row, cb) => {
-      if (!row.transaction_id) {
-        return cb(null, false, 'transaction_id is missing')
-      }
-      if (row.event_date && !moment(row.event_date, moment.ISO_8601).isValid()) {
-        return cb(null, false, 'event_date is not a valid ISO_8601 string')
-      }
-      return cb(null, true)
-    })
-    .on('error', error => {
-      req.flash('error', `There was an error parsing the csv: ${error.message}`)
-    })
-    .on('data', row => { })
-    .on('data-invalid', (row, rowNumber, reason) => {
-      validationError = true
-      req.flash('error', `CSV invalid on row ${rowNumber}: ${reason}`)
-      res.redirect('/transactions/update')
-    })
-    .on('end', async (rowCount: number) => {
-      // end is fired if final row is parsed even if there is a validation error
-      if (!validationError) {
-        logger.info(`Successfully parsed transactions update CSV: ${rowCount} rows`)
-        try {
-          await uploadToS3(req.file.buffer, req.user)
-          req.flash('info', 'File upload successful')
-        } catch (err) {
-          logger.error('Error uploading to s3: ' + err.message)
-          req.flash('error', 'There was an error uploading the file to S3')
-        }
-        res.redirect('/transactions/update')
-      }
-    })
+  if (!req.file || !req.file.buffer) {
+    req.flash('error', 'Select a CSV containing transaction updates')
+    return res.redirect('/transactions/update')
+  }
+
+  try {
+    const data = await validateAndAddDefaults(req.file.buffer.toLocaleString())
+    const parser = new Parser()
+    const output = parser.parse(data)
+    await uploadToS3(output, req.user)
+    req.flash('info', 'File upload successful')
+  } catch (err) {
+    logger.error(`Error updating transactions: ${err.message}`)
+    req.flash('error', err.message)
+  }
+  res.redirect('/transactions/update')
 }


### PR DESCRIPTION
If no value is provided for `event_date` for a row, add in the current timestamp.

Require a value for `event_type`. We may revisit this and use a default if none is provided, we'll look at how people are using this field. Some instructions will be added to the page for what the value should look like.

Also show an error message if no CSV file is selected