### PR TITLE
PP-8026 - Performance data to use Ledger performance endpoint

### DIFF
--- a/src/web/modules/statistics/performance.http.ts
+++ b/src/web/modules/statistics/performance.http.ts
@@ -4,6 +4,11 @@ import { Service } from '../../../lib/pay-request/types/adminUsers'
 import { getLiveNotArchivedServices } from '../services/getFilteredServices'
 import { Ledger } from '../../../lib/pay-request'
 
+function displayAsMillion(amount: number) {
+    const stringOfAmount = (amount/1.0e6).toFixed(1) + " million";
+    return stringOfAmount;
+}
+
 export async function overview(req: Request, res: Response) {
   res.render('statistics/performancePage')
 }
@@ -32,12 +37,12 @@ export async function downloadData(req: Request, res: Response) {
       return aggregate
     }, {})
 
-  const paymentStatistics = await Ledger.paymentStatistics()
+  const paymentStatistics = await Ledger.paymentVolumesAggregate()
 
   const data = {
     dateUpdated: moment().format('D MMMM YYYY'),
-    numberOfPayments: paymentStatistics.payments.count,
-    totalPaymentAmount: paymentStatistics.payments.gross_amount,
+    numberOfPayments: displayAsMillion(paymentStatistics.total_volume),
+    totalPaymentAmount: displayAsMillion(paymentStatistics.total_amount),
     numberOfServices: services.length,
     numberOfOrganisations: Object.keys(orderedCountByOrganisation).length,
     serviceCountBySector: countBySector,


### PR DESCRIPTION
Description:
- Toolbox now uses the /performance-report Ledger endpoint for performance data
- Performance data json file now displays results in millions

JSON now displays as following:
`{
  "dateUpdated": "4 May 2021",
  "numberOfPayments": "1.2 million",
  "totalPaymentAmount": "123.5 million",
  "numberOfServices": 0,
  "numberOfOrganisations": 0,
  "serviceCountBySector": {},
  "serviceCountByOrganisation": {}
}`