### PR TITLE
BAU Update Joi validation library to 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "govuk-frontend": "3.4.0",
         "helmet": "^4.4.1",
         "https-proxy-agent": "3.0.1",
-        "joi": "14.3.1",
+        "joi": "^17.4.0",
         "json2csv": "4.5.4",
         "lodash": "4.17.20",
         "moment": "2.27.0",
@@ -353,6 +353,19 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@juggle/resize-observer": {
@@ -827,6 +840,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.2",
@@ -4201,12 +4232,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues."
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
@@ -4636,17 +4661,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "node_modules/isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dependencies": {
-        "punycode": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4716,14 +4730,15 @@
       }
     },
     "node_modules/joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-      "deprecated": "This module has moved and is now available at @hapi/joi. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "dependencies": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -6107,6 +6122,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7469,15 +7485,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dependencies": {
-        "hoek": "6.x.x"
-      }
-    },
     "node_modules/triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -8809,6 +8816,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@juggle/resize-observer": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.1.3.tgz",
@@ -9172,6 +9192,24 @@
         "@sentry/types": "5.21.1",
         "tslib": "^1.9.3"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.2",
@@ -11899,11 +11937,6 @@
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.4.1.tgz",
       "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-    },
     "hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
@@ -12208,14 +12241,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      }
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -12272,13 +12297,15 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "requires": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {
@@ -13391,7 +13418,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.9.6",
@@ -14486,14 +14514,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
     },
     "triple-beam": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "govuk-frontend": "3.4.0",
     "helmet": "^4.4.1",
     "https-proxy-agent": "3.0.1",
-    "joi": "14.3.1",
+    "joi": "^17.4.0",
     "json2csv": "4.5.4",
     "lodash": "4.17.20",
     "moment": "2.27.0",

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -1,17 +1,16 @@
 const Joi = require('joi')
 
-const expectedAuthEnvironmentValues = {
+const expectedAuthEnvironmentValues = Joi.object({
   AUTH_GITHUB_ENABLED: Joi.boolean().required(),
   AUTH_GITHUB_CLIENT_ID: Joi.string(),
   AUTH_GITHUB_CLIENT_SECRET: Joi.string(),
   AUTH_GITHUB_RETURN_URL: Joi.string(),
   AUTH_GITHUB_TEAM_ID: Joi.number(),
   AUTH_GITHUB_ADMIN_TEAM_ID: Joi.number().allow('')
-}
+})
 
