### PR TITLE
BAU Allow optional description to override the not found error

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -15,8 +15,8 @@ export class RequestError extends Error {
 export class EntityNotFoundError extends RequestError {
   public data: { name: string; identifier: string }
 
-  public constructor(name: string, identifier: string) {
-    super(`${name} with ID ${identifier} was not found.`)
+  public constructor(name: string, identifier: string, description: string = 'ID') {
+    super(`${name} with ${description} ${identifier} was not found.`)
     this.data = { name, identifier }
   }
 }

--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -25,7 +25,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.post(path, { username: email })
       .then(utilExtractData)
       .catch((error) => {
-        if (error.data.response && error.data.response.status === 404) throw new EntityNotFoundError('User', email)
+        if (error.data.response && error.data.response.status === 404) throw new EntityNotFoundError('User', email, 'Email')
         throw error
       })
   }
@@ -36,7 +36,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
       .then(utilExtractData)
       .then(redactOtp)
       .catch((error) => {
-        if (error.data.response && error.data.response.status === 404) throw new EntityNotFoundError('User', id)
+        if (error.data.response && error.data.response.status === 404) throw new EntityNotFoundError('User', id, 'External ID')
         throw error
       })
   }
@@ -79,7 +79,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
       .then(utilExtractData)
       .catch((error) => {
         if (error.data.response && error.data.response.status === 404) {
-          throw new EntityNotFoundError('Service', id)
+          throw new EntityNotFoundError('Service', id, 'External ID')
         }
         throw error
       })


### PR DESCRIPTION
When reporting an entity is not found, allow an optional description to
be more specific than 'ID'. This is useful if the lookup done by some
other value.