### PR TITLE
PP-6389 Fix incorrect Sentry import

### DIFF
--- a/src/lib/winstonSentryTransport.js
+++ b/src/lib/winstonSentryTransport.js
@@ -1,5 +1,5 @@
 import TransportStream from 'winston-transport'
-import Sentry from '@sentry/node'
+import * as Sentry from '@sentry/node'
 
 export default class WinstonSentryTransport extends TransportStream {
   log(info, callback) {


### PR DESCRIPTION
Sentry is a Typescript library that doesn't have a default export, this
means that the wildcard syntax should be used to collect all of the
modules individual exports. Without this Sentry has been failing to
intialise correctly in some cases and potentially stopping the entire
winston logging pipeline out of the app.