### PR TITLE
PP-7738 Fix Stripe test API key name

### DIFF
--- a/src/web/modules/stripe/basic/confirm-create-test-account.njk
+++ b/src/web/modules/stripe/basic/confirm-create-test-account.njk
@@ -7,7 +7,7 @@
     <a href="/services/{{ systemLinkService }}" class="govuk-back-link">Back to service ({{ systemLinkService }})</a>
   </div>
 
-  <h1 class="govuk-heading-m">Create test Stripe account</h1>
+  <h1 class="govuk-heading-m">Create test stripe account</h1>
 
   {{ govukTable({
     firstCellIsHeader: true,
@@ -21,7 +21,7 @@
   }}
 
   <form method="POST" action="/stripe/basic/create-test-account">
-    <p class="govuk-body">You are about to create Stripe account for the service. This will create:</p>
+    <p class="govuk-body">You are about to create a Stripe account for the service. This will create:</p>
     <ul class="govuk-list govuk-list--number">
       <li>Stripe test connect account through the Stripe API</li>
       <li>GOV.UK Pay test gateway account setting the provider to Stripe. This will be available for service immediately on the admin tool "My services" page</li>

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -16,8 +16,8 @@ import { stripeTestResponsiblePersonDetails } from '../model/person.model'
 
 const Stripe = require('stripe-latest')
 const { StripeError } = Stripe.errors
-const STRIPE_TEST_ACCOUNT_API_KEY: string = process.env.STRIPE_TEST_ACCOUNT_API_KEY || ''
-const stripe = new Stripe(STRIPE_TEST_ACCOUNT_API_KEY, {
+const STRIPE_ACCOUNT_TEST_API_KEY: string = process.env.STRIPE_ACCOUNT_TEST_API_KEY || ''
+const stripe = new Stripe(STRIPE_ACCOUNT_TEST_API_KEY, {
     apiVersion: '2020-08-27',
 })
 
@@ -36,7 +36,7 @@ function validateRequest(currentPspTestAccountStage: string) {
 }
 
 const createTestAccount = async function createTestAccount(req: Request, res: Response): Promise<void> {
-    if (!STRIPE_TEST_ACCOUNT_API_KEY) {
+    if (!STRIPE_ACCOUNT_TEST_API_KEY) {
         throw new CustomValidationError('Stripe test API Key was not configured for this Toolbox instance')
     }
 


### PR DESCRIPTION

- Fix name of Stripe test API key as provisioned in environments.
- Minor changes based on story review comments https://github.com/alphagov/pay-toolbox/pull/884