### PR TITLE
BAU Only list live services by default

### DIFF
--- a/src/web/modules/services/overview.njk
+++ b/src/web/modules/services/overview.njk
@@ -3,6 +3,21 @@
 {% block main %}
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Services</h1>
+
+  {% if filterLive %}
+    <div class="govuk-body">
+      <p class="govuk-body">
+        <span>Filtering to only show live services, excluding internal and archived services</span>
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="?live=false">
+          Show all services
+        </a>
+      </p>
+    </div>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  {% endif %}
+
   <div>
     <a href="services/performance_platform_csv"
       class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">


### PR DESCRIPTION
When viewing "Platform services", by default only show the services that have "Go live status" of "LIVE", and do not have the "internal" or "archived" flags set to true.

Add a link to display all services.

This should help with support when trying to track down a service you're looking for e.g. based on an organisation name as many services have several old or test variants of their service.

<img width="983" alt="Screenshot 2020-07-08 at 17 15 17" src="https://user-images.githubusercontent.com/5648592/86943972-050c1600-c13f-11ea-93db-22604e07c13f.png">
