### PR TITLE
BAU Allow gateway accounts to update Stripe payout descriptor

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -166,6 +166,12 @@
     href: "/gateway_accounts/" + gatewayAccountId + "/stripe_statement_descriptor"
     })
     }}
+    {{ govukButton({
+    text: "Update payout descriptor",
+    href: "/gateway_accounts/" + gatewayAccountId + "/stripe_payout_descriptor"
+    })
+    }}
+
     {% endif %}
     {% if account.payment_method !== "DIRECT_DEBIT" %}
       {{ govukButton({

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -30,5 +30,7 @@ export default {
   toggleBlockPrepaidCards: http.toggleBlockPrepaidCards,
   toggleMotoPayments: http.toggleMotoPayments,
   updateStripeStatementDescriptorPage: http.updateStripeStatementDescriptorPage,
-  updateStripeStatementDescriptor: http.updateStripeStatementDescriptor
+  updateStripeStatementDescriptor: http.updateStripeStatementDescriptor,
+  updateStripePayoutDescriptorPage: http.updateStripePayoutDescriptorPage,
+  updateStripePayoutDescriptor: http.updateStripePayoutDescriptor
 }

--- a/src/web/modules/gateway_accounts/stripe_payout_descriptor.njk
+++ b/src/web/modules/gateway_accounts/stripe_payout_descriptor.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+  <span class="govuk-caption-m">Update gateway account</span>
+  <h1 class="govuk-heading-m">Stripe payout descriptor</h1>
+
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Gateway account ({{ account.gateway_account_id }})</a>
+  </div>
+
+  <p class="govuk-body">
+    The Stripe payout descriptor is what the integrating service will see in their bank account when they receive payments (payouts) from Stripe. This tool will update the Stripe Connect account.
+  </p>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://stripe.com/docs/api/payouts/object#payout_object-statement_descriptor">Payout statement descriptors</a>
+  </p>
+
+  <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/stripe_payout_descriptor">
+    {{ govukInput({
+      id: "statement_descriptor",
+      name: "statement_descriptor",
+      label: { text: "Stripe payout descriptor" },
+      hint: {
+        text: "Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
+      },
+      autocomplete: "off"
+    })
+    }}
+
+    {{ govukButton({
+    text: "Update Stripe payout descriptor"
+    })
+    }}
+
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+  </form>
+{% endblock %}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -62,6 +62,8 @@ router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccount
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
+router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)
+router.post('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptor)
 
 router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)


### PR DESCRIPTION
Provide a similar update route for the support role to update the payout
descriptor for a given Stripe account.

Payout and payment descriptors are currently separated to allow changing only what needs
configuring (it also allows linking to separate documentation). We may
find that practically these will always be the same and the UX can be
simplified.