### PR TITLE
PP-6257 Add live services CSV download

### DIFF
--- a/src/lib/pay-request/types/adminUsers.ts
+++ b/src/lib/pay-request/types/adminUsers.ts
@@ -1,4 +1,6 @@
 export interface Service {
+  id: number;
+
   external_id: string;
 
   current_go_live_stage: string;
@@ -10,6 +12,16 @@ export interface Service {
   collect_billing_address: boolean;
 
   experimental_features_enabled: boolean;
+
+  internal: boolean;
+
+  archived: boolean;
+
+  sector: string;
+
+  went_live_date: string;
+
+  created_date: string;
 
   custom_branding: { 
     [key: string]: any;

--- a/src/web/modules/gateway_accounts/csv.ts
+++ b/src/web/modules/gateway_accounts/csv.ts
@@ -80,7 +80,7 @@ const fields = [{
   value: 'corporate_surcharge'
 }]
 
-export function format(linksUsage: any): string {
+export function format(gatewayAccounts: any): string {
   const parser = new Parser({ fields })
-  return parser.parse(linksUsage)
+  return parser.parse(gatewayAccounts)
 }

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -3,6 +3,7 @@ import * as exceptions from './services.exceptions'
 
 export default {
   overview: http.overview,
+  performancePlatformCsv: http.performancePlatformCsv,
   detail: {
     http: http.detail,
     exceptions: exceptions.detail

--- a/src/web/modules/services/overview.njk
+++ b/src/web/modules/services/overview.njk
@@ -3,6 +3,13 @@
 {% block main %}
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Services</h1>
+  <div>
+    <a href="services/performance_platform_csv"
+      class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
+      Export live services CSV for Performance platform
+    </a>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/src/web/modules/services/performancePlatformCsv.ts
+++ b/src/web/modules/services/performancePlatformCsv.ts
@@ -1,0 +1,50 @@
+import { Parser } from 'json2csv'
+import { Service } from '../../../lib/pay-request/types/adminUsers'
+import _ from 'lodash'
+import moment from 'moment'
+
+const fields = [
+  {
+    label: "_timestamp",
+    value: "went_live_date"
+  }, {
+    label: 'service',
+    value: 'alwaysdefault',
+    default: 'govuk-pay'
+  }, {
+    label: 'service_id',
+    value: 'id'
+  }, {
+    label: 'agency',
+    value: 'agency'
+  }, {
+    label: 'service_name',
+    value: 'service_name'
+  }, {
+    label: 'count',
+    value: 'count',
+    default: '1'
+  }, {
+    label: 'sorting',
+    value: 'sorting'
+  }
+]
+
+export function format(liveServices: Service[]): string {
+  const parser = new Parser({ fields })
+  const sortedServices = _.orderBy(liveServices, [
+    service => service.merchant_details && service.merchant_details.name && service.merchant_details.name.toLowerCase(),
+    service => service.service_name.en.toLowerCase(),
+    service => service.id
+  ])
+  const csvData = sortedServices.map((service, index) => {
+      return {
+        went_live_date: service.went_live_date && moment(service.went_live_date).format('YYYY-MM-DD') || '',
+        id: service.id,
+        agency: service.merchant_details && service.merchant_details.name && service.merchant_details.name.trim() || '',
+        service_name: service.service_name.en.trim(),
+        sorting: index + 1
+      }
+    })
+  return parser.parse(csvData)
+}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -67,6 +67,7 @@ router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLi
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)
 
 router.get('/services', auth.secured, services.overview)
+router.get('/services/performance_platform_csv', auth.secured, services.performancePlatformCsv)
 router.get('/services/search', auth.secured, services.search)
 router.post('/services/search', auth.secured, services.searchRequest)
 router.get('/services/:id', auth.secured, services.detail.http, services.detail.exceptions)


### PR DESCRIPTION
Add a button the the "Platform services" page to download a CSV listing the active live services in the format expected by the performance platform.

<img width="1034" alt="Screenshot 2020-07-02 at 18 39 59" src="https://user-images.githubusercontent.com/5648592/86392499-778a7b00-bc93-11ea-9505-035a7ca41110.png">
