### PR TITLE
PP-7739 Creating Stripe Test Account - set Stripe setup values to true.

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -104,6 +104,21 @@ const connectorMethods = function connectorMethods(instance) {
     })
   }
 
+  const updateStripeSetupValues = function updateStripeSetupValues(id, stripeSetupFields) {
+    const url = `/v1/api/accounts/${id}/stripe-setup`
+    const payload = []
+    
+    stripeSetupFields.forEach((field) =>{
+      payload.push({
+        op: 'replace',
+        path: field,
+        value: true
+      })
+    })
+
+    return axiosInstance.patch(url, payload)
+  }
+
   const toggleBlockPrepaidCards = async function toggleBlockPrepaidCards(id) {
     const gatewayAccount = await account(id)
     const url = `/v1/api/accounts/${id}`
@@ -159,7 +174,8 @@ const connectorMethods = function connectorMethods(instance) {
     updateEmailBranding,
     toggleBlockPrepaidCards,
     toggleMotoPayments,
-    toggleAllowTelephonePaymentNotifications
+    toggleAllowTelephonePaymentNotifications,
+    updateStripeSetupValues
   }
 }
 

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -109,6 +109,14 @@ async function createTestGatewayAccount(serviceId: string, serviceName: string, 
     const gatewayAccountIdDerived = String(cardAccount.gateway_account_id)
     logger.info(`Created new Gateway Account ${gatewayAccountIdDerived}`)
 
+    await Connector.updateStripeSetupValues(gatewayAccountIdDerived, [
+        'bank_account', 
+        'company_number',
+        'responsible_person',
+        'vat_number'
+    ])
+    logger.info(`Set Stripe setup values to 'true' for Stripe test Gateway Account ${gatewayAccountIdDerived}`) 
+
     // connect system linked services to the created account
     await AdminUsers.updateServiceGatewayAccount(serviceId, gatewayAccountIdDerived)
     logger.info(`Service ${serviceId} linked to new Gateway Account ${gatewayAccountIdDerived}`)


### PR DESCRIPTION
with @SandorArpa

-  When creating a Stripe test account, we want all the Stripe setup values
   to be true.  So that in Self service there are no banner messages shown
   telling the user add extra Stripe info - e.g. bank account, VAT number.