### PR TITLE
BAU Add exemption engine configuration to gateway accounts

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -170,6 +170,18 @@ const connectorMethods = function connectorMethods (instance) {
     return !gatewayAccount.allow_telephone_payment_notifications
   }
 
+  const toggleWorldpayExemptionEngine = async function toggleWorldpayExemptionEngine(id) {
+    const gatewayAccount = await account(id)
+    const url = `/v1/api/accounts/${gatewayAccount.gateway_account_id}`
+    const toggledValue = !(gatewayAccount.worldpay_3ds_flex && gatewayAccount.worldpay_3ds_flex.exemption_engine_enabled)
+    await axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'worldpay_exemption_engine_enabled',
+      value: toggledValue
+    })
+    return toggledValue
+  }
+
   return {
     performanceReport,
     gatewayAccountPerformanceReport,
@@ -194,7 +206,8 @@ const connectorMethods = function connectorMethods (instance) {
     toggleBlockPrepaidCards,
     toggleMotoPayments,
     toggleAllowTelephonePaymentNotifications,
-    updateStripeSetupValues
+    updateStripeSetupValues,
+    toggleWorldpayExemptionEngine
   }
 }
 

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -103,6 +103,13 @@
           <dd class="govuk-summary-list__value">{{ account.integration_version_3ds | string }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
+        {% if account.payment_provider === 'worldpay' %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Exemption Engine</dt>
+            <dd class="govuk-summary-list__value">{{ "Enabled" if account.worldpay_3ds_flex and account.worldpay_3ds_flex.exemption_engine_enabled else "Disabled" }}</dd>
+            <dd class="govuk-summary-list__actions"></dd>
+          </div>
+        {% endif %}
     {% endif %}
     {% if account.allow_apple_pay != undefined %}
         <div class="govuk-summary-list__row">
@@ -297,6 +304,28 @@
         <input type="hidden" name="_csrf" value="{{ csrf }}">
       </form>
     </div>
+  {% endif %}
+
+  {% if account.payment_provider === 'worldpay' %}
+    {% set 3dsFlexEnabled = account.worldpay_3ds_flex %}
+    {% set exemptionEngineEnabled = account.worldpay_3ds_flex and account.worldpay_3ds_flex.exemption_engine_enabled %}
+
+    {% set exemptionEngineHeader = "Worldpay Exemption Engine is enabled" if exemptionEngineEnabled else "Worldpay Exemption Engine is disabled" %}
+    {% set exemptionEngineAction = "Disable Worldpay Exemption Engine" if exemptionEngineEnabled else "Enable Worldpay Exemption Engine" %}
+
+    <div>
+      <h1 class="govuk-heading-s">{{ exemptionEngineHeader }}</h1>
+      <p class="govuk-body">The Worldpay Exemption Engine can only be enabled if the service has configured Worldpay 3DS Flex. This action will be requested by the service through support.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_worldpay_exemption_engine">
+        {{ govukButton({
+          text: exemptionEngineAction,
+          classes: "" if exemptionEngineEnabled else "govuk-button--warning"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+    <div>
   {% endif %}
 
   {{ json("Gateway account details source", account) }}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -293,6 +293,14 @@ const toggleMotoPayments = async function toggleMotoPayments(
   res.redirect(`/gateway_accounts/${id}`)
 }
 
+const toggleWorldpayExemptionEngine = async function toggleWorldpayExemptionEngine(req: Request, res: Response): Promise<void> {
+  const { id } = req.params
+
+  const result = await Connector.toggleWorldpayExemptionEngine(id)
+  req.flash('info', `Worldpay Exception Engine ${result ? 'enabled' : 'disabled' }`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
 const toggleAllowTelephonePaymentNotifications = async function toggleAllowTelephonePaymentNotifications(
   req: Request,
   res: Response
@@ -551,5 +559,6 @@ export default {
   search: wrapAsyncErrorHandler(search),
   searchRequest: wrapAsyncErrorHandler(searchRequest),
   agentInitiatedMotoPage: wrapAsyncErrorHandler(agentInitiatedMotoPage),
-  createAgentInitiatedMotoProduct: wrapAsyncErrorHandler(createAgentInitiatedMotoProduct)
+  createAgentInitiatedMotoProduct: wrapAsyncErrorHandler(createAgentInitiatedMotoProduct),
+  toggleWorldpayExemptionEngine: wrapAsyncErrorHandler(toggleWorldpayExemptionEngine)
 }

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -38,5 +38,6 @@ export default {
   search: http.search,
   searchRequest: http.searchRequest,
   agentInitiatedMotoPage: http.agentInitiatedMotoPage,
-  createAgentInitiatedMotoProduct: http.createAgentInitiatedMotoProduct
+  createAgentInitiatedMotoProduct: http.createAgentInitiatedMotoProduct,
+  toggleWorldpayExemptionEngine: http.toggleWorldpayExemptionEngine
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -67,6 +67,7 @@ router.get('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts
 router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccounts.updateEmailBranding)
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
 router.post('/gateway_accounts/:id/toggle_allow_telephone_payment_notifications', auth.secured, gatewayAccounts.toggleAllowTelephonePaymentNotifications)
+router.post('/gateway_accounts/:id/toggle_worldpay_exemption_engine', auth.secured, gatewayAccounts.toggleWorldpayExemptionEngine)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)


### PR DESCRIPTION
The Worldpay Exemption Engine configuration can be enabled and disabled
by the support role. This makes it available through the gateway
accounts tool.

Ideally support should not have to tunnel into production environments.

* Exposes `Exemption Engine` property on the top data definition list for
visibility
* Adds a tool with description to allow enabling and disabled the
exemption engine property