### PR TITLE
PP-7026 Unpin the node buildpack version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,6 @@ applications:
 - name: toolbox
   buildpacks:
   - https://github.com/alphagov/env-map-buildpack.git#v1
-  - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.9
   health-check-type: http
   health-check-http-endpoint: '/healthcheck'
   health-check-invocation-timeout: 5


### PR DESCRIPTION
The node build pack was being taken from upstream because at the time
toolbox was on an later version of node which the latest node
buildpack offered by PaaS included. Now that PaaS have upgraded their
node buildpack it can satisfy the node version required. Therefore
remove it and take the buildpack offered by PaaS.