### PR TITLE
BAU Update helmet dependency (major v4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "fast-csv": "^4.3.6",
         "google-libphonenumber": "3.2.16",
         "govuk-frontend": "3.4.0",
-        "helmet": "3.21.2",
+        "helmet": "^4.4.1",
         "https-proxy-agent": "3.0.1",
         "joi": "14.3.1",
         "json2csv": "4.5.4",
@@ -1913,11 +1913,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2024,11 +2019,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001185",
@@ -2379,14 +2369,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-security-policy-builder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
-      "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/content-type": {
@@ -2778,11 +2760,6 @@
         "d3-time": "1"
       }
     },
-    "node_modules/dasherize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
-    },
     "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -2914,14 +2891,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dns-prefetch-control": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz",
-      "integrity": "sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2932,14 +2901,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dont-sniff-mimetype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
-      "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -3676,14 +3637,6 @@
       "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
       "dev": true
     },
-    "node_modules/expect-ct": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
-      "integrity": "sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -3839,14 +3792,6 @@
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
-      }
-    },
-    "node_modules/feature-policy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
-      "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/fecha": {
@@ -4024,14 +3969,6 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frameguard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
-      "integrity": "sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/fresh": {
@@ -4279,66 +4216,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.2.tgz",
-      "integrity": "sha512-okUo+MeWgg00cKB8Csblu8EXgcIoDyb5ZS/3u0W4spCimeVuCUvVZ6Vj3O2VJ1Sxpyb8jCDvzu0L1KKT11pkIg==",
-      "dependencies": {
-        "depd": "2.0.0",
-        "dns-prefetch-control": "0.2.0",
-        "dont-sniff-mimetype": "1.1.0",
-        "expect-ct": "0.2.0",
-        "feature-policy": "0.3.0",
-        "frameguard": "3.1.0",
-        "helmet-crossdomain": "0.4.0",
-        "helmet-csp": "2.9.4",
-        "hide-powered-by": "1.1.0",
-        "hpkp": "2.0.0",
-        "hsts": "2.2.0",
-        "ienoopen": "1.1.0",
-        "nocache": "2.1.0",
-        "referrer-policy": "1.2.0",
-        "x-xss-protection": "1.3.0"
-      },
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.4.1.tgz",
+      "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw==",
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/helmet-crossdomain": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
-      "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/helmet-csp": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.9.4.tgz",
-      "integrity": "sha512-qUgGx8+yk7Xl8XFEGI4MFu1oNmulxhQVTlV8HP8tV3tpfslCs30OZz/9uQqsWPvDISiu/NwrrCowsZBhFADYqg==",
-      "dependencies": {
-        "bowser": "^2.7.0",
-        "camelize": "1.0.0",
-        "content-security-policy-builder": "2.1.0",
-        "dasherize": "2.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/helmet/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/hide-powered-by": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
-      "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg==",
-      "engines": {
-        "node": ">=4.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/hoek": {
@@ -4358,30 +4240,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
-    },
-    "node_modules/hpkp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-    },
-    "node_modules/hsts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-      "dependencies": {
-        "depd": "2.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/hsts/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/http-errors": {
       "version": "1.7.2",
@@ -4447,14 +4305,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "node_modules/ienoopen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
-      "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -5593,14 +5443,6 @@
         "isarray": "0.0.1"
       }
     },
-    "node_modules/nocache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
-      "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
@@ -6611,14 +6453,6 @@
       },
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/referrer-policy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
-      "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -8615,14 +8449,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "node_modules/x-xss-protection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
-      "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
@@ -10261,11 +10087,6 @@
         }
       }
     },
-    "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10347,11 +10168,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
       "version": "1.0.30001185",
@@ -10650,11 +10466,6 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
-    },
-    "content-security-policy-builder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
-      "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ=="
     },
     "content-type": {
       "version": "1.0.4",
@@ -10977,11 +10788,6 @@
         "d3-time": "1"
       }
     },
-    "dasherize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
-    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -11081,11 +10887,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "dns-prefetch-control": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz",
-      "integrity": "sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q=="
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11094,11 +10895,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dont-sniff-mimetype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
-      "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
     },
     "dotenv": {
       "version": "8.2.0",
@@ -11685,11 +11481,6 @@
       "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
       "dev": true
     },
