### PR TITLE
BAU Remove npm audit step from Jenkins master build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 pipeline {
   agent any
   options { timestamps() }
-  parameters {
-    booleanParam(name: 'SKIP_NPM_AUDIT', defaultValue: false, description: 'Run npm security audit. This should only ever be set to false if a known fix is not yet merged on a dependency.')
-  }
   libraries { lib("pay-jenkins-library@master") }
   environment {
     npm_config_cache = 'npm-cache'
@@ -29,14 +26,6 @@ pipeline {
 
             // @TODO(sfount) CI envrionment should be configured outside of direct Jenkinsfile call
             sh 'node scripts/generate-dev-environment.js'
-          }
-        }
-        stage('Security audit') {
-          when {
-            not { expression { return params.SKIP_NPM_AUDIT } }
-          }
-          steps {
-            sh 'npm audit'
           }
         }
         stage('Lint') {


### PR DESCRIPTION
We currently run Snyk on individual PRs and prioritise security
dependabot upgrades.

`npm audit` returns a non-0 status code for minor vulnerabilities
multiple layers down dependency trees. This behaviour would be useful
for when the package-lock has changed but has negatively impacted the
master building process.

Generally when small issues arise developers skip the audit process on
master because they know they aren't important, this isn't a good
pattern to reinforce.

Remove the audit from the master build step in favour of running it
against individual PRs.