### PR TITLE
BAU Find transaction by gateway transaction ID

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -61,6 +61,9 @@ const ledgerMethods = function ledgerMethods(instance) {
   const transactionsByReference = async function transactionsByReference(reference, limit = 2) {
     return transactions(null, null, null, { reference, display_size: limit })
   }
+  const transactionsByGatewayTransactionId = function transactionsByGatewayTransactionId(gatewayTransactionId, limit = 2) {
+    return transactions(null, null, null, { gateway_transaction_id: gatewayTransactionId, display_size: limit })
+  }
   const relatedTransactions = async function relatedTransactions(id, accountId) {
     const params = {
       gateway_account_id: accountId
@@ -157,6 +160,7 @@ const ledgerMethods = function ledgerMethods(instance) {
     getPaymentsByState,
     paymentStatistics,
     transactionsByReference,
+    transactionsByGatewayTransactionId,
     relatedTransactions,
     paymentVolumesByHour,
     paymentVolumesAggregate,

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -33,6 +33,15 @@
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   {% endif %}
 
+{% if filters.gateway_transaction_id %}
+  <div class="govuk-body">
+    <span>Filtered by gateway transaction ID </span>
+    <span><strong class="govuk-tag">{{ filters.gateway_transaction_id }}</strong></span>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  {% endif %}
+
+
   <div>
     <table class="govuk-table">
       <thead class="govuk-table__head">

--- a/src/web/modules/transactions/search.njk
+++ b/src/web/modules/transactions/search.njk
@@ -10,7 +10,7 @@
     {{ govukInput({
       id: "id",
       name: "id",
-      hint: { text: "GOV.UK Pay external ID or payment reference" },
+      hint: { text: "GOV.UK Pay external ID, gateway transaction ID or transaction reference" },
       label: { text: "Search" }
       })
       }}


### PR DESCRIPTION
Allow the 'Find by transaction' search tool to try passing the field
through to `gateway_transaction_id` search filter. The same behaviour is
respected
* If nothing is found, throw search criteria not found
* If one result is returned, directly link to that transaction
* If multiple results are found, filter the main transactions view by
transaction id