### PR TITLE
BAU Trim payments ids for discrepancy checker

### DIFF
--- a/src/web/modules/discrepancies/discrepancies.http.js
+++ b/src/web/modules/discrepancies/discrepancies.http.js
@@ -8,7 +8,7 @@ const searchTransaction = async function searchTransaction(req, res) {
 }
 
 const getDiscrepancyReport = async function getDiscrepancyReport(req, res) {
-  const chargeIds = req.body.search_string.split(',')
+  const chargeIds = req.body.search_string.split(',').map(chargeId => chargeId.trim())
   const comparisons = await Connector.getGatewayComparisons(chargeIds)
 
   const interpretedComparisons = comparisons.map((comparison) => {


### PR DESCRIPTION
Trim IDs that are sent to connector to remove spaces. It was failing
when providing a comma separated list which had spaces.