### PR TITLE
PP-6219 Run ECS task after file uploaded

### DIFF
--- a/src/config/aws.js
+++ b/src/config/aws.js
@@ -1,7 +1,8 @@
 const Joi = require('joi')
 
 const expectedAwsEnvironmentValues = {
-  AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME: Joi.string()
+  AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME: Joi.string(),
+  AWC_ECS_UPDATE_TRANSACTIONS_TASK_DEFINITION: Joi.string()
 }
 
 const { error, value: validatedAwsEnvironmentValues } = Joi.validate(

--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -4,7 +4,7 @@ import { Parser } from 'json2csv'
 import { S3, ECS } from 'aws-sdk'
 import moment from 'moment'
 import logger from '../../../../lib/logger'
-import { aws } from '../../../../config'
+import { aws, common } from '../../../../config'
 
 type TransactionRow = {
   transaction_id: string;
@@ -48,6 +48,7 @@ const runEcsTask = async function runEcsTask(fileKey: string, jobId: string): Pr
     const ecs = new ECS()
     const response = await ecs.runTask({
       taskDefinition: aws.AWC_ECS_UPDATE_TRANSACTIONS_TASK_DEFINITION,
+      cluster: common.ENVIRONMENT,
       overrides: {
         containerOverrides: [
           {

--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -52,6 +52,7 @@ const runEcsTask = async function runEcsTask(fileKey: string, jobId: string): Pr
       overrides: {
         containerOverrides: [
           {
+            name: 'stream-s3-sqs',
             environment: [
               { name: "PROVIDER_S3_SOURCE_FILE", value: fileKey },
               { name: "JOB_ID", value: jobId }


### PR DESCRIPTION
Run the ECS task to stream the CSV to the events SQS, giving the key of
the file uploaded to S3 to process.

Report back the ARN of the task so the user can check the progress in
splunk.

The task definition is provided using the
AWS_ECS_UPDATE_TRANSACTIONS_TASK_DEFINITION environment variable.