### PR TITLE
PP-7458 Display created date on service detail

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -37,20 +37,22 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Sector</th>
-          <td class="govuk-table__cell">{{(service.sector or "(Not set)")}}</td>
+          <td class="govuk-table__cell">{{service.sector | capitalize or "(This is set when the service is made live)"}}</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Internal service</th>
-          <td class="govuk-table__cell">{{service.internal}}</td>
+          <td class="govuk-table__cell">{{service.internal | string | capitalize }}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Created date</th>
+          <td class="govuk-table__cell">
+            {{service.created_date | formatToSimpleDate or "(Service was created before we captured this date)" }}
+          </td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Went live date</th>
           <td class="govuk-table__cell">
-            {% if service.went_live_date %} 
-              {{service.went_live_date | formatDate }} 
-            {% else %} 
-              (Not set) 
-            {% endif %}
+            {{service.went_live_date | formatToSimpleDate or "(This is set when the service is made live)"}}
           </td>
         </tr>
     </tbody>


### PR DESCRIPTION
Display created date if the service has one.

Fix the format for the "Went live date" and capitalize other values for
consistency.

Add some content telling toolbox users why there aren't values for the
various reporting details (sector, went live date).