### PR TITLE
ZD-4531285 Add archive service button

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -239,6 +239,18 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     return axiosInstance.patch(path, payload).then(utilExtractData)
   }
 
+  const toggleArchiveService = async function toggleArchiveService(serviceId) {
+    const path = `v1/api/services/${serviceId}`
+    const targetService = await service(serviceId)
+
+    const payload = {
+      op: 'replace',
+      path: 'archived',
+      value: !targetService.archived
+    }
+    return axiosInstance.patch(path, payload).then(utilExtractData)
+  }
+
   return {
     user,
     findUser,
@@ -260,7 +272,8 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     toggleTerminalStateRedirectFlag,
     toggleExperimentalFeaturesEnabledFlag,
     toggleAgentInitiatedMotoEnabledFlag,
-    adminEmailsForGatewayAccounts
+    adminEmailsForGatewayAccounts,
+    toggleArchiveService
   }
 }
 

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -21,6 +21,7 @@
       { key: { text: "Name" }, value: { text: service.name } },
       { key: { text: "Organisation" }, value: { text: service.merchant_details.name or "(Not set)" }, actions: { items: [{ href: "/services/" + service.external_id + "/organisation", text: "Change" }] } },
       { key: { text: "Go live status" }, value: { text: service.current_go_live_stage | upper } },
+      { key: { text: "Archived" }, value: { text: service.archived | string | upper } },
       { key: { text: "Redirect to service on terminal state" }, value: { text: service.redirect_to_service_immediately_on_terminal_state | string | capitalize } },
       { key: { text: "Agent-initiated MOTO payments are enabled" }, value: { text: service.agent_initiated_moto_enabled | string | capitalize } },
       { key: { text: "Experimental features are enabled" }, value: { text: service.experimental_features_enabled | string | capitalize } }
@@ -230,15 +231,18 @@
   {% endif %}
 
   <div>
-    {% set archive_action_name = "Archive this service" if service.archived else "Un-archive this service" %}
+    {% set serviceActionName = "Un-archive this service" if service.archived else "Archive this service" %}
 
-    <h1 class="govuk-heading-s">{{ archive_action_name }}</h1>
-    <p class="govuk-body">Toggle the archived status of this service.</p>
+    <h1 class="govuk-heading-s">{{ serviceActionName }}</h1>
+    <p class="govuk-body">
+      Toggle the archived status of this service. Archived status will impact internal Pay team reports only. There is currently no change to the service user journey
+    </p>
+    <p class="govuk-body">This should not be used if you need to suspend a service</p>
     {{ govukButton({
-      text: archive_action_name,
+      text: serviceActionName,
       classes: "govuk-button--warning",
       href: "/services/" + serviceId + "/toggle_archived_status"
-    })
+    }) }}
   </div>
 
   {{ json("Service details source", service) }}

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -229,6 +229,18 @@
   </div>
   {% endif %}
 
+  <div>
+    {% set archive_action_name = "Archive this service" if service.archived else "Un-archive this service" %}
+
+    <h1 class="govuk-heading-s">{{ archive_action_name }}</h1>
+    <p class="govuk-body">Toggle the archived status of this service.</p>
+    {{ govukButton({
+      text: archive_action_name,
+      classes: "govuk-button--warning",
+      href: "/services/" + serviceId + "/toggle_archived_status"
+    })
+  </div>
+
   {{ json("Service details source", service) }}
   {{ json("Users details source", users) }}
 {% endblock %}

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -22,5 +22,6 @@ export default {
   toggleExperimentalFeaturesEnabled: http.toggleExperimentalFeaturesEnabledFlag,
   toggleAgentInitiatedMotoEnabled: http.toggleAgentInitiatedMotoEnabled,
   updateOrganisationForm: http.updateOrganisationForm,
-  updateOrganisation: http.updateOrganisation
+  updateOrganisation: http.updateOrganisation,
+  toggleArchiveService: http.toggleArchiveService
 }

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -235,6 +235,20 @@ const updateOrganisation = async function updateOrganisation(
   }
 }
 
+const toggleArchiveService = async function toggleArchiveService(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const serviceId = req.params.id
+
+  const serviceResult = await AdminUsers.toggleArchiveService(serviceId)
+  const { archived } = serviceResult
+  logger.info(`Toggled archive status to ${archived} for service ${serviceId}`, { externalId: serviceId })
+
+  req.flash('info', `Service archived status changed to ${archived} for service`)
+  res.redirect(`/services/${serviceId}`)
+}
+
 export default {
   overview: wrapAsyncErrorHandler(overview),
   listCsv: wrapAsyncErrorHandler(listCsv),
@@ -250,6 +264,7 @@ export default {
   toggleExperimentalFeaturesEnabledFlag: wrapAsyncErrorHandler(toggleExperimentalFeaturesEnabledFlag),
   toggleAgentInitiatedMotoEnabled: wrapAsyncErrorHandler(toggleAgentInitiatedMotoEnabledFlag),
   updateOrganisationForm: wrapAsyncErrorHandler(updateOrganisationForm),
-  updateOrganisation: wrapAsyncErrorHandler(updateOrganisation)
+  updateOrganisation: wrapAsyncErrorHandler(updateOrganisation),
+  toggleArchiveService: wrapAsyncErrorHandler(toggleArchiveService)
 }
 

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -90,6 +90,7 @@ router.post('/services/:id/link_accounts', auth.secured, auth.administrative, se
 router.get('/services/:id/toggle_terminal_state_redirect', auth.secured, services.toggleTerminalStateRedirectFlag)
 router.get('/services/:id/toggle_experimental_features_enabled', auth.secured, services.toggleExperimentalFeaturesEnabled)
 router.get('/services/:id/toggle_agent_initiated_moto_enabled', auth.secured, services.toggleAgentInitiatedMotoEnabled)
+router.get('/services/:id/toggle_archived_status', auth.secured, services.toggleArchiveService)
 router.get('/services/:id/organisation', auth.secured, services.updateOrganisationForm)
 router.post('/services/:id/organisation', auth.secured, services.updateOrganisation)
 


### PR DESCRIPTION
Currently to archive a service we have to make a SQL update via the production database.

To make developer's lives less stressful, we've added a simple toggle button in Toolbox to do this, in a similar way to the other toggle methods on the service page.

- Adds Archived status in the top info box
- Adds short description of the impact of archiving (i.e. only for reporting purposes)
- Calls Adminusers to make the change to the service.