### PR TITLE
PP-7931 Generate performance page HTML

### DIFF
--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -45,6 +45,9 @@
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/platform/dashboard/live">Dashboard</a>
             </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/performance-page">Performance page</a>
+            </li>
           </ul>
 
           <h4 class="govuk-heading-s app-subnav__header">Transactions</h4>

--- a/src/web/modules/services/getFilteredServices.ts
+++ b/src/web/modules/services/getFilteredServices.ts
@@ -1,0 +1,32 @@
+import { BooleanFilterOption } from '../common/BooleanFilterOption'
+import { Service, User } from '../../../lib/pay-request/types/adminUsers'
+import { AdminUsers } from '../../../lib/pay-request'
+
+export interface ServiceFilters {
+  live: BooleanFilterOption;
+  internal: BooleanFilterOption;
+  archived: BooleanFilterOption;
+}
+
+function serviceAttributeMatchesFilter(filterValue: BooleanFilterOption, serviceValue: Boolean) {
+  return filterValue === BooleanFilterOption.True && serviceValue ||
+    filterValue === BooleanFilterOption.False && !serviceValue ||
+    filterValue === BooleanFilterOption.All
+}
+
+export async function fetchAndFilterServices(filters: ServiceFilters): Promise<Service[]> {
+  const services: Service[] = await AdminUsers.services()
+  return services.filter(service =>
+    serviceAttributeMatchesFilter(filters.live, service.current_go_live_stage === 'LIVE')
+    && serviceAttributeMatchesFilter(filters.internal, service.internal)
+    && serviceAttributeMatchesFilter(filters.archived, service.archived)
+  )
+}
+
+export async function getLiveNotArchivedServices() {
+  return await fetchAndFilterServices({
+    live: BooleanFilterOption.True,
+    internal: BooleanFilterOption.False,
+    archived: BooleanFilterOption.False
+  })
+}

--- a/src/web/modules/statistics/performance.http.ts
+++ b/src/web/modules/statistics/performance.http.ts
@@ -1,0 +1,160 @@
+import { Request, Response } from 'express'
+import moment from 'moment'
+import { Service } from '../../../lib/pay-request/types/adminUsers'
+import { getLiveNotArchivedServices } from '../services/getFilteredServices'
+
+export async function overview(req: Request, res: Response) {
+  res.render('statistics/performancePage')
+}
+
+export async function getPerformancePageHtml(req: Request, res: Response) {
+  const services = await getLiveNotArchivedServices()
+  const countBySector = services.reduce((aggregate: { [key: string]: number; }, service: Service) => {
+    const sector = service.sector
+    aggregate[sector] = aggregate[sector] + 1 || 1
+    return aggregate
+  }, {})
+  const countByOrganisation = services.reduce((aggregate: { [key: string]: number; }, service: Service) => {
+    const org = service.merchant_details && service.merchant_details.name
+    if (org) {
+      aggregate[org] = aggregate[org] + 1 || 1
+    }
+    return aggregate
+  }, {})
+
+  const organisationTableRows = Object.keys(countByOrganisation).sort().reduce((aggregate: string, organisation: string) => {
+    const count = countByOrganisation[organisation]
+    return aggregate + `<tr class="govuk-table__row">
+    <td class="govuk-table__cell">
+        ${organisation}
+    </td>
+    <td class="govuk-table__cell">${count}</td>
+</tr>
+`
+  }, '')
+
+  const numberOfOrganisations = Object.keys(countByOrganisation).length
+  const date = moment().format('D MMMM YYYY')
+
+  const html = `<main class="govuk-main-wrapper govuk-!-margin-top-4">
+  <div class="govuk-grid-row  govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Performance data</h1>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">
+              Since September 2016
+          </h2>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-third">
+          <div class="govuk-heading-xl govuk-!-margin-bottom-0">${services.length}</div>
+          <div class="govuk-body">live services</div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+          <div class="govuk-heading-xl govuk-!-margin-bottom-0">X million</div>
+          <div class="govuk-body">total transactions processed</div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+          <div class="govuk-heading-xl govuk-!-margin-bottom-0">&#163; X million</div>
+          <div class="govuk-body">total amount processed by Pay</div>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <div class="govuk-body-s">Last updated: ${date}</div>
+      </div>
+  </div>
+
+  <div class="product-page-!-border-bottom govuk-!-margin-bottom-8"></div>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <table class="govuk-table govuk-!-margin-bottom-9">
+              <caption class="govuk-visually-hidden">Sectors using pay</caption>
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Sector type</th>
+                  <th scope="col" class="govuk-table__header">Number of live services</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Central government, including devolved administrations, arms length
+                      bodies
+                      and executive agencies
+                  </td>
+                  <td class="govuk-table__cell">${countBySector['central']}</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Local government</td>
+                  <td class="govuk-table__cell">${countBySector['local']}</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Central NHS</td>
+                  <td class="govuk-table__cell">${countBySector['nhs central']}</td>
+              </tr>
+
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">NHS Trust</td>
+                  <td class="govuk-table__cell">${countBySector['nhs trust']}</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Police</td>
+                  <td class="govuk-table__cell">${countBySector['police']}</td>
+              </tr>
+              </tbody>
+          </table>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Organisations using GOV.UK Pay</h2>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+          <span class="govuk-visually-hidden">There are</span>
+          <div class="govuk-heading-xl govuk-!-margin-bottom-0">${numberOfOrganisations}</div>
+          <div class="govuk-body">organisations</div>
+      </div>
+      <div class="govuk-grid-column-one-half">
+          <span class="govuk-visually-hidden">and</span>
+          <div class="govuk-heading-xl govuk-!-margin-bottom-0">${services.length}</div>
+          <div class="govuk-body">services</div>
+      </div>
+  </div>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <table class="govuk-table govuk-!-margin-top-4">
+              <caption class="govuk-visually-hidden">Live services per organisation</caption>
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Organisations</th>
+                  <th scope="col" class="govuk-table__header">Number of live services</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                ${organisationTableRows}
+              </tbody>
+          </table>
+      </div>
+  </div>
+</main>
+`
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain',
+    'Content-Length': html.length,
+  });
+  res.end(html)
+}

