### PR TITLE
PP-8030 - Modify performance json to use Ledger numbers

### DIFF
--- a/src/web/modules/statistics/performance.http.ts
+++ b/src/web/modules/statistics/performance.http.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import moment from 'moment'
 import { Service } from '../../../lib/pay-request/types/adminUsers'
 import { getLiveNotArchivedServices } from '../services/getFilteredServices'
+import { Ledger } from '../../../lib/pay-request'
 
 export async function overview(req: Request, res: Response) {
   res.render('statistics/performancePage')
@@ -31,10 +32,12 @@ export async function downloadData(req: Request, res: Response) {
       return aggregate
     }, {})
 
+  const paymentStatistics = await Ledger.paymentStatistics()
+
   const data = {
     dateUpdated: moment().format('D MMMM YYYY'),
-    numberOfPayments: 'GET_DATA_FROM_QUERY',
-    totalPaymentAmount: 'GET_DATA_FROM_QUERY',
+    numberOfPayments: paymentStatistics.payments.count,
+    totalPaymentAmount: paymentStatistics.payments.gross_amount,
     numberOfServices: services.length,
     numberOfOrganisations: Object.keys(orderedCountByOrganisation).length,
     serviceCountBySector: countBySector,

--- a/src/web/modules/statistics/performancePage.njk
+++ b/src/web/modules/statistics/performancePage.njk
@@ -8,22 +8,6 @@
       Download the <a class="govuk-link govuk-link--no-visited-state" href="/statistics/performance-data">generated JSON data file</a>.
     </li>
     <li>
-      Update numberOfPayments and totalPaymentAmount with numbers obtained by running the following SQL query against the ledger database:
-      <pre>
-SELECT 
-  COUNT(1), 
-  SUM(
-    CASE WHEN total_amount IS NULL 
-    THEN amount 
-    ELSE total_amount 
-    END) amount_in_pence
-FROM transaction
-WHERE type = 'PAYMENT'
-AND state = 'SUCCESS'
-AND live IS TRUE;
-  </pre>
-    </li>
-    <li>
       Replace the 
       <a class="govuk-link" href="https://github.com/alphagov/pay-product-page/blob/master/data/performance.json">performance.json</a>
       data file in pay-product-page and deploy the product page.


### PR DESCRIPTION
Description:
- The performance data for number of transactions and total volume in the .json file can be queried from Ledger via the /transaction-summary endpoint
- This PR updates the code so that it is added into the .json file removing the need to query Ledger using the SQL on the page