### PR TITLE
PP-7738 Create Stripe test account

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-22T10:03:19Z",
+  "generated_at": "2021-02-13T01:59:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,7 +90,7 @@
       {
         "hashed_secret": "b7e04b33fdd186ab6bd2deace04ea6b551b9bd4a",
         "is_verified": false,
-        "line_number": 215,
+        "line_number": 212,
         "type": "Secret Keyword"
       }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "qs": "6.9.6",
         "sass": "^1.32.7",
         "stripe": "7.15.0",
+        "stripe-latest": "npm:stripe@^8.135.0",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"
       },
@@ -6760,6 +6761,19 @@
         "node": "^6 || ^8.1 || >=10.*"
       }
     },
+    "node_modules/stripe-latest": {
+      "name": "stripe",
+      "version": "8.135.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.135.0.tgz",
+      "integrity": "sha512-cy2IhKhENtvcwdrqtX4jZK4kgu0crA0YrwMgHovIzMAv/Ebr5LqBQ/nhyBqsssExY1hJjn765vhltNrf0WV+Iw==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.6.0"
+      },
+      "engines": {
+        "node": "^8.1 || >=10.*"
+      }
+    },
     "node_modules/superagent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
@@ -13404,6 +13418,15 @@
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.15.0.tgz",
       "integrity": "sha512-TmouNGv1rIU7cgw7iFKjdQueJSwYKdPRPBuO7eNjrRliZUnsf2bpJqYe+n6ByarUJr38KmhLheVUxDyRawByPQ==",
       "requires": {
+        "qs": "^6.6.0"
+      }
+    },
+    "stripe-latest": {
+      "version": "npm:stripe@8.135.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.135.0.tgz",
+      "integrity": "sha512-cy2IhKhENtvcwdrqtX4jZK4kgu0crA0YrwMgHovIzMAv/Ebr5LqBQ/nhyBqsssExY1hJjn765vhltNrf0WV+Iw==",
+      "requires": {
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "qs": "6.9.6",
     "sass": "^1.32.7",
     "stripe": "7.15.0",
+    "stripe-latest": "npm:stripe@^8.135.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"
   },

--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -181,6 +181,16 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.patch(path, payload).then(utilExtractData)
   }
 
