### PR TITLE
BAU Redact tokens from payment links list API

### DIFF
--- a/src/lib/pay-request/api_utils/products.js
+++ b/src/lib/pay-request/api_utils/products.js
@@ -1,4 +1,5 @@
 import { EntityNotFoundError } from '../../errors'
+const { redactProductTokens } = require('./redact')
 
 const productsMethods = function productsMethods(instance) {
   const axiosInstance = instance || this
@@ -17,6 +18,7 @@ const productsMethods = function productsMethods(instance) {
     }
     return axiosInstance.get('/v1/api/stats/products', queryParams)
       .then(utilExtractData)
+      .then(redactProductTokens)
   }
 
   return {

--- a/src/lib/pay-request/api_utils/redact.js
+++ b/src/lib/pay-request/api_utils/redact.js
@@ -1,0 +1,8 @@
+const redactProductTokens = function redactProductTokens(productResults) {
+  return productResults.map((productResult) => {
+    delete productResult.product.pay_api_token
+    return productResult
+  })
+}
+
+module.exports = { redactProductTokens }

--- a/src/lib/pay-request/api_utils/redact.spec.js
+++ b/src/lib/pay-request/api_utils/redact.spec.js
@@ -1,0 +1,21 @@
+const chai = require('chai')
+const { expect } = chai
+
+const { redactProductTokens } = require('./redact')
+const { paymentLinksListResponse } = require('./../../../tests/fixtures/paymentLink')
+
+describe('redaction utility for internal apis that cant be changed immediately', () => {
+  describe('product api', () => {
+    it('pay_api_token property is removed from all returned products', () => {
+      const redactedResultStream = redactProductTokens(paymentLinksListResponse)
+      expect(redactedResultStream[0].product.pay_api_token).to.equal(undefined)
+      expect(redactedResultStream[1].product.pay_api_token).to.equal(undefined)
+      expect(redactedResultStream[2].product.pay_api_token).to.equal(undefined)
+    })
+
+    it('returns the same empty list if nothing is returned from the server', () => {
+      const redactedResultStream = redactProductTokens([])
+      expect(redactedResultStream).to.deep.equal([])
+    })
+  })
+})

--- a/src/tests/fixtures/paymentLink.js
+++ b/src/tests/fixtures/paymentLink.js
@@ -1,0 +1,23 @@
+const paymentLinksListResponse = [{
+  payment_count: 100,
+  last_payment_date: 'some-payment-date',
+  product: {
+    external_id: 'some-product-external-id',
+    pay_api_token: 'some-api-token'
+  }
+}, {
+  payment_count: 200,
+  last_payment_date: 'some-payment_date',
+  product: {
+    external_id: 'some-second-product-external-id',
+    pay_api_token: 'some-api-token'
+  }
+}, {
+  payment_count: 200,
+  last_payment_date: 'some-payment-date',
+  product: {
+    pay_api_token: 'some-api-token'
+  }
+}]
+
+module.exports = { paymentLinksListResponse }


### PR DESCRIPTION
The products backend service only exposes an internal `v1/api` route
for payment links with all of the information used by other services.

Currently other services rely on the token used to generate payments 
through the payment link for the management of that link (deletion). 
This should be changed to use a key mapping to the token allowing 
us to remove the token from this endpoint entirely.

Until that work is prioritised, redact the tokens from the API call
before it can reach the Toolbox service/ controller code.