### PR TITLE
BAU Do not validate phone number if its a fake

### DIFF
--- a/src/web/modules/users/UpdatePhoneNumberForm.ts
+++ b/src/web/modules/users/UpdatePhoneNumberForm.ts
@@ -11,7 +11,9 @@ class UpdatePhoneNumberFormRequest extends Validated {
   public constructor(formValues: {[key: string]: string}) {
     super()
     this.telephone_number = formValues.telephone_number
-    this.validate()
+    if (formValues.is_real_number === 'yes') {
+      this.validate()
+    }
   }
 }
 

--- a/src/web/modules/users/users.update_phone.njk
+++ b/src/web/modules/users/users.update_phone.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "common/errorSummary.njk" import errorSummary %}
 {% extends "layout/layout.njk" %}
 
@@ -23,6 +24,34 @@
     name: "telephone_number",
     value: formValues.telephone_number,
     errorMessage: errorMap.telephone_number and { text: errorMap.telephone_number }
+    })
+  }}
+
+  {{ govukRadios({
+    classes: "govuk-radios--inline",
+    idPrefix: "is_real_number",
+    name: "is_real_number",
+    fieldset: {
+      legend: {
+        text: "Is this a real phone number?",
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
+    hint: {
+      text: "If this is a fake number for testing then select No"
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes",
+        checked: true
+      },
+      {
+        value: "no",
+        text: "No"
+      }
+    ]
     })
   }}
 


### PR DESCRIPTION
Sometimes we want to use fake numbers when setting up test users. This
allows the user to select whether it is a real number or not. We will
not validate the phone number if it is not a real number.

## What ##
Dan tries to do some frontend dev.