### PR TITLE
BAU Move Sentry error handling into app error handler

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,22 +1,11 @@
 /* eslint-disable max-classes-per-file */
 import { ValidationError as ClassValidatorError } from 'class-validator'
 import { AxiosError } from 'axios'
-
-// any error managed/ handled by the app (will not be thrown to upstream
-// services like Sentry)
-export class ManagedError extends Error {
-  public isManaged: boolean
-  public constructor(message: string, isManaged: boolean = true) {
-    super(message)
-    this.isManaged = isManaged
-  }
-}
-
-export class RequestError extends ManagedError {
+export class RequestError extends Error {
   public name: string
 
-  public constructor(message: string, isManaged?: boolean) {
-    super(message, isManaged)
+  public constructor(message: string) {
+    super(message)
     this.name = this.constructor.name
     Error.captureStackTrace(this, this.constructor)
   }
@@ -25,15 +14,15 @@ export class RequestError extends ManagedError {
 export class EntityNotFoundError extends RequestError {
   public data: { name: string; identifier: string }
 
-  public constructor(name: string, identifier: string, description: string = 'ID', isManaged?: boolean) {
-    super(`${name} with ${description} ${identifier} was not found.`, isManaged)
+  public constructor(name: string, identifier: string, description: string = 'ID') {
+    super(`${name} with ${description} ${identifier} was not found.`)
     this.data = { name, identifier }
   }
 }
 
 // wrap errors from other frameworks in a format that this service can report on
 // @FIXME(sfount) stack trace isn't respected
-export class RESTClientError extends ManagedError {
+export class RESTClientError extends Error {
   public name: string
 
   public data: AxiosError
@@ -50,7 +39,7 @@ export class RESTClientError extends ManagedError {
 }
 
 // expects to be passed a class-validator ValidationError object
-export class IOValidationError extends ManagedError {
+export class IOValidationError extends Error {
   public source: ClassValidatorError[]
 
   public constructor(validations: ClassValidatorError[]) {
@@ -60,7 +49,7 @@ export class IOValidationError extends ManagedError {
   }
 }
 
-export class ValidationError extends ManagedError {
+export class ValidationError extends Error {
   public name: string
 
   public constructor(message: string) {
@@ -70,7 +59,7 @@ export class ValidationError extends ManagedError {
   }
 }
 
-export class NotImplementedError extends ManagedError {
+export class NotImplementedError extends Error {
   public name: string
 
   public constructor(message: string) {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -156,11 +156,6 @@ const configureSentry = function configureSentry() {
         }
       }
 
-      if (error && error.isManaged) {
-        // discard the event from going to Sentry if the app has already flagged
-        // this error as managed/ handled
-        return null
-      }
       return event
     }
   })
@@ -168,10 +163,6 @@ const configureSentry = function configureSentry() {
 
 const configureSentryRequestHandler = function configureSentryRequestHandler(instance) {
   instance.use(Sentry.Handlers.requestHandler())
-}
-
-const configureSentryErrorHandler = function configureSentryErrorHandler(instance) {
-  instance.use(Sentry.Handlers.errorHandler())
 }
 
 const readManifest = function readManifest(name) {
@@ -204,7 +195,6 @@ const configure = [
   configureServingPublicStaticFiles,
   configureTemplateRendering,
   configureRouting,
-  configureSentryErrorHandler,
   configureErrorHandling
 ]
 configure.map((config) => config(app))


### PR DESCRIPTION
Remove the `ManagedError` error design patter, favour moving capturing
exceptions into the app default error handler. This means that anything
that hasn't been handled further up the stack will eventually go to
Sentry unless it's filtered out by Sentry's rules (status code 4xx etc.)

This will need to happen in conjunction with team guidance on how to
capture Sentry exceptions where error are manually handled rather than
being passed down the middleware stack.