### PR TITLE
PP-8026 - Send Ledger no timezone information for request for gateway monthly performance report

### DIFF
--- a/src/web/modules/statistics/statistics.http.js
+++ b/src/web/modules/statistics/statistics.http.js
@@ -147,7 +147,7 @@ const byServices = async function byServices (req, res, next) {
     res.write(parser.getHeader())
     res.flush()
 
-    const gatewayAccountReport = await Ledger.gatewayMonthlyPerformanceReport(fromDate.format(), toDate.format())
+    const gatewayAccountReport = await Ledger.gatewayMonthlyPerformanceReport(fromDate.format("YYYY-MM-DD"), toDate.format("YYYY-MM-DD"))
 
     // default 0 amounts for all months and all gateway accounts
     const report_schema = liveGatewayAccounts


### PR DESCRIPTION
Description:
- Ledger no longer processes timezones for gateway monthly performance report - see https://github.com/alphagov/pay-ledger/pull/1201