+  const updateServiceTestPspAccountStageToCreated = function updateServiceTestPspAccountStageToCreated(id) {
+    const path = `v1/api/services/${id}`
+    const payload = {
+      op: 'replace',
+      path: 'current_psp_test_account_stage',
+      value: 'CREATED'
+    }
+    return axiosInstance.patch(path, payload).then(utilExtractData)
+  }
+
   const updateServiceOrganisationName = function updateServiceOrganisationName(id, status) {
     const path = `v1/api/services/${id}`
     const payload = {
@@ -229,6 +239,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     gatewayAccountServices,
     updateServiceDetails,
     updateServiceOrganisationName,
+    updateServiceTestPspAccountStageToCreated,
     updateUserPhone,
     updateUserEmail,
     toggleUserEnabled,

--- a/src/lib/pay-request/types/adminUsers.ts
+++ b/src/lib/pay-request/types/adminUsers.ts
@@ -5,6 +5,8 @@ export interface Service {
 
   current_go_live_stage: string;
 
+  current_psp_test_account_stage: string;
+
   gateway_account_ids: string[];
 
   redirect_to_service_immediately_on_terminal_state: boolean;

--- a/src/web/modules/gateway_accounts/createSuccess.njk
+++ b/src/web/modules/gateway_accounts/createSuccess.njk
@@ -20,40 +20,64 @@ A {{ account.type | upper }} Gateway account has been created through Admin User
 </p>
 
 <h2 class="govuk-heading-m">What to do next</h2>
-<p class="govuk-body">In Zendesk, respond to the request to go live using the appropriate Zendesk macro (either “Stripe account” or “non-Stripe”).</p>
-<p class="govuk-body">Replace the placeholders in the macro with the following:</p>
 
-{{ govukTable({
-		head: [ 
-			{ text: "Zendesk macro placeholder"}, 
-			{ text: "Value"} 
-		],
-		rows: 
-		[
-			[ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/service/" + linkedService + "/dashboard/live", classes: "stripe-go-live-url-table-cell"  } ],
-			[ { text: "***STATEMENT_DESCRIPTOR***" }, { text: stripeAccountStatementDescriptors.statementDescriptor | upper } ],
-			[ { text: "***PAYOUT_STATEMENT_DESCRIPTOR***" }, { text: stripeAccountStatementDescriptors.payoutStatementDescriptor | upper } ]
-		] 
-		if isStripe else
-		[
-			[ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/service/" + linkedService + "/dashboard/live", classes: "stripe-go-live-url-table-cell"  } ]
-		]
-		})
-}}
+{% if isStripe and not isLive %}
+    <p class="govuk-body">In Zendesk, respond to the request using "Stripe test account" macro</p>
+    <p class="govuk-body">Replace the placeholders in the macro with the following:</p>
+
+    {{ govukTable({
+            head: [
+                { text: "Zendesk macro placeholder"},
+                { text: "Value"}
+            ],
+            rows:
+            [
+                [ { text: "***STRIPE_TEST_ACCOUNT_URL***" },
+                  { text: selfServiceBaseUrl + "/account/" + account.external_id + "/dashboard", classes: "stripe-go-live-url-table-cell"  } ]
+            ]
+            })
+    }}
+
+{% else %}
+    <p class="govuk-body">In Zendesk, respond to the request to go live using the appropriate Zendesk macro (either “Stripe account” or “non-Stripe”).</p>
+    <p class="govuk-body">Replace the placeholders in the macro with the following:</p>
+
+    {{ govukTable({
+            head: [
+                { text: "Zendesk macro placeholder"},
+                { text: "Value"}
+            ],
+            rows:
+            [
+                [ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/account/" + account.external_id + "/dashboard", classes: "stripe-go-live-url-table-cell"  } ],
+                [ { text: "***STATEMENT_DESCRIPTOR***" }, { text: stripeAccountStatementDescriptors.statementDescriptor | upper } ],
+                [ { text: "***PAYOUT_STATEMENT_DESCRIPTOR***" }, { text: stripeAccountStatementDescriptors.payoutStatementDescriptor | upper } ]
+            ]
+            if isStripe else
+            [
+                [ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/service/" + linkedService + "/dashboard/live", classes: "stripe-go-live-url-table-cell"  } ]
+            ]
+            })
+    }}
+{% endif %}
 
 <h2 class="govuk-heading-m">Actions taken</h2>
 <ol class="govuk-list govuk-list--number">
-	<li>New {{ account.type }} {{ provider | capitalize }} account ({{ gatewayAccountIdDerived }}) record created</li>
+    {% if stripeConnectAccountId %}
+	    <li>New Stripe connect account ({{stripeConnectAccountId}}) created</li>
+	{% endif %}
+	<li>New {{ account.type }} {{ provider | capitalize }} gateway account ({{ gatewayAccountIdDerived }}) record created</li>
 
-  {% if linkedService %}
-	<li>(System Link) Service linked to new Gateway account ({{ gatewayAccountIdDerived }})</li>
+    {% if linkedService %}
+	    <li>(System Link) Service linked to new Gateway account ({{ gatewayAccountIdDerived }})</li>
 	{% endif %}
 
+    {% if account.requires_3ds %}
+        <li>Set ‘requires_3ds’ to ‘true’ for gateway account</li>
+    {% endif %}
 	{% if isLive %}
-	<li>Set ‘requires_3ds’ to ‘true’ for live account</li>
-	<li>Service go live status updated to ‘LIVE’</li>
+	    <li>Service go live status updated to ‘LIVE’</li>
 	{% endif %}
-
 </ol>
 
 <h2 class="govuk-heading-m">Relevant resources</h2>

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -122,7 +122,7 @@ class GatewayAccount extends Validated {
       internalFlag: this.internalFlag
     }
 
-    if (this.isLive()) {
+    if (this.isLive() || this.provider === 'stripe' ) {
       payload.requires_3ds = 'true'
     } else {
       payload.requires_3ds = 'false'

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Request, Response, NextFunction } from 'express'
-import { parse, ParsedQs, stringify } from 'qs'
+import { Request, Response } from 'express'
+import { stringify } from 'qs'
 
 import logger from '../../../lib/logger'
 
@@ -13,7 +13,7 @@ import { extractFiltersFromQuery, toAccountSearchParams } from '../../../lib/gat
 import GatewayAccountFormModel from './gatewayAccount.model'
 import { Service } from '../../../lib/pay-request/types/adminUsers'
 import DirectDebitGatewayAccount from '../../../lib/pay-request/types/directDebitConnector'
-import { GatewayAccount as CardGatewayAccount, GatewayAccount } from '../../../lib/pay-request/types/connector'
+import { GatewayAccount as CardGatewayAccount } from '../../../lib/pay-request/types/connector'
 import { ClientFormError } from '../common/validationErrorFormat'
 import * as config from '../../../config'
 import Stripe from 'stripe'

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -102,7 +102,9 @@
   </div>
 
   <div>
-    <h1 class="govuk-heading-s">Going live - new Stripe payment provider</h1>
+    <h1 class="govuk-heading-m">Stripe payment provider</h1>
+
+    <h2 class="govuk-heading-s">Going live</h2>
     <p class="govuk-body">This will guide you through:</p>
     <ul class="govuk-list govuk-list--number">
       <li>Creating new Stripe account through the Stripe API</li>
@@ -114,17 +116,18 @@
       href: "/stripe/basic/create?service=" + service.external_id
       })
     }}
+    <h2 class="govuk-heading-s">Test account</h2>
+    {{ govukButton({
+      text: "Setup test Stripe account",
+      classes: "govuk-button--secondary",
+      href: "/stripe/basic/create-test-account?service=" + service.external_id
+      })
+    }}
 
-    <p>
-      <a class="govuk-link" href="/stripe/create?service={{ service.external_id }}">
-        Create live Stripe account with all details (the old way)
-      </a>
-    </p>
-    <br/>
   </div>
 
   <div>
-    <h1 class="govuk-heading-s">Going live - existing payment provider</h1>
+    <h1 class="govuk-heading-m">Going live - existing payment provider</h1>
     <p class="govuk-body">This will guide you through:</p>
     <ul class="govuk-list govuk-list--number">
       <li>Creating a GOV.UK Pay gateway account</li>
@@ -138,7 +141,7 @@
   </div>
 
   <div>
-    <h1 class="govuk-heading-s">Service actions</h1>
+    <h1 class="govuk-heading-m">Service actions</h1>
     {{ govukButton({
       text: "Edit custom branding",
       href: "/services/" + serviceId + "/branding"

--- a/src/web/modules/stripe/basic/confirm-create-test-account.njk
+++ b/src/web/modules/stripe/basic/confirm-create-test-account.njk
@@ -1,0 +1,40 @@
+{% extends "layout/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block main %}
+  <div class="govuk-body">
+    <a href="/services/{{ systemLinkService }}" class="govuk-back-link">Back to service ({{ systemLinkService }})</a>
+  </div>
+
+  <h1 class="govuk-heading-m">Create test Stripe account</h1>
+
+  {{ govukTable({
+    firstCellIsHeader: true,
+    rows: [
+      [
+        { text: "Service name" },
+        { text: serviceName }
+      ]
+    ]
+    })
+  }}
+
+  <form method="POST" action="/stripe/basic/create-test-account">
+    <p class="govuk-body">You are about to create Stripe account for the service. This will create:</p>
+    <ul class="govuk-list govuk-list--number">
+      <li>Stripe test connect account through the Stripe API</li>
+      <li>GOV.UK Pay test gateway account setting the provider to Stripe. This will be available for service immediately on the admin tool "My services" page</li>
+    </ul>
+
+    <input hidden="hidden" name="systemLinkService" id="systemLinkService" value="{{ systemLinkService }}">
+    <div class="govuk-form-group">
+      {{ govukButton({
+		    text: "Create test stripe account"
+        })
+      }}
+    </div>
+
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+  </form>
+{% endblock %}

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -1,0 +1,139 @@
+import HTTPSProxyAgent from 'https-proxy-agent'
+import { Request, Response, NextFunction } from 'express'
+
+import logger from '../../../../lib/logger'
+import * as config from '../../../../config'
+import { Connector, AdminUsers } from '../../../../lib/pay-request'
+import { ValidationError as CustomValidationError } from '../../../../lib/errors'
+import { wrapAsyncErrorHandler } from '../../../../lib/routes'
+import { Service } from '../../../../lib/pay-request/types/adminUsers'
+import GatewayAccountFormModel from "../../gateway_accounts/gatewayAccount.model";
+import { GatewayAccount as CardGatewayAccount } from "../../../../lib/pay-request/types/connector";
+// @ts-ignore
+import { accounts } from "stripe";
+import { stripeTestAccountDetails } from '../model/account.model'
+import { stripeTestResponsiblePersonDetails } from '../model/person.model'
+
+const Stripe = require('stripe-latest')
+const { StripeError } = Stripe.errors
+const STRIPE_TEST_ACCOUNT_API_KEY: string = process.env.STRIPE_TEST_ACCOUNT_API_KEY || ''
+const stripe = new Stripe(STRIPE_TEST_ACCOUNT_API_KEY, {
+    apiVersion: '2020-08-27',
+})
+
+if (config.server.HTTPS_PROXY) {
+    // @ts-ignore
+    stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+}
+
+function validateRequest(currentPspTestAccountStage: string) {
+    if (currentPspTestAccountStage === 'CREATED') {
+        throw new CustomValidationError('Stripe test account has already been created for service')
+    }
+    if (currentPspTestAccountStage !== 'REQUEST_SUBMITTED') {
+        throw new CustomValidationError('Service has not completed a request for Stripe test account')
+    }
+}
+
+const createTestAccount = async function createTestAccount(req: Request, res: Response): Promise<void> {
+    if (!STRIPE_TEST_ACCOUNT_API_KEY) {
+        throw new CustomValidationError('Stripe test API Key was not configured for this Toolbox instance')
+    }
+
+    const serviceExternalId = req.query.service as string
+    const service: Service = await AdminUsers.service(serviceExternalId)
+
+    validateRequest(service.current_psp_test_account_stage)
+
+    const context: {
+        systemLinkService: string; serviceName: string;
+        csrf: string;
+        flash: object
+    } = {
+        systemLinkService: serviceExternalId,
+        serviceName: service.service_name.en,
+        csrf: req.csrfToken(),
+        flash: req.flash()
+    }
+
+    return res.render('stripe/basic/confirm-create-test-account', context)
+}
+
+const createTestAccountConfirm = async function createTestAccountConfirm(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { systemLinkService } = req.body
+    let service: Service
+
+    try {
+        service = await AdminUsers.service(systemLinkService)
+
+        validateRequest(service.current_psp_test_account_stage)
+
+        const stripeAccount = await createStripeTestAccount(service.service_name.en)
+
+        const account: CardGatewayAccount = await createTestGatewayAccount(systemLinkService, service.service_name.en, stripeAccount.id)
+        const gatewayAccountIdDerived = String(account.gateway_account_id)
+        res.render('gateway_accounts/createSuccess', {
+            account: account,
+            linkedService: systemLinkService,
+            gatewayAccountIdDerived,
+            provider: 'stripe',
+            isLive: false,
+            isStripe: true,
+            stripeConnectAccountId: stripeAccount.id,
+            selfServiceBaseUrl: config.services.SELFSERVICE_URL
+        })
+    } catch (error) {
+        if (error instanceof StripeError) {
+            logger.error(`Stripe Error - ${error.message}`)
+            req.flash('error', `Stripe Error: ${error.message}`)
+            res.redirect(`/stripe/basic/create-test-account?service=${systemLinkService}`)
+        } else {
+            next(error)
+        }
+    }
+}
+
+async function createTestGatewayAccount(serviceId: string, serviceName: string, stripeConnectId: string): Promise<CardGatewayAccount> {
+    const account = new GatewayAccountFormModel({
+        live: 'not-live',
+        paymentMethod: 'card',
+        description: `Stripe test account for service ${serviceName}`,
+        analyticsId: 'Stripe-connect-test-account',
+        sector: 'Other',
+        serviceName: serviceName,
+        provider: 'stripe',
+        credentials: stripeConnectId
+    })
+
+    const cardAccount: CardGatewayAccount = await Connector.createAccount(account.formatPayload())
+    const gatewayAccountIdDerived = String(cardAccount.gateway_account_id)
+    logger.info(`Created new Gateway Account ${gatewayAccountIdDerived}`)
+
+    // connect system linked services to the created account
+    await AdminUsers.updateServiceGatewayAccount(serviceId, gatewayAccountIdDerived)
+    logger.info(`Service ${serviceId} linked to new Gateway Account ${gatewayAccountIdDerived}`)
+
+    await AdminUsers.updateServiceTestPspAccountStageToCreated(serviceId)
+
+    return cardAccount
+}
+
+// @ts-ignore
+async function createStripeTestAccount(serviceName: string): Promise<accounts> {
+    logger.info('Requesting new Stripe test account from stripe API')
+
+    const stripeAccountCreated = await stripe.accounts.create(stripeTestAccountDetails(serviceName))
+    await createRepresentative(stripeAccountCreated.id)
+
+    logger.info(`Stripe API responded with success, account ${stripeAccountCreated.id} created.`)
+    return stripeAccountCreated
+}
+
+async function createRepresentative(connectAccountId: string) {
+    await stripe.accounts.createPerson(connectAccountId, stripeTestResponsiblePersonDetails())
+}
+
+export default {
+    createTestAccount: wrapAsyncErrorHandler(createTestAccount),
+    createTestAccountConfirm: wrapAsyncErrorHandler(createTestAccountConfirm)
+}

--- a/src/web/modules/stripe/index.js
+++ b/src/web/modules/stripe/index.js
@@ -1,7 +1,10 @@
 // @TODO(sfount) improve TS export -> JS import
 const httpBasic = require('./basic/basic.http').default
+const httpBasicTest = require('./basic/test-account.http').default
 
 module.exports = {
   basic: httpBasic.createAccountForm,
-  basicCreate: httpBasic.submitAccountCreate
+  basicCreate: httpBasic.submitAccountCreate,
+  createTestAccount: httpBasicTest.createTestAccount,
+  createTestAccountConfirm: httpBasicTest.createTestAccountConfirm
 }

--- a/src/web/modules/stripe/model/account.model.js
+++ b/src/web/modules/stripe/model/account.model.js
@@ -1,0 +1,53 @@
+function stripeTestAccountDetails (serviceName) {
+  // test Stripe account details as per https://stripe.com/docs/connect/testing
+  return {
+    type: 'custom',
+    country: 'GB',
+    business_type: 'company',
+    company: {
+      name: serviceName,
+      address: {
+        line1: 'address_full_match',
+        line2: 'WCB',
+        city: 'London',
+        postal_code: 'E1 8QS',
+        country: 'GB'
+      },
+      phone: '+441212345678',
+      tax_id: '000000000',
+      vat_id: 'NOTAPPLI',
+      owners_provided: true,
+      directors_provided: true,
+      executives_provided: true
+    },
+    capabilities: {
+      card_payments: { requested: true },
+      transfers: { requested: true },
+    },
+    external_account: {
+      object: 'bank_account',
+      country: 'GB',
+      currency: 'GBP',
+      account_holder_name: 'Jane Doe',
+      account_holder_type: 'individual',
+      routing_number: '108800',
+      account_number: '00012345'
+    },
+    settings: {
+      payouts: {
+        schedule: { interval: 'daily', delay_days: '7' },
+        statement_descriptor: 'TEST ACCOUNT'
+      }
+    },
+    business_profile: {
+      mcc: 9399,
+      product_description: 'Test account for a service'
+    },
+    tos_acceptance: {
+      ip: '0.0.0.0',
+      date: Math.floor(new Date().getTime() / 1000)
+    }
+  }
+}
+
+module.exports = { stripeTestAccountDetails }

--- a/src/web/modules/stripe/model/person.model.js
+++ b/src/web/modules/stripe/model/person.model.js
@@ -1,0 +1,32 @@
+function stripeTestResponsiblePersonDetails () {
+  return {
+    first_name: 'Jane',
+    last_name: 'Doe',
+    dob: {
+      day: '01',
+      month: '01',
+      year: '1901'
+    },
+    relationship: {
+      representative: true,
+      executive: true,
+      title: 'CEO'
+    },
+    address: {
+      line1: 'address_full_match',
+      line2: 'WCB',
+      city: 'London',
+      postal_code: 'E1 8QS',
+      country: 'GB'
+    },
+    phone: '8888675309',
+    email: 'test@example.org',
+    verification: {
+      document: {
+        front: 'file_identity_document_success'
+      }
+    }
+  }
+}
+
+module.exports = { stripeTestResponsiblePersonDetails }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -100,6 +100,8 @@ router.post('/charges/search', auth.secured, charges.searchTransaction.http, cha
 
 router.get('/stripe/basic/create', auth.secured, stripe.basic)
 router.post('/stripe/basic/create', auth.secured, stripe.basicCreate)
+router.get('/stripe/basic/create-test-account', auth.secured, stripe.createTestAccount)
+router.post('/stripe/basic/create-test-account', auth.secured, stripe.createTestAccountConfirm)
 
 // @TODO(sfount) simple to integrate into table action - should be reconsidered for POST or PATCH
 router.get('/users/search', auth.secured, users.searchPage)


### PR DESCRIPTION
## WHAT
- Added functionality to create test Stripe connect account and a test gateway account (Stripe). Test account can only be created when service requests (from selfservice) for Stripe test account.
- Uses Stripe latest library to create test account as per Stripe docs https://stripe.com/docs/connect/testing
- Stripe library (v7.15.0) still exists to create live accounts. Moving to latest library could mean we need to request connect account capabilities explicitly and the `legacy_payments` capability required for live accounts is no longer supported by Stripe.

# Screenshots

## Create Stripe test account page on service page
<img width="492" alt="Screenshot 2021-02-15 at 08 36 53" src="https://user-images.githubusercontent.com/40598480/107938984-07104000-6f7e-11eb-8f4c-59fcd95c56b5.png">


## Confirmation page
<img width="724" alt="Screenshot 2021-02-15 at 08 37 01" src="https://user-images.githubusercontent.com/40598480/107938998-0d062100-6f7e-11eb-8ad7-271fcadfc328.png">


## Success page
<img width="589" alt="Screenshot 2021-02-15 at 08 38 27" src="https://user-images.githubusercontent.com/40598480/107939014-11cad500-6f7e-11eb-9c90-0ec766c06db6.png">




