### PR TITLE
BAU: Bump class-validator from 0.11.0 to 0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "pay-toolbox",
       "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -15,7 +14,7 @@
         "aws-sdk": "2.828.0",
         "axios": "0.21.1",
         "body-parser": "1.19.0",
-        "class-validator": "0.11.0",
+        "class-validator": "0.13.1",
         "client-sessions": "0.8.0",
         "cls-hooked": "4.2.2",
         "connect-flash": "0.1.1",
@@ -1160,9 +1159,9 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
-      "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w=="
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
+      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.15.0",
@@ -2118,13 +2117,13 @@
       }
     },
     "node_modules/class-validator": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.0.tgz",
-      "integrity": "sha512-niAmmSPFku9xsnpYYrddy8NZRrCX3yyoZ/rgPKOilE5BG0Ma1eVCIxpR4X0LasL/6BzbYzsutG+mSbAXlh4zNw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
       "dependencies": {
-        "@types/validator": "10.11.3",
-        "google-libphonenumber": "^3.1.6",
-        "validator": "12.0.0"
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
       }
     },
     "node_modules/client-sessions": {
@@ -4874,6 +4873,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.10.tgz",
+      "integrity": "sha512-XyBYwt1dQCc9emeb78uCqJv9qy9tJQsg6vYDeJt37dwBYiZga8z0rHI5dcrn3aFKz9C5Nn9azaRBC+wmW91FfQ=="
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
@@ -7991,9 +7995,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
-      "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng==",
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -9520,9 +9524,9 @@
       }
     },
     "@types/validator": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
-      "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w=="
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
+      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.15.0",
@@ -10244,13 +10248,13 @@
       }
     },
     "class-validator": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.0.tgz",
-      "integrity": "sha512-niAmmSPFku9xsnpYYrddy8NZRrCX3yyoZ/rgPKOilE5BG0Ma1eVCIxpR4X0LasL/6BzbYzsutG+mSbAXlh4zNw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
       "requires": {
-        "@types/validator": "10.11.3",
-        "google-libphonenumber": "^3.1.6",
-        "validator": "12.0.0"
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
       }
     },
     "client-sessions": {
@@ -12420,6 +12424,11 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "libphonenumber-js": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.10.tgz",
+      "integrity": "sha512-XyBYwt1dQCc9emeb78uCqJv9qy9tJQsg6vYDeJt37dwBYiZga8z0rHI5dcrn3aFKz9C5Nn9azaRBC+wmW91FfQ=="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -14893,9 +14902,9 @@
       }
     },
     "validator": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
-      "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng=="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "aws-sdk": "2.828.0",
     "axios": "0.21.1",
     "body-parser": "1.19.0",
-    "class-validator": "0.11.0",
+    "class-validator": "0.13.1",
     "client-sessions": "0.8.0",
     "cls-hooked": "4.2.2",
     "connect-flash": "0.1.1",

--- a/src/web/modules/users/UpdatePhoneNumberForm.ts
+++ b/src/web/modules/users/UpdatePhoneNumberForm.ts
@@ -3,7 +3,7 @@ import { IsPhoneNumber, IsNotEmpty, IsString } from 'class-validator'
 import Validated from '../common/validated'
 
 class UpdatePhoneNumberFormRequest extends Validated {
-  @IsPhoneNumber('ZZ', { message: 'User telephone number must be a valid international phone number' })
+  @IsPhoneNumber(undefined, { message: 'User telephone number must be a valid international phone number' })
   @IsNotEmpty()
   @IsString()
   public telephone_number: string;


### PR DESCRIPTION
This change bumps [class-validator](https://github.com/typestack/class-validator) from 0.11.0 to 0.13.1.
- [Release notes](https://github.com/typestack/class-validator/releases)
- [Changelog](https://github.com/typestack/class-validator/blob/develop/CHANGELOG.md)
- [Commits](typestack/class-validator@v0.11.0...v0.13.1)

It replaces `'ZZ'` with `undefined` value in region parameter in UpdatePhoneNumberFormRequest.ts to fix the following error message `TS2345: Argument of type '"ZZ"' is not assignable to parameter of type 'CountryCode'`. Source: https://github.com/typestack/class-validator/issues/871