### PR TITLE
PP-7267 Use `secureProxy` setting for cookies

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -4,7 +4,8 @@ const expectedServerEnvironmentValues = {
   PORT: Joi.number().integer().required(),
   COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required(),
   HTTP_PROXY: Joi.string(),
-  HTTPS_PROXY: Joi.string()
+  HTTPS_PROXY: Joi.string(),
+  SESSION_COOKIE_DURATION_IN_MILLIS: Joi.number().integer()
 }
 
 const { error, value: validatedServerEnvironmentValues } = Joi.validate(

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -76,13 +76,14 @@ const configureServingPublicStaticFiles = function configureServingPublicStaticF
 
 const configureClientSessions = function configureClientSessions(instance) {
   const serverBehindProxy = server.HTTP_PROXY
+  const twelveHoursInMillis = 12 * 60 * 60 * 1000
   instance.use(sessions({
     cookieName: 'session',
     secret: server.COOKIE_SESSION_ENCRYPTION_SECRET,
-    duration: 12 * 60 * 60 * 1000,
+    duration: server.SESSION_COOKIE_DURATION_IN_MILLIS || twelveHoursInMillis,
     activeDuration: 5 * 60 * 1000,
     cookie: {
-      secure: serverBehindProxy
+      secureProxy: serverBehindProxy
     }
   }))
 }


### PR DESCRIPTION
Set `secureProxy` flag to require secure cookies over HTTP and behind 
forward facing Nginx proxies.

According to the documentation this is a deprecated flag however it
looks like environments are rejecting the `secure` flag even though the
proxy settings look to be correctly configured in the express app.

The issue is likely caused by a header not being correctly set by the
upstream Nginx proxy, until that has been looked into, try using this
flag.

Add an environment variable to allow different environments to reduce
session time if required.