### PR TITLE
BAU Warn user if service hasn't requested stripe test account

### DIFF
--- a/src/web/modules/stripe/basic/confirm-create-test-account.njk
+++ b/src/web/modules/stripe/basic/confirm-create-test-account.njk
@@ -1,6 +1,7 @@
 {% extends "layout/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block main %}
   <div class="govuk-body">
@@ -19,6 +20,13 @@
     ]
     })
   }}
+
+  {% if not stripeTestAccountRequested %}
+    {{ govukWarningText({
+      text: "This service has not requested a Stripe test account using the self service tool",
+      iconFallbackTest: "Warning"
+    }) }}
+  {% endif %}
 
   <form method="POST" action="/stripe/basic/create-test-account">
     <p class="govuk-body">You are about to create a Stripe account for the service. This will create:</p>

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -34,15 +34,12 @@ const createTestAccount = async function createTestAccount(req: Request, res: Re
     const serviceExternalId = req.query.service as string
     const service: Service = await AdminUsers.service(serviceExternalId)
 
-    const context: {
-        systemLinkService: string; serviceName: string;
-        csrf: string;
-        flash: object
-    } = {
+    const context = {
         systemLinkService: serviceExternalId,
         serviceName: service.service_name.en,
         csrf: req.csrfToken(),
-        flash: req.flash()
+        flash: req.flash(),
+        stripeTestAccountRequested: service.current_psp_test_account_stage === 'REQUEST_SUBMITTED'
     }
 
     return res.render('stripe/basic/confirm-create-test-account', context)
@@ -97,12 +94,12 @@ async function createTestGatewayAccount(serviceId: string, serviceName: string, 
     logger.info(`Created new Gateway Account ${gatewayAccountIdDerived}`)
 
     await Connector.updateStripeSetupValues(gatewayAccountIdDerived, [
-        'bank_account', 
+        'bank_account',
         'company_number',
         'responsible_person',
         'vat_number'
     ])
-    logger.info(`Set Stripe setup values to 'true' for Stripe test Gateway Account ${gatewayAccountIdDerived}`) 
+    logger.info(`Set Stripe setup values to 'true' for Stripe test Gateway Account ${gatewayAccountIdDerived}`)
 
     // connect system linked services to the created account
     await AdminUsers.updateServiceGatewayAccount(serviceId, gatewayAccountIdDerived)


### PR DESCRIPTION
Add a non-blocking warning as a reminder to developers/ admins when
adding a test account to a service.

This isn't intended to block the process but should hopefully catch
mistakes if the wrong service is selected.

![Screenshot 2021-03-31 at 12 16 02](https://user-images.githubusercontent.com/2844572/113136492-58694b80-921b-11eb-81cb-82477bd59f0e.png)
