### PR TITLE
PP-7784 Fix transaction page payer text overlap

### DIFF
--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -254,3 +254,7 @@
   word-break: break-word;
 }
 
+.ellipses-text-wrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -24,7 +24,7 @@
       <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
     </div>
     {% if transaction.card_details %}
-    <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-grid-column-one-quarter ellipses-text-wrap">
       <span class="govuk-caption-m">Payer</span>
       <span class="govuk-body">{{ transaction.card_details.cardholder_name }}</span>
     </div>


### PR DESCRIPTION
Long payer names without space breaks have difficulty overlapping, allow
spaces to break to the next line but limit unbroken text with `...`.

**Behaviour following change**

<img width="510" alt="Screenshot 2021-02-15 at 11 53 04" src="https://user-images.githubusercontent.com/2844572/107943523-bea85080-6f84-11eb-95e7-99b44d0e0a3c.png">

<img width="518" alt="Screenshot 2021-02-15 at 11 52 50" src="https://user-images.githubusercontent.com/2844572/107943525-bf40e700-6f84-11eb-8588-d7ba5ef711e2.png">