-const { error, value: validatedAuthEnvironmentValues } = Joi.validate(
+const { error, value: validatedAuthEnvironmentValues } = expectedAuthEnvironmentValues.validate(
   process.env,
-  expectedAuthEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/aws.js
+++ b/src/config/aws.js
@@ -1,13 +1,12 @@
 const Joi = require('joi')
 
-const expectedAwsEnvironmentValues = {
+const expectedAwsEnvironmentValues = Joi.object({
   AWS_S3_UPDATE_TRANSACTIONS_BUCKET_NAME: Joi.string(),
   AWC_ECS_UPDATE_TRANSACTIONS_TASK_DEFINITION: Joi.string()
-}
+})
 
-const { error, value: validatedAwsEnvironmentValues } = Joi.validate(
+const { error, value: validatedAwsEnvironmentValues } = expectedAwsEnvironmentValues.validate(
   process.env,
-  expectedAwsEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/common.js
+++ b/src/config/common.js
@@ -3,14 +3,13 @@
 // correctly.
 const Joi = require('joi')
 
-const expectedCommonEnvironmentValues = {
-  NODE_ENV: Joi.string().valid([ 'development', 'production', 'staging', 'test' ]).required(),
+const expectedCommonEnvironmentValues = Joi.object({
+  NODE_ENV: Joi.string().valid('development', 'production', 'staging', 'test').required(),
   ENVIRONMENT: Joi.string()
-}
+})
 
-const { error, value: validatedCommonEnvironmentValues } = Joi.validate(
+const { error, value: validatedCommonEnvironmentValues } = expectedCommonEnvironmentValues.validate(
   process.env,
-  expectedCommonEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -1,12 +1,11 @@
 const Joi = require('joi')
 
-const expectedLoggingEnvironmentValues = {
+const expectedLoggingEnvironmentValues = Joi.object({
   DISABLE_REQUEST_LOGGING: Joi.boolean().default(false)
-}
+})
 
-const { error, value: validatedLoggingEnvironmentValues } = Joi.validate(
+const { error, value: validatedLoggingEnvironmentValues } = expectedLoggingEnvironmentValues.validate(
   process.env,
-  expectedLoggingEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/sentry.js
+++ b/src/config/sentry.js
@@ -1,12 +1,11 @@
 const Joi = require('joi')
 
-const expectedSentryEnvironmentValues = {
+const expectedSentryEnvironmentValues = Joi.object({
   SENTRY_DSN: Joi.string()
-}
+})
 
-const { error, value: validatedSentryEnvironmentValues } = Joi.validate(
+const { error, value: validatedSentryEnvironmentValues } = expectedSentryEnvironmentValues.validate(
   process.env,
-  expectedSentryEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,16 +1,15 @@
 const Joi = require('joi')
 
-const expectedServerEnvironmentValues = {
+const expectedServerEnvironmentValues = Joi.object({
   PORT: Joi.number().integer().required(),
   COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required(),
   HTTP_PROXY: Joi.string(),
   HTTPS_PROXY: Joi.string(),
   SESSION_COOKIE_DURATION_IN_MILLIS: Joi.number().integer()
-}
+})
 
-const { error, value: validatedServerEnvironmentValues } = Joi.validate(
+const { error, value: validatedServerEnvironmentValues } = expectedServerEnvironmentValues.validate(
   process.env,
-  expectedServerEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/config/services.js
+++ b/src/config/services.js
@@ -2,7 +2,7 @@
 // be configured even if they are not used by all flows
 const Joi = require('joi')
 
-const expectedConnectedServicesEnvironmentValues = {
+const expectedConnectedServicesEnvironmentValues = Joi.object({
   ADMINUSERS_URL: Joi.string().required(),
   CONNECTOR_URL: Joi.string().required(),
   DIRECT_DEBIT_CONNECTOR_URL: Joi.string().required(),
@@ -10,11 +10,10 @@ const expectedConnectedServicesEnvironmentValues = {
   PUBLIC_AUTH_URL: Joi.string().required(),
   LEDGER_URL: Joi.string().required(),
   SELFSERVICE_URL: Joi.string().required()
-}
+})
 
-const { error, value: validatedConnectedServicesEnvironmentValues } = Joi.validate(
+const { error, value: validatedConnectedServicesEnvironmentValues } = expectedConnectedServicesEnvironmentValues.validate(
   process.env,
-  expectedConnectedServicesEnvironmentValues,
   { allowUnknown: true, stripUnknown: true }
 )
 

--- a/src/web/modules/statistics/dateFilter.model.js
+++ b/src/web/modules/statistics/dateFilter.model.js
@@ -2,10 +2,10 @@ const Joi = require('joi')
 
 const { ValidationError } = require('./../../../lib/errors')
 
-const schema = {
+const schema = Joi.object({
   date: Joi.date(),
   compareDate: Joi.date()
-}
+})
 
 const convertToISODates = function convertToISODates(model) {
   const converted = { ...model }
@@ -28,7 +28,7 @@ const parseFromBody = function parseFromBody(body) {
 
 class DateFilter {
   constructor(body) {
-    const { error, value: model } = Joi.validate(parseFromBody(body), schema)
+    const { error, value: model } = schema.validate(parseFromBody(body))
 
     if (error) {
       throw new ValidationError(`StatisticsDateFilter ${error.details[0].message}`)

--- a/src/web/modules/stripe/address.model.js
+++ b/src/web/modules/stripe/address.model.js
@@ -2,18 +2,17 @@ const Joi = require('joi')
 
 const { ValidationError } = require('./../../../lib/errors')
 
-const schema = {
+const schema = Joi.object({
   line1: Joi.string().required(),
   city: Joi.string().required(),
   postal_code: Joi.string().required()
-}
+})
 
 class StripeAddress {
   constructor(body) {
     const params = { ...body }
-    const { error, value: model } = Joi.validate(
+    const { error, value: model } = schema.validate(
       params,
-      schema,
       { allowUnknown: true, stripUnknown: true }
     )
 

--- a/src/web/modules/stripe/bankAccount.model.js
+++ b/src/web/modules/stripe/bankAccount.model.js
@@ -3,10 +3,10 @@ const Joi = require('joi')
 const { ValidationError } = require('./../../../lib/errors')
 const { stripEmpty } = require('./../../../lib/validation')
 
-const schema = {
+const schema = Joi.object({
   bank_account_sort_code: Joi.string().required(),
   bank_account_number: Joi.string().required()
-}
+})
 
 const build = function build(params) {
   const core = {
@@ -24,9 +24,8 @@ const build = function build(params) {
 class StripeBankAccount {
   constructor(body) {
     const params = { ...body }
-    const { error, value: model } = Joi.validate(
+    const { error, value: model } = schema.validate(
       params,
-      schema,
       { allowUnknown: true, stripUnknown: true }
     )
 

--- a/src/web/modules/stripe/dob.model.js
+++ b/src/web/modules/stripe/dob.model.js
@@ -2,18 +2,17 @@ const Joi = require('joi')
 
 const { ValidationError } = require('./../../../lib/errors')
 
-const schema = {
+const schema = Joi.object({
   day: Joi.number().required(),
   month: Joi.number().required(),
   year: Joi.number().required()
-}
+})
 
 class Dob {
   constructor(body) {
     const params = { ...body }
-    const { error, value: model } = Joi.validate(
+    const { error, value: model } = schema.validate(
       params,
-      schema,
       { allowUnknown: true, stripUnknown: true }
     )
 

--- a/src/web/modules/stripe/legalEntity.model.js
+++ b/src/web/modules/stripe/legalEntity.model.js
@@ -5,12 +5,12 @@ const { addModelIfValid, stripEmpty } = require('./../../../lib/validation')
 const Address = require('./address.model')
 const Dob = require('./dob.model')
 
-const schema = {
+const schema = Joi.object({
   org_id: Joi.string(),
   org_name: Joi.string().required(),
   person_first_name: Joi.string(),
   person_last_name: Joi.string()
-}
+})
 
 const addSubModels = function addSubModels(legalEntity, params) {
   let entityWithSubModels = { ...legalEntity }
@@ -54,7 +54,7 @@ const build = function build(params) {
 class StripeLegalEntity {
   constructor(body) {
     const params = { ...body }
-    const { error, value: model } = Joi.validate(params, schema, { allowUnknown: true })
+    const { error, value: model } = schema.validate(params, { allowUnknown: true })
 
     if (error) {
       throw new ValidationError(`StripeLegalEntity ${error.details[0].message}`)

--- a/src/web/modules/stripe/stripe.model.js
+++ b/src/web/modules/stripe/stripe.model.js
@@ -8,13 +8,13 @@ const { addModelIfValid, stripEmpty } = require('./../../../lib/validation')
 const StripeBankAccount = require('./bankAccount.model')
 const StripeLegalEntity = require('./legalEntity.model')
 
-const schema = {
+const schema = Joi.object({
   org_id: Joi.string().required(),
   org_name: Joi.string().required(),
   org_ip_address: Joi.string().required(),
   org_statement_descriptor: Joi.string().required(),
   org_phone_number: Joi.string().required()
-}
+})
 
 const toE164InternationalFormat = function toE164InternationalFormat(rawNumber) {
   if (rawNumber) {
@@ -47,7 +47,7 @@ const build = function build(params) {
 
 class StripeAccount {
   constructor(body) {
-    const { error, value: model } = Joi.validate(body, schema, { allowUnknown: true })
+    const { error, value: model } = schema.validate(body, { allowUnknown: true })
 
     if (error) {
       throw new ValidationError(`StripeAccount ${error.details[0].message}`)

--- a/src/web/modules/transactions/legacy/transactionSearch.model.js
+++ b/src/web/modules/transactions/legacy/transactionSearch.model.js
@@ -2,17 +2,16 @@ const Joi = require('joi')
 
 const { ValidationError } = require('../../../../lib/errors')
 
-const schema = {
+const schema = Joi.object({
   account_id: Joi.string().required(),
   search_string: Joi.string().required(),
   search_by: Joi.string().valid('chargeId', 'reference').required()
-}
+})
 
 class TransactionSearch {
   constructor(body) {
-    const { error, value: model } = Joi.validate(
+    const { error, value: model } = schema.validate(
       body,
-      schema,
       { allowUnknown: true, stripUnknown: true }
     )
 


### PR DESCRIPTION
Update 3 major versions to [Joi](https://github.com/sideway/joi) 17. 

A breaking change in schema definition and the top level Joi `validate` method requires updating usage of the library.

https://joi.dev/resources/changelog/