### PR TITLE
PP-6659 Fix redirect in generate dev environment script

### DIFF
--- a/scripts/generate-dev-environment
+++ b/scripts/generate-dev-environment
@@ -47,7 +47,7 @@ else
   URL_MAP="$URL_TARGET_TUNNEL"
 fi
 
-cat > "$ENV_FILE" << EOM
+cat < "$ENV_FILE" << EOM
 PORT=3000
 NODE_ENV=development
 BUILD_FOLDER_ROOT=$PWD/dist


### PR DESCRIPTION
Needs to point in other direction to feed the env file into `cat`, which I assume was the intention.

### HOW TO TEST ###
Run the script and see the env file printed to stdout
```
gds5062:pay-toolbox danworth$ ./scripts/generate-dev-environment local
PORT=3000
NODE_ENV=development
....
```