--- a/src/web/modules/statistics/performancePage.njk
+++ b/src/web/modules/statistics/performancePage.njk
@@ -1,0 +1,32 @@
+{% extends "layout/layout.njk" %}
+{% block main %}
+  <h1 class="govuk-heading-m">Static performance data page</h1>
+  <p class="govuk-body">We host our performance data as a <a class="govuk-link" href="https://www.payments.service.gov.uk/performance">static page on the product pages</a>.</p>
+  <p class="govuk-body">To update this page:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      Copy the <a class="govuk-link govuk-link--no-visited-state" href="/statistics/performance-page-html">generated HTML</a>, which contains the latest statistics about services and organisations.
+    </li>
+    <li>
+      Replace the <i>&lsaquo;main&rsaquo;</i> element in the
+      <a class="govuk-link" href="https://github.com/alphagov/pay-product-page/blob/master/source/performance.html.erb">performance page source</a>
+      with the copied HTML
+    </li>
+    <li>
+      Update the numbers for the transaction volume and totals with numbers obtained by running the following SQL query against the ledger database:
+      <pre>
+SELECT 
+  COUNT(1), 
+  SUM(
+    CASE WHEN total_amount IS NULL 
+    THEN amount 
+    ELSE total_amount 
+    END) amount_in_pence
+FROM transaction
+WHERE type = 'PAYMENT'
+AND state = 'SUCCESS'
+AND live;
+  </pre>
+    </li>
+  </ul>
+{% endblock %}</p>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -22,6 +22,7 @@ const parity = require('./modules/transactions/discrepancies/validateLedger.http
 const platform = require('./modules/platform/dashboard.http')
 const paymentLinks = require('./modules/payment_links/payment_links.http')
 const ledgerPayouts = require('./modules/ledger_payouts/payout.http')
+const performance = require('./modules/statistics/performance.http')
 
 // @TODO(sfount) remove `default`s on update to import export syntax
 const users = require('./modules/users/users.http').default
@@ -44,6 +45,8 @@ router.get('/statistics/compare/date', auth.secured, statistics.compareFilterReq
 router.post('/statistics/compare/date', auth.secured, statistics.compareFilter)
 router.get('/statistics/services', auth.secured, statistics.csvServices)
 router.post('/statistics/services', auth.secured, statistics.byServices)
+router.get('/statistics/performance-page', auth.secured, performance.overview)
+router.get('/statistics/performance-page-html', auth.secured, performance.getPerformancePageHtml)
 
 router.get('/gateway_accounts', auth.secured, gatewayAccounts.overview)
 router.get('/gateway_accounts/csv', auth.secured, gatewayAccounts.listCSV)


### PR DESCRIPTION
Add a route to generate the HTML for the static performance page.

This generates the main body of the page and fills in the statistics about the services and organisations using Pay. This is returned as raw HTML to be copied into the product page file and released.

It leaves the payment statistics blank as these currently need to be queried directly from the database due to performance concerns.

Link to this page from a page containing instructions for updating the product page.