### PR TITLE
PP-7711 Add ability to create AGENT_INITIATED_MOTO products

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-02-13T01:59:08Z",
+  "generated_at": "2021-02-26T11:50:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,7 +90,7 @@
       {
         "hashed_secret": "b7e04b33fdd186ab6bd2deace04ea6b551b9bd4a",
         "is_verified": false,
-        "line_number": 212,
+        "line_number": 216,
         "type": "Secret Keyword"
       }
     ],

--- a/src/lib/pay-request/api_utils/products.js
+++ b/src/lib/pay-request/api_utils/products.js
@@ -1,5 +1,5 @@
 import { EntityNotFoundError } from '../../errors'
-const { redactProductTokens } = require('./redact')
+const { redactProductTokensFromProducts, redactProductTokensFromPaymentLinksWithUsage } = require('./redact')
 
 const productsMethods = function productsMethods(instance) {
   const axiosInstance = instance || this
@@ -10,6 +10,17 @@ const productsMethods = function productsMethods(instance) {
       .then(utilExtractData)
   }
 
+  const paymentLinksByGatewayAccountAndType = function paymentLinksByGatewayAccountAndType(id, productType) {
+    const queryParams = {
+      params: {
+        type: productType
+      }
+    }
+    return axiosInstance.get(`/v1/api/gateway-account/${id}/products`, queryParams)
+      .then(utilExtractData)
+      .then(redactProductTokensFromProducts)
+   }
+
   const paymentLinksWithUsage = function paymentLinksWithUsage(gatewayAccountId) {
     const queryParams = {
       params: {
@@ -18,12 +29,18 @@ const productsMethods = function productsMethods(instance) {
     }
     return axiosInstance.get('/v1/api/stats/products', queryParams)
       .then(utilExtractData)
-      .then(redactProductTokens)
+      .then(redactProductTokensFromPaymentLinksWithUsage)
+  }
+
+  const createProduct = function createProduct(createProductRequest) {
+    return axiosInstance.post('/v1/api/products', createProductRequest).then(utilExtractData)
   }
 
   return {
     paymentLinksByGatewayAccount,
-    paymentLinksWithUsage
+    paymentLinksByGatewayAccountAndType,
+    paymentLinksWithUsage,
+    createProduct
   }
 }
 

--- a/src/lib/pay-request/api_utils/publicAuth.js
+++ b/src/lib/pay-request/api_utils/publicAuth.js
@@ -8,12 +8,16 @@ const publicAuthMethods = function publicAuthMethods(instance) {
       .then((data) => data.tokens)
   }
 
+  const createApiToken = function createApiToken(createTokenRequest) {
+    return axiosInstance.post('/v1/frontend/auth', createTokenRequest).then(utilExtractData)
+  }
+
   const deleteApiToken = function deleteApiToken(accountId, tokenId) {
     const payload = { token_link: tokenId }
     return axiosInstance.delete(`/v1/frontend/auth/${accountId}`, { data: payload })
   }
 
-  return { apiKeyTokens, deleteApiToken }
+  return { apiKeyTokens, createApiToken, deleteApiToken }
 }
 
 module.exports = publicAuthMethods

--- a/src/lib/pay-request/api_utils/redact.js
+++ b/src/lib/pay-request/api_utils/redact.js
@@ -1,8 +1,15 @@
-const redactProductTokens = function redactProductTokens(productResults) {
+const redactProductTokensFromPaymentLinksWithUsage = function redactProductTokens(productResults) {
   return productResults.map((productResult) => {
     delete productResult.product.pay_api_token
     return productResult
   })
 }
 
-module.exports = { redactProductTokens }
+const redactProductTokensFromProducts = function redactProductTokens(products) {
+  return products.map((product) => {
+    delete product.pay_api_token
+    return product
+  })
+}
+
+module.exports = { redactProductTokensFromPaymentLinksWithUsage, redactProductTokensFromProducts }

--- a/src/lib/pay-request/api_utils/redact.spec.js
+++ b/src/lib/pay-request/api_utils/redact.spec.js
@@ -1,20 +1,20 @@
 const chai = require('chai')
 const { expect } = chai
 
-const { redactProductTokens } = require('./redact')
+const { redactProductTokensFromPaymentLinksWithUsage } = require('./redact')
 const { paymentLinksListResponse } = require('./../../../tests/fixtures/paymentLink')
 
 describe('redaction utility for internal apis that cant be changed immediately', () => {
   describe('product api', () => {
     it('pay_api_token property is removed from all returned products', () => {
-      const redactedResultStream = redactProductTokens(paymentLinksListResponse)
+      const redactedResultStream = redactProductTokensFromPaymentLinksWithUsage(paymentLinksListResponse)
       expect(redactedResultStream[0].product.pay_api_token).to.equal(undefined)
       expect(redactedResultStream[1].product.pay_api_token).to.equal(undefined)
       expect(redactedResultStream[2].product.pay_api_token).to.equal(undefined)
     })
 
     it('returns the same empty list if nothing is returned from the server', () => {
-      const redactedResultStream = redactProductTokens([])
+      const redactedResultStream = redactProductTokensFromPaymentLinksWithUsage([])
       expect(redactedResultStream).to.deep.equal([])
     })
   })

--- a/src/lib/pay-request/types/products.ts
+++ b/src/lib/pay-request/types/products.ts
@@ -1,0 +1,17 @@
+export interface Product {
+  external_id: string;
+
+  name: string;
+
+  status: string;
+
+  type: string;
+
+  gateway_account_id: number;
+
+  reference_enabled: boolean;
+
+  reference_label: string;
+
+  language: string;
+}

--- a/src/web/modules/gateway_accounts/CreateAgentInitiatedMotoProductFormRequest.ts
+++ b/src/web/modules/gateway_accounts/CreateAgentInitiatedMotoProductFormRequest.ts
@@ -1,0 +1,33 @@
+import { MaxLength, IsNotEmpty, IsString } from 'class-validator'
+import Validated from '../common/validated'
+
+class CreateAgentInitiatedMotoProductFormRequest extends Validated {
+  @IsString()
+  @IsNotEmpty({ message: "Enter a payment description" })
+  @MaxLength(255, {message: "Payment description must be 255 characters or fewer" })
+  public name: string;
+
+  @IsString()
+  @MaxLength(255, {message: "Details must be 255 characters or fewer" })
+  public description: string;
+
+  @IsString()
+  @IsNotEmpty({ message: "Enter a name of reference" })
+  @MaxLength(50, {message: "Reference label must be 50 characters or fewer" })
+  public reference_label: string;
+
+  @IsString()
+  @MaxLength(255, {message: "Reference hint text must be 255 characters or fewer" })
+  public reference_hint: string;
+
+  public constructor(formValues: { [key: string]: string }) {
+    super()
+    this.name = formValues.name
+    this.description = formValues.description
+    this.reference_label = formValues.reference_label
+    this.reference_hint = formValues.reference_hint
+    this.validate()
+  }
+}
+
+export default CreateAgentInitiatedMotoProductFormRequest

--- a/src/web/modules/gateway_accounts/agent_initiated_moto.njk
+++ b/src/web/modules/gateway_accounts/agent_initiated_moto.njk
@@ -1,0 +1,148 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "common/errorSummary.njk" import errorSummary %}
+{% from "common/json.njk" import json %}
+{% extends "layout/layout.njk" %}
+
+{% set serviceName = service.service_name.en if account.gateway_account_id else "" %}
+
+{% block main %}
+  <span class="govuk-caption-m">
+    {% if account.gateway_account_id %}
+      <span>{{ serviceName }}</span>
+    {% else %}
+      <span>GOV.UK Pay platform</span>
+    {% endif %}
+  </span>
+
+  <h1 class="govuk-heading-m">Agent-initiated MOTO payments</h1>
+
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Associated gateway account {{serviceName}} ({{ account.gateway_account_id }})</a>
+  </div>
+
+  {% if errors %}
+    {{ errorSummary({ errors: errors }) }}
+  {% endif %}
+
+  <p class="govuk-body">
+    Agent-initiated MOTO payments (‘telephone payment links’) allow service users with appropriate permissions to take telephone payments using a link on the admin tool dashboard.
+  </p>
+
+  <p class="govuk-body">
+    For the link to appear and work, several things must be set up.
+  </p>
+
+  <h2 class="govuk-heading-s">The service must have agent-initated MOTO payments enabled</h2>
+  {% if service.agent_initiated_moto_enabled %}
+    <p class="govuk-body">Agent-initiated MOTO payments are enabled for this service.</p>
+  {% else %}
+    <p class="govuk-body">Agent-initiated MOTO payments are disabled for this service.</p>
+  {% endif %}
+
+  <h2 class="govuk-heading-s">The gateway account must have MOTO enabled</h2>
+  {% if account.allow_moto %}
+    <p class="govuk-body">MOTO is enabled for this gateway account.</p>
+  {% else %}
+    <p class="govuk-body">MOTO is disabled for this gateway account.</p>
+    {{ govukWarningText({
+      text: "If you complete the other steps but do not enable MOTO for the gateway account, the link will appear but payments will not create successfully.",
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
+
+  <h2 class="govuk-heading-s">An agent-initiated MOTO product must exist</h2>
+
+  {% if products.length === 0 %}
+    <p class="govuk-body">There are no agent-initiated MOTO products. Why don’t you create one?</p>
+  {% elif products.length === 1 %}
+    <p class="govuk-body">There is 1 agent-initiated MOTO product.</p>
+    {{ govukWarningText({
+      text: "Only the first agent-initiated MOTO product is used, so you probably do not want to create another.",
+      iconFallbackText: "Warning"
+    }) }}
+  {% else %}
+    <p class="govuk-body">There is {{ products | length }} agent-initiated MOTO products.</p>
+    {{ govukWarningText({
+      text: "Only the first agent-initiated MOTO product is used so something probably is not right here.",
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
+
+  <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/agent_initiated_moto">
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+
+    {{ govukInput({
+      id: "name",
+      name: "name",
+      label: { 
+        text: "Payment description",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Shown to the agent while taking the payment and included in the payment confirmation email sent to the paying user. "
+      },
+      spellcheck: true,
+      value: formValues.name,
+      errorMessage: errorMap.name and { text: errorMap.name }
+    }) }}
+
+    {{ govukCharacterCount({
+      id: "description",
+      name: "description",
+      maxlength: 255,
+      label: {
+        text: "Details (optional)",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Shown to the agent at the beginning of the payment process."
+      },
+      spellcheck: true,
+      value: formValues.description,
+      errorMessage: errorMap.description and { text: errorMap.description }
+    }) }}
+
+    {{ govukInput({
+      id: "reference_label",
+      name: "reference_label",
+      label: { 
+        text: "Name of the reference",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Shown to the agent at the point they need to enter the paying user’s reference. For example, ‘Invoice number’ ."
+      },
+      spellcheck: true,
+      value: formValues.reference_label,
+      errorMessage: errorMap.reference_label and { text: errorMap.reference_label }
+    }) }}
+
+    {{ govukCharacterCount({
+      id: "reference_hint",
+      name: "reference_hint",
+      maxlength: 255,
+      label: {
+        text: "Reference hint text (optional)",
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Shown to the agent at the point they need to enter the paying user’s reference. This could describe what the payment reference looks like and where the paying user can find it."
+      },
+      spellcheck: true,
+      value: formValues.reference_hint,
+      errorMessage: errorMap.reference_hint and { text: errorMap.reference_hint }
+    }) }}
+
+
+  {{ govukButton({
+    text: "Create product"
+    }) }}
+  </form>
+
+  {{ json("Agent-initiated MOTO products source", products) }}
+
+{% endblock %}

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -204,6 +204,11 @@
         href: "/gateway_accounts/" + gatewayAccountId + "/email_branding"
       })
       }}
+      {{ govukButton({
+        text: "Configure agent-initiated MOTO payments",
+        href: "/gateway_accounts/" + gatewayAccountId + "/agent_initiated_moto"
+      })
+      }}
    {% endif %}
   </div>
 

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -36,5 +36,7 @@ export default {
   updateStripePayoutDescriptorPage: http.updateStripePayoutDescriptorPage,
   updateStripePayoutDescriptor: http.updateStripePayoutDescriptor,
   search: http.search,
-  searchRequest: http.searchRequest
+  searchRequest: http.searchRequest,
+  agentInitiatedMotoPage: http.agentInitiatedMotoPage,
+  createAgentInitiatedMotoProduct: http.createAgentInitiatedMotoProduct
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -68,6 +68,8 @@ router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, ga
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptor)
+router.get('/gateway_accounts/:id/agent_initiated_moto', auth.secured, gatewayAccounts.agentInitiatedMotoPage)
+router.post('/gateway_accounts/:id/agent_initiated_moto', auth.secured, gatewayAccounts.createAgentInitiatedMotoProduct)
 
 router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)


### PR DESCRIPTION
Add a page in toolbox to allow us to create an `AGENT_INITIATED_MOTO` product for a gateway account (along with an API key for it).

![image](https://user-images.githubusercontent.com/24316348/109298550-ad383180-782b-11eb-8cd4-5d3d094bc826.png)