### PR TITLE
PP-7710 Add ‘Toggle agent-initiated MOTO payments enabled flag’ button

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -227,6 +227,18 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.patch(path, payload).then(utilExtractData)
   }
 
+  const toggleAgentInitiatedMotoEnabledFlag = async function toggleAgentInitiatedMotoEnabledFlag(serviceId) {
+    const path = `v1/api/services/${serviceId}`
+    const targetService = await service(serviceId)
+
+    const payload = {
+      op: 'replace',
+      path: 'agent_initiated_moto_enabled',
+      value: !targetService.agent_initiated_moto_enabled
+    }
+    return axiosInstance.patch(path, payload).then(utilExtractData)
+  }
+
   return {
     user,
     findUser,
@@ -247,6 +259,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     resetUserSecondFactor,
     toggleTerminalStateRedirectFlag,
     toggleExperimentalFeaturesEnabledFlag,
+    toggleAgentInitiatedMotoEnabledFlag,
     adminEmailsForGatewayAccounts
   }
 }

--- a/src/lib/pay-request/types/adminUsers.ts
+++ b/src/lib/pay-request/types/adminUsers.ts
@@ -15,6 +15,8 @@ export interface Service {
 
   experimental_features_enabled: boolean;
 
+  agent_initiated_moto_enabled: boolean;
+
   internal: boolean;
 
   archived: boolean;

--- a/src/web/modules/gateway_accounts/csv.ts
+++ b/src/web/modules/gateway_accounts/csv.ts
@@ -78,6 +78,9 @@ const fields = [{
 }, {
   label: 'Has corporate card surcharge',
   value: 'corporate_surcharge'
+}, {
+  label: 'Agent-initated MOTO payments are enabled',
+  value: 'service.agent_initiated_moto_enabled'
 }]
 
 export function format(gatewayAccounts: any): string {

--- a/src/web/modules/gateway_accounts/csv_with_admin_emails.ts
+++ b/src/web/modules/gateway_accounts/csv_with_admin_emails.ts
@@ -81,6 +81,9 @@ const fields = [{
 }, {
   label: 'Has corporate card surcharge',
   value: 'corporate_surcharge'
+}, {
+  label: 'Agent-initated MOTO payments are enabled',
+  value: 'service.agent_initiated_moto_enabled'
 }]
 
 export function formatWithAdminEmails(gatewayAccounts: any): string {

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -22,6 +22,7 @@
       { key: { text: "Organisation" }, value: { text: service.merchant_details.name or "(Not set)" }, actions: { items: [{ href: "/services/" + service.external_id + "/organisation", text: "Change" }] } },
       { key: { text: "Go live status" }, value: { text: service.current_go_live_stage | upper } },
       { key: { text: "Redirect to service on terminal state" }, value: { text: service.redirect_to_service_immediately_on_terminal_state | string | capitalize } },
+      { key: { text: "Agent-initiated MOTO payments are enabled" }, value: { text: service.agent_initiated_moto_enabled | string | capitalize } },
       { key: { text: "Experimental features are enabled" }, value: { text: service.experimental_features_enabled | string | capitalize } }
     ]
     })
@@ -162,6 +163,18 @@
       text: "Toggle redirect to service on terminal state flag",
       classes: "govuk-button--warning",
       href: "/services/" + serviceId + "/toggle_terminal_state_redirect"
+      })
+    }}
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s">Toggle agent-initiated MOTO payments enabled flag</h1>
+    <p class="govuk-body">Enabling this flag for a service shows a ‘Take a telephone payment’ link on the admin tool dashboard if there is at least one agent-initiated MOTO product for the linked gateway account.</p>
+    <p class="govuk-body">It also allows administrators to assign users to the ‘View and take telephone payments’ and ‘View, refund and take telephone payments’ roles.</p>
+    <p class="govuk-body">Linked gateway accounts must have MOTO payments enabled or payment creation will fail.</p>
+    {{ govukButton({
+      text: "Toggle agent-initiated MOTO payments enabled flag",
+      href: "/services/" + serviceId + "/toggle_agent_initiated_moto_enabled"
       })
     }}
   </div>

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -20,6 +20,7 @@ export default {
   searchRequest: http.searchRequest,
   toggleTerminalStateRedirectFlag: http.toggleTerminalStateRedirectFlag,
   toggleExperimentalFeaturesEnabled: http.toggleExperimentalFeaturesEnabledFlag,
+  toggleAgentInitiatedMotoEnabled: http.toggleAgentInitiatedMotoEnabled,
   updateOrganisationForm: http.updateOrganisationForm,
   updateOrganisation: http.updateOrganisation
 }

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -187,6 +187,20 @@ const toggleExperimentalFeaturesEnabledFlag = async function toggleExperimentalF
   res.redirect(`/services/${serviceId}`)
 }
 
+const toggleAgentInitiatedMotoEnabledFlag = async function toggleAgentInitiatedMotoEnabledFlag(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const serviceId = req.params.id
+
+  const serviceResult = await AdminUsers.toggleAgentInitiatedMotoEnabledFlag(serviceId)
+  const { agent_initiated_moto_enabled: state } = serviceResult
+  logger.info(`Toggled agent-initiated MOTO enabled flag to ${state} for service ${serviceId}`, { externalId: serviceId })
+
+  req.flash('info', `Agent-initiated MOTO enabled flag set to ${state} for service`)
+  res.redirect(`/services/${serviceId}`)
+}
+
 interface RecoverContext {
   service: Service;
   csrf: string;
@@ -258,6 +272,7 @@ export default {
   searchRequest: wrapAsyncErrorHandler(searchRequest),
   toggleTerminalStateRedirectFlag: wrapAsyncErrorHandler(toggleTerminalStateRedirectFlag),
   toggleExperimentalFeaturesEnabledFlag: wrapAsyncErrorHandler(toggleExperimentalFeaturesEnabledFlag),
+  toggleAgentInitiatedMotoEnabled: wrapAsyncErrorHandler(toggleAgentInitiatedMotoEnabledFlag),
   updateOrganisationForm: wrapAsyncErrorHandler(updateOrganisationForm),
   updateOrganisation: wrapAsyncErrorHandler(updateOrganisation)
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -84,6 +84,7 @@ router.get('/services/:id/link_accounts', auth.secured, auth.administrative, ser
 router.post('/services/:id/link_accounts', auth.secured, auth.administrative, services.updateLinkAccounts.http, services.updateLinkAccounts.exceptions)
 router.get('/services/:id/toggle_terminal_state_redirect', auth.secured, services.toggleTerminalStateRedirectFlag)
 router.get('/services/:id/toggle_experimental_features_enabled', auth.secured, services.toggleExperimentalFeaturesEnabled)
+router.get('/services/:id/toggle_agent_initiated_moto_enabled', auth.secured, services.toggleAgentInitiatedMotoEnabled)
 router.get('/services/:id/organisation', auth.secured, services.updateOrganisationForm)
 router.post('/services/:id/organisation', auth.secured, services.updateOrganisation)
 


### PR DESCRIPTION
Add a button for toggling the `agent_initiated_moto_enabled` flag on a service.