### PR TITLE
BAU Always fetch related transactions for a payments

### DIFF
--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -96,13 +96,11 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
         return event
       })
 
-    if (transaction.refund_summary && transaction.refund_summary.amount_submitted !== 0) {
-      const relatedResult = await Ledger.relatedTransactions(
-        transaction.transaction_id,
-        transaction.gateway_account_id
-      )
-      relatedTransactions.push(...relatedResult.transactions)
-    }
+    const relatedResult = await Ledger.relatedTransactions(
+      transaction.transaction_id,
+      transaction.gateway_account_id
+    )
+    relatedTransactions.push(...relatedResult.transactions)
 
     const renderKey = transaction.transaction_type.toLowerCase()
     res.render(`transactions/${renderKey}`, {


### PR DESCRIPTION
Remove logic trying to determine if a successful refund has happened
before showing related transactions on a payment.

It is useful to see failed refunds against payments for support.