### PR TITLE
PP-7589 Allow toggling telephone notifications for gateway accounts

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -112,6 +112,7 @@ const connectorMethods = function connectorMethods(instance) {
       path: 'block_prepaid_cards',
       value: !gatewayAccount.block_prepaid_cards
     })
+    return !gatewayAccount.block_prepaid_cards
   }
 
   const toggleMotoPayments = async function toggleMotoPayments(id) {
@@ -123,6 +124,17 @@ const connectorMethods = function connectorMethods(instance) {
       value: !gatewayAccount.allow_moto
     })
     return !gatewayAccount.allow_moto
+  }
+
+  const toggleAllowTelephonePaymentNotifications = async function toggleAllowTelephonePaymentNotifications(id) {
+    const gatewayAccount = await account(id)
+    const url = `/v1/api/accounts/${gatewayAccount.gateway_account_id}`
+    await axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'allow_telephone_payment_notifications',
+      value: !gatewayAccount.allow_telephone_payment_notifications
+    })
+    return !gatewayAccount.allow_telephone_payment_notifications
   }
 
   return {
@@ -146,7 +158,8 @@ const connectorMethods = function connectorMethods(instance) {
     updateCorporateSurcharge,
     updateEmailBranding,
     toggleBlockPrepaidCards,
-    toggleMotoPayments
+    toggleMotoPayments,
+    toggleAllowTelephonePaymentNotifications
   }
 }
 

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -264,6 +264,36 @@
     </div>
   {% endif %}
 
+  {% if account.allow_telephone_payment_notifications === false %}
+    <div>
+      <h1 class="govuk-heading-s">Enable telephone payment notifications</h1>
+      <p class="govuk-body">Allows use of the <a class="govuk-link govuk-link--no-visited-state" href="https://github.com/alphagov/pay-telephone-payments">API to store records of telephone payments</a> which were taken outside of GOV.UK Pay.</p>
+      <p class="govuk-body">It should be ensured that the gateway account is only used for this purpose by the service and they have a separate service if they take payments using our payment pages.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_allow_telephone_payment_notifications">
+        {{ govukButton({
+          text: "Enable telephone payment notifications",
+          classes: "govuk-button--warning"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
+
+  {% if account.allow_telephone_payment_notifications === true %}
+    <div>
+      <h1 class="govuk-heading-s">Telephone payment notifications are enabled</h1>
+      <p class="govuk-body">Use of the <a class="govuk-link govuk-link--no-visited-state" href="https://github.com/alphagov/pay-telephone-payments">telephone payment notifications API</a> is enabled for this account. This is used to store records of telephone payments which were taken outside of GOV.UK Pay.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_allow_telephone_payment_notifications">
+        {{ govukButton({
+          text: "Disable telephone payment notifications"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
+
   {{ json("Gateway account details source", account) }}
   {{ json("Accepted cards source", acceptedCards) }}
   {{ json("Gateway account services source", services) }}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -202,10 +202,10 @@ const writeAccount = async function writeAccount(req: Request, res: Response): P
     statementDescriptor?: string
   } = {}
 
-  if (account.provider === 'stripe'){
+  if (account.provider === 'stripe') {
     const stripeAccountDetails = await stripe.accounts.retrieve(account.credentials);
-    stripeAccountStatementDescriptors.payoutStatementDescriptor =  stripeAccountDetails.payout_statement_descriptor
-    stripeAccountStatementDescriptors.statementDescriptor =  stripeAccountDetails.statement_descriptor
+    stripeAccountStatementDescriptors.payoutStatementDescriptor = stripeAccountDetails.payout_statement_descriptor
+    stripeAccountStatementDescriptors.statementDescriptor = stripeAccountDetails.statement_descriptor
   }
 
   // note payment_provider is not returned in the object returned from createAccount
@@ -320,9 +320,9 @@ const toggleBlockPrepaidCards = async function toggleBlockPrepaidCards(
   res: Response
 ): Promise<void> {
   const { id } = req.params
-  await Connector.toggleBlockPrepaidCards(id)
+  const blocked = await Connector.toggleBlockPrepaidCards(id)
 
-  req.flash('info', 'Toggled block prepaid cards flag')
+  req.flash('info', `Prepaid cards are ${blocked ? 'blocked' : 'allowed'}`)
   res.redirect(`/gateway_accounts/${id}`)
 }
 
@@ -330,11 +330,22 @@ const toggleMotoPayments = async function toggleMotoPayments(
   req: Request,
   res: Response
 ): Promise<void> {
-  const gatewayAccountId = req.params.id
-  const motoPaymentsEnabled = await Connector.toggleMotoPayments(gatewayAccountId)
+  const { id } = req.params
+  const motoPaymentsEnabled = await Connector.toggleMotoPayments(id)
 
   req.flash('info', `MOTO payments ${motoPaymentsEnabled ? 'enabled' : 'disabled'}`)
-  res.redirect(`/gateway_accounts/${gatewayAccountId}`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
+const toggleAllowTelephonePaymentNotifications = async function toggleAllowTelephonePaymentNotifications(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const { id } = req.params
+  const enabled = await Connector.toggleAllowTelephonePaymentNotifications(id)
+
+  req.flash('info', `Telephone payment notifications ${enabled ? 'enabled' : 'disabled'}`)
+  res.redirect(`/gateway_accounts/${id}`)
 }
 
 const updateStripeStatementDescriptorPage = async function updateStripeStatementDescriptorPage(
@@ -442,6 +453,7 @@ export default {
   updateEmailBranding: wrapAsyncErrorHandler(updateEmailBranding),
   toggleBlockPrepaidCards: wrapAsyncErrorHandler(toggleBlockPrepaidCards),
   toggleMotoPayments: wrapAsyncErrorHandler(toggleMotoPayments),
+  toggleAllowTelephonePaymentNotifications: wrapAsyncErrorHandler(toggleAllowTelephonePaymentNotifications),
   updateStripeStatementDescriptorPage: wrapAsyncErrorHandler(updateStripeStatementDescriptorPage),
   updateStripeStatementDescriptor: wrapAsyncErrorHandler(updateStripeStatementDescriptor),
   updateStripePayoutDescriptorPage: wrapAsyncErrorHandler(updateStripePayoutDescriptorPage),

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -29,6 +29,7 @@ export default {
   updateEmailBranding: http.updateEmailBranding,
   toggleBlockPrepaidCards: http.toggleBlockPrepaidCards,
   toggleMotoPayments: http.toggleMotoPayments,
+  toggleAllowTelephonePaymentNotifications: http.toggleAllowTelephonePaymentNotifications,
   updateStripeStatementDescriptorPage: http.updateStripeStatementDescriptorPage,
   updateStripeStatementDescriptor: http.updateStripeStatementDescriptor,
   updateStripePayoutDescriptorPage: http.updateStripePayoutDescriptorPage,

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -62,6 +62,7 @@ router.post('/gateway_accounts/:id/surcharge', auth.secured, gatewayAccounts.upd
 router.get('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.emailBranding)
 router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.updateEmailBranding)
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
+router.post('/gateway_accounts/:id/toggle_allow_telephone_payment_notifications', auth.secured, gatewayAccounts.toggleAllowTelephonePaymentNotifications)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)


### PR DESCRIPTION
Add button on the gateway account detail page to toggle whether the telephone payment notifications API is enabled for the account.