### PR TITLE
BAU — Put GOV.UK Pay ID on payment page

### DIFF
--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -40,6 +40,10 @@
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">GOV.UK Pay ID</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.transaction_id }}</td>
+        </tr>
+        <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Reference</span></th>
           <td class="govuk-table__cell payment__cell">{{ transaction.reference }}</td>
         </tr>
@@ -48,7 +52,7 @@
           <td class="govuk-table__cell payment__cell">{{ transaction.description }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date (local date & time)</span></th>
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date</span></th>
           <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLocalTimeZone }}</td>
         </tr>
         <tr class="govuk-table__row">


### PR DESCRIPTION
Also remove a misleading “local date & time” label on the same page.