### PR TITLE
BAU Fix refunds always showing as test data

### DIFF
--- a/src/web/modules/transactions/@types/transactions.d.ts
+++ b/src/web/modules/transactions/@types/transactions.d.ts
@@ -59,6 +59,8 @@ declare module 'ledger' {
     refund_summary: RefundSummary;
     transaction_id: string;
     transaction_type: string;
+    parent_transaction_id?: string;
+    parent?: Transaction;
   }
 
   export interface Event {

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -2,7 +2,7 @@
 
 {% extends "layout/layout.njk" %}
 
-{% set isTestData = not transaction.live %}
+{% set isTestData = not (transaction.parent and transaction.parent.live) %}
 
 {% block main %}
   <h1 class="govuk-heading-m">Refund</h1>

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -102,6 +102,10 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     )
     relatedTransactions.push(...relatedResult.transactions)
 
+    if (transaction.parent_transaction_id) {
+      transaction.parent = await Ledger.transaction(transaction.parent_transaction_id) as Transaction
+    }
+
     const renderKey = transaction.transaction_type.toLowerCase()
     res.render(`transactions/${renderKey}`, {
       transaction,


### PR DESCRIPTION
The `live` column isn't provided for transactions of resource type
`refund` in Ledger. This should be passed through based on the
properties of the gateway account used to process the refund.

This updates the template to use the information attached to the parent
transaction until this is available.