### PR TITLE
PP-7458 Improve search filters

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-18T09:00:02Z",
+  "generated_at": "2020-12-04T11:04:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,7 +90,7 @@
       {
         "hashed_secret": "b7e04b33fdd186ab6bd2deace04ea6b551b9bd4a",
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 260,
         "type": "Secret Keyword"
       }
     ],

--- a/src/web/modules/common/BooleanFilterOption.ts
+++ b/src/web/modules/common/BooleanFilterOption.ts
@@ -1,0 +1,11 @@
+export enum BooleanFilterOption {
+  True = 'true',
+  False = 'false',
+  All = 'all'
+}
+
+export namespace BooleanFilterOption {
+  export function toNullableBooleanString(booleanFilterOption: BooleanFilterOption) {
+    return booleanFilterOption === BooleanFilterOption.All ? null : booleanFilterOption
+  }
+}

--- a/src/web/modules/common/booleanFilterSelect.njk
+++ b/src/web/modules/common/booleanFilterSelect.njk
@@ -1,0 +1,27 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% macro booleanFilterSelect(params) %}
+  {{ govukSelect({
+    id: params.id,
+    name: params.name,
+    label: { text: params.label },
+    items: [
+      {
+        text: 'All',
+        value: 'all',
+        selected: params.currentValue === 'all'
+      },
+      {
+        text: params.trueOptionText,
+        value: 'true',
+        selected: params.currentValue === 'true'
+      },
+      {
+        text: params.falseOptionText,
+        value: 'false',
+        selected: params.currentValue === 'false'
+      }
+    ]
+  })
+}}
+{% endmacro %}

--- a/src/web/modules/gateway_accounts/filter.njk
+++ b/src/web/modules/gateway_accounts/filter.njk
@@ -1,71 +1,57 @@
-{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/booleanFilterSelect.njk" import booleanFilterSelect %}
 
 <div class="filter govuk-grid-row">
   <form clas="govuk-clearfix" method="GET" action="/gateway_accounts" novalidate="novalidate">
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukSelect({
-        id: "type",
-        name: "type",
-        label: { text: "Type" },
-        items: [
-          {
-            text: 'All',
-            value: null,
-            selected: filters.type === null
-          },
-          {
-            text: 'Live',
-            value: 'live',
-            selected: filters.type === 'live'
-          },
-          {
-            text: 'Test',
-            value: 'test',
-            selected: filters.type === 'test'
-          }
-        ]
-      })
-    }}
+      {{ booleanFilterSelect({
+          id: "live",
+          name: "live",
+          label: "Type",
+          trueOptionText: "Live",
+          falseOptionText: "Test",
+          currentValue: filters.live
+        })
+      }}
     </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
       {{ govukSelect({
-        id: "payment-provider",
-        name: "payment_provider",
+        id: "provider",
+        name: "provider",
         label: { text: "Provider" },
         items: [
           {
             text: 'All',
             value: null,
-            selected: filters.payment_provider === null
+            selected: filters.provider === null
           },
           {
             text: 'Sandbox',
             value: 'sandbox',
-            selected: filters.payment_provider === 'sandbox'
+            selected: filters.provider === 'sandbox'
           },
           {
             text: 'Worldpay',
             value: 'worldpay',
-            selected: filters.payment_provider === 'worldpay'
+            selected: filters.provider === 'worldpay'
           },
           {
             text: 'Smartpay',
             value: 'smartpay',
-            selected: filters.payment_provider === 'smartpay'
+            selected: filters.provider === 'smartpay'
           },
           {
             text: 'ePDQ',
             value: 'epdq',
-            selected: filters.payment_provider === 'epdq'
+            selected: filters.provider === 'epdq'
           },
           {
             text: 'Stripe',
             value: 'stripe',
-            selected: filters.payment_provider === 'stripe'
+            selected: filters.provider === 'stripe'
           }
         ]
       })
@@ -73,110 +59,52 @@
     </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukSelect({
-        id: "requires-3ds",
-        name: "requires_3ds",
-        label: { text: "3D Secure" },
-        items: [
-          {
-            text: 'All',
-            value: null,
-            selected: filters.requires_3ds === null
-          },
-          {
-            text: 'Enabled',
-            value: 'true',
-            selected: filters.requires_3ds === 'true'
-          },
-          {
-            text: 'Disabled',
-            value: 'false',
-            selected: filters.requires_3ds === 'false'
-          }
-        ]
-      })
-    }}
+      {{ booleanFilterSelect({
+          id: "three-ds",
+          name: "three_ds",
+          label: "3D Secure",
+          trueOptionText: "Enabled",
+          falseOptionText: "Disabled",
+          currentValue: filters.three_ds
+        })
+      }}
     </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukSelect({
-        id: "apple-pay-enabled",
-        name: "apple_pay_enabled",
-        label: { text: "Apple pay" },
-        items: [
-          {
-            text: 'All',
-            value: null,
-            selected: filters.apple_pay_enabled === null
-          },
-          {
-            text: 'Enabled',
-            value: 'true',
-            selected: filters.apple_pay_enabled === 'true'
-          },
-          {
-            text: 'Disabled',
-            value: 'false',
-            selected: filters.apple_pay_enabled === 'false'
-          }
-        ]
-      })
-    }}
+      {{ booleanFilterSelect({
+          id: "apple-pay",
+          name: "apple_pay",
+          label: "Apple pay",
+          trueOptionText: "Enabled",
+          falseOptionText: "Disabled",
+          currentValue: filters.apple_pay
+        })
+      }}
     </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukSelect({
-        id: "google-pay-enabled",
-        name: "google_pay_enabled",
-        label: { text: "Google pay" },
-        items: [
-          {
-            text: 'All',
-            value: null,
-            selected: filters.google_pay_enabled === null
-          },
-          {
-            text: 'Enabled',
-            value: 'true',
-            selected: filters.google_pay_enabled === 'true'
-          },
-          {
-            text: 'Disabled',
-            value: 'false',
-            selected: filters.google_pay_enabled === 'false'
-          }
-        ]
-      })
-    }}
+      {{ booleanFilterSelect({
+          id: "google-pay",
+          name: "google_pay",
+          label: "Google pay",
+          trueOptionText: "Enabled",
+          falseOptionText: "Disabled",
+          currentValue: filters.google_pay
+        })
+      }}
     </div>
 
     <div class="govuk-grid-column-one-third inputs-less-margin">
