### PR TITLE
PP-6659 Add .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules/.cache


### PR DESCRIPTION
- Currently toolbox does not deploy correctly on PaaS because the
Cloudfoundry Cloud Controller does not let you push read only files