### PR TITLE
PP-7906 Validate and document reproject_domain_object column header

### DIFF
--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -18,7 +18,8 @@ type TransactionRow = {
   captured_date?: string, 
   refund_status?: string, 
   refund_amount_refunded?: string, 
-  refund_amount_available?: string 
+  refund_amount_available?: string,
+  reproject_domain_object?: string
 }
 
 export async function fileUpload(req: Request, res: Response): Promise<void> {
@@ -153,29 +154,35 @@ const validateAndAddDefaults = async function validateAndAddDefaults(csv: string
           return cb(null, false, 'captured_date is not a valid ISO_8601 string')
         }
 
-        if (row.refund_amount_refunded && !(parseInt(row.refund_amount_refunded) >= 0)){
+        if (row.refund_amount_refunded && !(parseInt(row.refund_amount_refunded) >= 0)) {
           return cb(null, false, 'refund_amount_refunded must be a number')
         }
 
-        if (row.refund_amount_available && !(parseInt(row.refund_amount_available) >= 0)){
+        if (row.refund_amount_available && !(parseInt(row.refund_amount_available) >= 0)) {
           return cb(null, false, 'refund_amount_available must be a number')
         }
 
         if (row.event_name === 'PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN') {
-          if (!row.captured_date){
+          if (!row.captured_date) {
             return cb(null, false, `captured_date is required when event_name is '${row.event_name}'`)
           }
           
-          if (!row.refund_status){
+          if (!row.refund_status) {
             return cb(null, false, `refund_status is required when event_name is '${row.event_name}'`)
           }
 
-          if (!row.refund_amount_refunded){
+          if (!row.refund_amount_refunded) {
             return cb(null, false, `refund_amount_refunded is required when event_name is '${row.event_name}'`)
           }
 
-          if (!row.refund_amount_available){
+          if (!row.refund_amount_available) {
             return cb(null, false, `refund_amount_available is required when event_name is '${row.event_name}'`)
+          }
+        }
+
+        if (row.reproject_domain_object) {
+          if (!['true', 'false'].includes(row.reproject_domain_object)) {
+            return cb(null, false, 'reproject_domain_object must be one of \'true\' or \'false\'')
           }
         }
 

--- a/src/web/modules/transactions/update/upload.njk
+++ b/src/web/modules/transactions/update/upload.njk
@@ -79,6 +79,10 @@
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">parent_transaction_id</span></th>
           <td class="govuk-table__cell">Required for refunds only, this is the payment external ID.</td>
         </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">reproject_domain_object</span></th>
+          <td class="govuk-table__cell">Whether the event should cause the domain object to be re-projected from previous events, one of ‘true’ or ‘false’. If true, no event will be persisted to the ledger database and any transaction data provided for the row in the CSV will be ignored.</td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
Add validation to the transaction update tool to ensure that the value given for the optional `reproject_domain_object` column in the CSV is one of "true" or "false".

Provide instructions for use of the `reproject_domain_object` header in the update transactions CSV.