### PR TITLE
PP-6483 Payment update tool references Splunk dashboard in favour of direct search

### DIFF
--- a/src/web/modules/transactions/update/success.njk
+++ b/src/web/modules/transactions/update/success.njk
@@ -13,12 +13,12 @@
 </div>
 
 <p class="govuk-body">
-A job has been started to process the transaction updates provided by CSV. Progress of this job can be monitored through Splunk
-by
+A job has been started to process the transaction updates provided by CSV. Progress of this job can be monitored using the
+payment update Splunk dashboard
 <a
   class="govuk-link"
-  href="https://gds.splunkcloud.com/en-GB/app/gds-004-pay/search?q=search%20{{ jobId }}">
-  searching with your job reference
+  href="https://gds.splunkcloud.com/en-GB/app/gds-004-pay/payment_update_job?form.job_id={{ jobId }}">
+  filtered by your job reference
 </a>.
 </p>
 


### PR DESCRIPTION
Splunk payment update Dashboard allows filtering events with a
`form.job_id`. This provides aggregate information on how many of the
payment updates have succeeded or failed. This should give developers a
good idea of if the job has completed successfully without understanding
the underlying mechanics.

**Example job progress dashboard**

![Screenshot 2020-05-11 at 12 30 22](https://user-images.githubusercontent.com/2844572/81580756-c1e33000-93a5-11ea-9ebc-579cef68f711.png)
