### PR TITLE
PP-6219 Modify accepted CSV headers

### DIFF
--- a/src/web/modules/transactions/update/upload.njk
+++ b/src/web/modules/transactions/update/upload.njk
@@ -53,7 +53,7 @@
           <td class="govuk-table__cell">Yes</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">event_type</th>
+          <td class="govuk-table__cell">event_name</th>
           <td class="govuk-table__cell">The name of the event that will be stored against the transaction. It should be SCREAMING_SNAKE_CASE and describe the action performed against the transaction in the past tense.</td>
           <td class="govuk-table__cell">Yes</td>
         </tr>
@@ -61,6 +61,16 @@
           <td class="govuk-table__cell">event_date</th>
           <td class="govuk-table__cell">The timestamp for the event. Must be a valid ISO_8601 format. If not provided, the time when the file is uploaded will be used.</td>
           <td class="govuk-table__cell">No</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">transaction_type</th>
+          <td class="govuk-table__cell">The type of the transaction. 'PAYMENT' or 'REFUND'. Defaults to 'PAYMENT' if not provided.</td>
+          <td class="govuk-table__cell">No</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">parent_transaction_id</th>
+          <td class="govuk-table__cell">For refunds, this is the payment external ID.</td>
+          <td class="govuk-table__cell">Required for refunds</td>
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">Transaction field headers</th>


### PR DESCRIPTION
`event_type` is now `event_name`.

Optionally expect `transaction_type` header and default to 'PAYMENT' if
not provided.

Expect `parent_transaction_id` to be provided if `transaction_type` is
`refund`.