### PR TITLE
PP-6218 Specify server side encryption for CSV upload

### DIFF
--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -32,7 +32,8 @@ const uploadToS3 = async function uploadToS3(content: string, user: any): Promis
     const response = await s3.putObject({
       Bucket: aws.AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME,
       Body: content,
-      Key: key
+      Key: key,
+      ServerSideEncryption: 'AES256'
     }).promise();
     logger.info('S3 upload response: ' + JSON.stringify(response))
   } catch (err) {


### PR DESCRIPTION
Documents uploaded to the update payments bucket are encrypted using the
S3 master encryption key as they may contain sensitive data. Specify
this in put request configuration or S3 will reject the upload.