### PR TITLE
PP-6622 Upgrade to Node.js 12.18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 language: node_js
 node_js:
-  - 12.14.1
+  - 12.18.1
 
 addons:
   apt:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node@sha256:cf63399ae3f4a1424a7776dac98ba088966a727089d7915915ed90db87da141b
+# Digest of image e.g. node:12.18.1-alpine3.12 for linux/amd64 from tags list on https://hub.docker.com/_/node
+FROM node@sha256:5f5cb21e96ad6ad28b6d2c1c2d5d9f3ec1a4c96ff8e130ab7d934f8e3034339c
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.3.0",
   "description": "Internal administrative tools service for the GOV.UK Pay products.",
   "engines": {
-    "node": "^12.14.1",
-    "npm": "^6.13.1"
+    "node": "^12.18.1"
   },
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Update to new minor Node.js version:

https://hub.docker.com/layers/node/library/node/12.18.1-alpine3.12/images/sha256-5f5cb21e96ad6ad28b6d2c1c2d5d9f3ec1a4c96ff8e130ab7d934f8e3034339c

Remove explicit NPM version in package.json and just rely on the version bundled with Node.js.