### PR TITLE
PP-7458 Add service list export

### DIFF
--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -3,6 +3,7 @@ import * as exceptions from './services.exceptions'
 
 export default {
   overview: http.overview,
+  listCsv: http.listCsv,
   performancePlatformCsv: http.performancePlatformCsv,
   detail: {
     http: http.detail,

--- a/src/web/modules/services/overview.njk
+++ b/src/web/modules/services/overview.njk
@@ -19,11 +19,17 @@
   {% endif %}
 
   <div>
+    <a href="/services/csv?live={{filterLive}}"
+      class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
+      Export page as CSV
+    </a>
+
     <a href="services/performance_platform_csv"
       class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
-      Export live services CSV for Performance platform
+      Download CSV for performance platform
     </a>
   </div>
+
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
   <table class="govuk-table">

--- a/src/web/modules/services/performancePlatformCsv.ts
+++ b/src/web/modules/services/performancePlatformCsv.ts
@@ -30,7 +30,7 @@ const fields = [
   }
 ]
 
-export function format(liveServices: Service[]): string {
+export function formatPerformancePlatformCsv(liveServices: Service[]): string {
   const parser = new Parser({ fields })
   const sortedServices = _.orderBy(liveServices, [
     service => service.merchant_details && service.merchant_details.name && service.merchant_details.name.toLowerCase(),

--- a/src/web/modules/services/serviceExportCsv.ts
+++ b/src/web/modules/services/serviceExportCsv.ts
@@ -1,0 +1,86 @@
+import { Parser } from 'json2csv'
+import { Service } from '../../../lib/pay-request/types/adminUsers'
+import _ from 'lodash'
+import moment from 'moment'
+
+const fields = [
+  {
+    label: 'Service ID',
+    value: 'id'
+  },
+  {
+    label: 'External ID',
+    value: 'external_id'
+  },
+  {
+    label: 'Name',
+    value: 'service_name.en'
+  },
+  {
+    label: 'Welsh name',
+    value: 'service_name.cy'
+  },
+  {
+    label: 'Organisation',
+    value: 'organisation_name'
+  },
+  {
+    label: 'Go live status',
+    value: 'current_go_live_stage'
+  },
+  {
+    label: 'Redirect to service on terminal state',
+    value: 'redirect_to_service_immediately_on_terminal_state'
+  },
+  {
+    label: 'Experimental features are enabled',
+    value: 'experimental_features_enabled'
+  },
+  {
+    label: 'Collect billing address',
+    value: 'collect_billing_address'
+  },
+  {
+    label: 'Sector',
+    value: 'sector'
+  },
+  {
+    label: 'Is internal service?',
+    value: 'internal'
+  },
+  {
+    label: 'Archived',
+    value: 'archived'
+  },
+  {
+    label: 'Created date',
+    value: 'created_date_string'
+  },
+  {
+    label: 'Went live date',
+    value: 'went_live_date_string'
+  },
+  {
+    label: 'Gateway account ids',
+    value: 'gateway_account_ids_string'
+  }
+]
+
+export function formatServiceExportCsv(liveServices: Service[]): string {
+  const parser = new Parser({ fields })
+  const sortedServices = _.orderBy(liveServices, [
+    service => service.merchant_details && service.merchant_details.name && service.merchant_details.name.toLowerCase(),
+    service => service.service_name.en.toLowerCase(),
+    service => service.id
+  ])
+  const csvData = sortedServices.map((service, index) => {
+      return {
+        ...service,
+        went_live_date_string: service.went_live_date && moment(service.went_live_date).format('YYYY-MM-DD') || '',
+        created_date_string: service.created_date && moment(service.created_date).format('YYYY-MM-DD') || '',
+        organisation_name: service.merchant_details && service.merchant_details.name && service.merchant_details.name.trim() || '',
+        gateway_account_ids_string: service.gateway_account_ids.join(', ')
+      }
+    })
+  return parser.parse(csvData)
+}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -69,6 +69,7 @@ router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLi
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)
 
 router.get('/services', auth.secured, services.overview)
+router.get('/services/csv', auth.secured, services.listCsv)
 router.get('/services/performance_platform_csv', auth.secured, services.performancePlatformCsv)
 router.get('/services/search', auth.secured, services.search)
 router.post('/services/search', auth.secured, services.searchRequest)


### PR DESCRIPTION
Add a CSV export that includes details about services for all services currently displayed on the service list page.

This uses filtering on the service list page to display either only live or all services.