-    "expect-ct": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
-      "integrity": "sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g=="
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -11834,11 +11625,6 @@
         "ua-parser-js": "^0.7.18"
       }
     },
-    "feature-policy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
-      "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
-    },
     "fecha": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
@@ -11972,11 +11758,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "frameguard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
-      "integrity": "sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -12151,54 +11932,9 @@
       "dev": true
     },
     "helmet": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.2.tgz",
-      "integrity": "sha512-okUo+MeWgg00cKB8Csblu8EXgcIoDyb5ZS/3u0W4spCimeVuCUvVZ6Vj3O2VJ1Sxpyb8jCDvzu0L1KKT11pkIg==",
-      "requires": {
-        "depd": "2.0.0",
-        "dns-prefetch-control": "0.2.0",
-        "dont-sniff-mimetype": "1.1.0",
-        "expect-ct": "0.2.0",
-        "feature-policy": "0.3.0",
-        "frameguard": "3.1.0",
-        "helmet-crossdomain": "0.4.0",
-        "helmet-csp": "2.9.4",
-        "hide-powered-by": "1.1.0",
-        "hpkp": "2.0.0",
-        "hsts": "2.2.0",
-        "ienoopen": "1.1.0",
-        "nocache": "2.1.0",
-        "referrer-policy": "1.2.0",
-        "x-xss-protection": "1.3.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
-    },
-    "helmet-crossdomain": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
-      "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
-    },
-    "helmet-csp": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.9.4.tgz",
-      "integrity": "sha512-qUgGx8+yk7Xl8XFEGI4MFu1oNmulxhQVTlV8HP8tV3tpfslCs30OZz/9uQqsWPvDISiu/NwrrCowsZBhFADYqg==",
-      "requires": {
-        "bowser": "^2.7.0",
-        "camelize": "1.0.0",
-        "content-security-policy-builder": "2.1.0",
-        "dasherize": "2.0.0"
-      }
-    },
-    "hide-powered-by": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
-      "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.4.1.tgz",
+      "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
     "hoek": {
       "version": "6.1.3",
@@ -12216,26 +11952,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
-    },
-    "hpkp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-    },
-    "hsts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-      "requires": {
-        "depd": "2.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -12293,11 +12009,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "ienoopen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
-      "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -13187,11 +12898,6 @@
         }
       }
     },
-    "nocache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
-      "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
-    },
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
@@ -13986,11 +13692,6 @@
         "react-lifecycles-compat": "^3.0.2",
         "symbol-observable": "^1.0.4"
       }
-    },
-    "referrer-policy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
-      "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
     },
     "regenerator-runtime": {
       "version": "0.13.7",
@@ -15530,11 +15231,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "x-xss-protection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
-      "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "fast-csv": "^4.3.6",
     "google-libphonenumber": "3.2.16",
     "govuk-frontend": "3.4.0",
-    "helmet": "3.21.2",
+    "helmet": "^4.4.1",
     "https-proxy-agent": "3.0.1",
     "joi": "14.3.1",
     "json2csv": "4.5.4",

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -38,13 +38,15 @@ const app = express()
 const configureSecureHeaders = function configureSecureHeaders(instance) {
   const serverBehindProxy = server.HTTP_PROXY
 
-  // only set certain proxy configured headers if not behind a proxy
-  instance.use(helmet({
-    noSniff: !serverBehindProxy,
-    frameguard: !serverBehindProxy,
-    hsts: !serverBehindProxy,
-    xssFilter: !serverBehindProxy
-  }))
+  // only set certain proxy configured headers if not behind a proxy, the proxy
+  // will be responsible for setting these headers
+  const helmetOptions = serverBehindProxy ? {
+    noSniff: false,
+    frameguard: false,
+    hsts: false,
+    xssFilter: false
+  } : {}
+  instance.use(helmet(helmetOptions))
   instance.use(helmet.contentSecurityPolicy({
     directives: {
       defaultSrc: [ '\'self\'' ],


### PR DESCRIPTION
Upgrade helmet from version 3 to 4.

The main breaking change is the inclusion of CSP protection by default,
as Toolbox already specifies custom CSP headers for all requests this
should require no change to the existing policies.

Reformat disabling certain rules behind a proxy as v4 no longer allows
explicit `true` to turn middleware on/ off (now favouring requiring a
configuration to be passed in).

https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#400---2020-08-02