### PR TITLE
BAU Show accepted card types for gateway accounts

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -21,6 +21,10 @@ const connectorMethods = function connectorMethods(instance) {
     return axiosInstance.get(`/v1/frontend/accounts/${id}`).then(utilExtractData)
   }
 
+  const acceptedCardTypes = function acceptedCardTypes(accountId) {
+    return axiosInstance.get(`/v1/frontend/accounts/${accountId}/card-types`).then(utilExtractData)
+  }
+
   const createAccount = function createAccount(accountDetails) {
     return axiosInstance.post('/v1/api/accounts', accountDetails).then(utilExtractData)
   }
@@ -127,6 +131,7 @@ const connectorMethods = function connectorMethods(instance) {
     account,
     accounts,
     accountWithCredentials,
+    acceptedCardTypes,
     createAccount,
     searchTransactionsByChargeId,
     searchTransactionsByReference,

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -254,5 +254,6 @@
   {% endif %}
 
   {{ json("Gateway account details source", account) }}
+  {{ json("Accepted cards source", acceptedCards) }}
   {{ json("Gateway account services source", services) }}
 {% endblock %}


### PR DESCRIPTION
At the bottom of the gateway account details page, display the response for a request to get the accepted card types.

This is useful when we get notifications about blocked card types from Worldpay, as this error is the same as for a too high payment amount. We can also see if the service has since enabled the card type so we know whether or not to contact them.