-      {{ govukSelect({
-        id: "moto-enabled",
-        name: "moto_enabled",
-        label: { text: "MOTO" },
-        items: [
-          {
-            text: 'All',
-            value: null,
-            selected: filters.moto_enabled === null
-          },
-          {
-            text: 'Enabled',
-            value: 'true',
-            selected: filters.moto_enabled === 'true'
-          },
-          {
-            text: 'Disabled',
-            value: 'false',
-            selected: filters.moto_enabled === 'false'
-          }
-        ]
-      })
-    }}
+      {{ booleanFilterSelect({
+          id: "moto",
+          name: "moto",
+          label: "MOTO",
+          trueOptionText: "Enabled",
+          falseOptionText: "Disabled",
+          currentValue: filters.moto
+        })
+      }}
     </div>
-
-    <div class="govuk-grid-column-one-third inputs-less-margin"></div>
 
     <div class="govuk-grid-column-full inputs-less-margin">
       {{ govukButton({

--- a/src/web/modules/gateway_accounts/overview.njk
+++ b/src/web/modules/gateway_accounts/overview.njk
@@ -5,17 +5,18 @@
   <h1 class="govuk-heading-m">Gateway accounts</h1>
 
   {% if card %}
+    {% include "gateway_accounts/filter.njk" %}
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <div>
-      <a href="gateway_accounts/csv"
-        class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
-        Export all as CSV
+      <a href="{{csvUrl}}" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
+        Export results as CSV
       </a>
     </div>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    {% include "gateway_accounts/filter.njk" %}
-
     <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3">
+      Showing
       {{total}}
       accounts
     </h3>

--- a/src/web/modules/services/filter.njk
+++ b/src/web/modules/services/filter.njk
@@ -1,0 +1,51 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/booleanFilterSelect.njk" import booleanFilterSelect %}
+
+<div class="filter govuk-grid-row">
+  <form clas="govuk-clearfix" method="GET" action="/services" novalidate="novalidate">
+    <div class="govuk-grid-column-one-third inputs-less-margin">
+      {{ booleanFilterSelect({
+          id: "live",
+          name: "live",
+          label: "Go live status",
+          trueOptionText: "Live",
+          falseOptionText: "Not live",
+          currentValue: filters.live
+        })
+      }}
+    </div>
+
+    <div class="govuk-grid-column-one-third inputs-less-margin">
+      {{ booleanFilterSelect({
+          id: "internal",
+          name: "internal",
+          label: "Internal",
+          trueOptionText: "Internal",
+          falseOptionText: "Not internal",
+          currentValue: filters.internal
+        })
+      }}
+    </div>
+
+    <div class="govuk-grid-column-one-third inputs-less-margin">
+      {{ booleanFilterSelect({
+          id: "archived",
+          name: "archived",
+          label: "Archived",
+          trueOptionText: "Archived",
+          falseOptionText: "Not archived",
+          currentValue: filters.archived
+        })
+      }}
+    </div>
+
+    <div class="govuk-grid-column-one-third inputs-less-margin"></div>
+
+    <div class="govuk-grid-column-full inputs-less-margin">
+      {{ govukButton({
+        text: "Filter"
+      })
+    }}
+    </div>
+  </form>
+</div>

--- a/src/web/modules/services/overview.njk
+++ b/src/web/modules/services/overview.njk
@@ -4,24 +4,14 @@
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Services</h1>
 
-  {% if filterLive %}
-    <div class="govuk-body">
-      <p class="govuk-body">
-        <span>Filtering to only show live services, excluding internal and archived services</span>
-      </p>
-      <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" href="?live=false">
-          Show all services
-        </a>
-      </p>
-    </div>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-  {% endif %}
+  {% include "services/filter.njk" %}
+
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
   <div>
-    <a href="/services/csv?live={{filterLive}}"
+    <a href="{{csvUrl}}"
       class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2">
-      Export page as CSV
+      Export results as CSV
     </a>
 
     <a href="services/performance_platform_csv"
@@ -31,6 +21,10 @@
   </div>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-top-3">
+      Showing {{total}} services
+    </h3>
 
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/src/web/modules/services/serviceExportCsv.ts
+++ b/src/web/modules/services/serviceExportCsv.ts
@@ -69,8 +69,6 @@ const fields = [
 export function formatServiceExportCsv(liveServices: Service[]): string {
   const parser = new Parser({ fields })
   const sortedServices = _.orderBy(liveServices, [
-    service => service.merchant_details && service.merchant_details.name && service.merchant_details.name.toLowerCase(),
-    service => service.service_name.en.toLowerCase(),
     service => service.id
   ])
   const csvData = sortedServices.map((service, index) => {


### PR DESCRIPTION
Add filters to the service list page to filter by "Go live status", "Internal" and "Archived". Default to displaying live, not internal, not archived services.

Add Nunjucks macro for select input that has 3 options, a true value, afalse value and an "all" value.

Improve the filters on the gateway accounts list page to use the new macro and patterns. Also make it so that the the CSV download for gateway accounts obeys the filter values.