### PR TITLE
BAU Don't log at error level

### DIFF
--- a/src/web/errorHandler.ts
+++ b/src/web/errorHandler.ts
@@ -72,7 +72,7 @@ const handleDefault = function handleDefault(
   next: NextFunction
 ): void {
   logger.warn('Unhandled error caught by middleware stack')
-  logger.error(error.stack)
+  logger.warn(error.stack)
 
   if (res.headersSent) {
     return next(error)


### PR DESCRIPTION
Don't log unhandled errors caught by the error handler at error level. This includes errors like 404s, so creates a lot of Sentry noise.