### PR TITLE
PP-8026 - Refactor performance report to send dates without timezone

### DIFF
--- a/browser/src/dashboard/ledgerResource.ts
+++ b/browser/src/dashboard/ledgerResource.ts
@@ -63,7 +63,7 @@ export async function fetchTransactionVolumesByHour(
 
 export async function fetchAggregateVolumes(date: moment.Moment, limitTime?: moment.Moment): Promise<AggregateVolumesResponse> {
   const timestamp = moment()
-  const limit = limitTime ? `&limit=${limitTime.format('YYYY-MM-DDTHH:mm:ss.SSSSSS')}Z` : ''
+  const limit = limitTime ? `&limit=${limitTime.format('YYYY-MM-DD')}` : ''
 
   const [ completedResponse, allResponse ] = await Promise.all([
     fetch(`/api/platform/aggregate?date=${date.utc().format()}&state=SUCCESS${limit}`),

--- a/src/web/modules/platform/dashboard.http.ts
+++ b/src/web/modules/platform/dashboard.http.ts
@@ -42,7 +42,6 @@ export async function timeseries(req: Request, res: Response, next: NextFunction
 
 export async function aggregate(req: Request, res: Response, next: NextFunction): Promise<void> {
   // limit expects an upper limit for the date provided - this can be to millisecond amount
-  // this should be an ISO formatted string that can be parsed by ZonedDateTime
   const { date, state, limit } = req.query
 
   try {
@@ -50,10 +49,10 @@ export async function aggregate(req: Request, res: Response, next: NextFunction)
 
     const toDate = limit && limit.length ?
       limit :
-      baseDate.utc().endOf('day').format()
+      baseDate.utc().endOf('day').format("YYY-MM-DD")
 
     const result = await Ledger.paymentVolumesAggregate(
-      baseDate.utc().startOf('day').format(),
+      baseDate.utc().startOf('day').format("YYYY-MM-DD"),
       toDate,
       state
     )


### PR DESCRIPTION
Description:
- Ledger` /performance-report` endpoint can only parse LocalDate so the corresponding call will only send LocalDate - see https://github.com/alphagov/pay-ledger/pull/1207