### PR TITLE
BAU Statistics disclaimer

### DIFF
--- a/src/web/modules/statistics/comparison.njk
+++ b/src/web/modules/statistics/comparison.njk
@@ -1,9 +1,15 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% extends "layout/layout.njk" %}
 
 {% block main %}
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Statistics</h1>
+
+  {{ govukWarningText({
+    text: "This data is taken from the in-flight payments database. The numbers only represent payments that have not yet been completed or were processed recently.",
+    iconFallbackText: "Warning"
+  }) }}
 
   <p class="govuk-body">{{ date | formatDateLong }}</p>
   {{ govukTable({

--- a/src/web/modules/statistics/overview.njk
+++ b/src/web/modules/statistics/overview.njk
@@ -1,9 +1,16 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
 {% extends "layout/layout.njk" %}
 
 {% block main %}
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
   <h1 class="govuk-heading-m">Statistics</h1>
+
+  {{ govukWarningText({
+    text: "This data is taken from the in-flight payments database. The numbers only represent payments that have not yet been completed or were processed recently.",
+    iconFallbackText: "Warning"
+  }) }}
 
   {% if date %}
     <p class="govuk-body">{{ date | formatDateLong }}</p>


### PR DESCRIPTION
Add a warning to make it clear the data on the  statistics page is
coming from Connector until we can prioritise a better tool for Ledger
stats.

![Screenshot 2020-12-08 at 10 55 44](https://user-images.githubusercontent.com/2844572/101475174-f4590980-3943-11eb-8f37-17e2ca57b332.png)

