### PR TITLE
PP-8026 Filter successful payments for performance data

### DIFF
--- a/src/web/modules/statistics/performance.http.ts
+++ b/src/web/modules/statistics/performance.http.ts
@@ -4,9 +4,17 @@ import { Service } from '../../../lib/pay-request/types/adminUsers'
 import { getLiveNotArchivedServices } from '../services/getFilteredServices'
 import { Ledger } from '../../../lib/pay-request'
 
-function displayAsMillion(amount: number) {
-    const stringOfAmount = (amount/1.0e6).toFixed(1) + " million";
-    return stringOfAmount;
+function convertToUnits(value: number) {
+  let stringOfAmount
+
+  if (value >= 1000000 && value < 1000000000) {
+    stringOfAmount = (value / 1.0e6).toFixed(1) + " million";
+  } else if (value >= 10000000) {
+    stringOfAmount = (value / 1.0e9).toFixed(1) + " billion";
+  } else
+    stringOfAmount = value.toString()
+
+  return stringOfAmount;
 }
 
 export async function overview(req: Request, res: Response) {
@@ -37,12 +45,12 @@ export async function downloadData(req: Request, res: Response) {
       return aggregate
     }, {})
 
-  const paymentStatistics = await Ledger.paymentVolumesAggregate()
+  const paymentStatistics = await Ledger.paymentVolumesAggregate(null, null, 'SUCCESS')
 
   const data = {
     dateUpdated: moment().format('D MMMM YYYY'),
-    numberOfPayments: displayAsMillion(paymentStatistics.total_volume),
-    totalPaymentAmount: displayAsMillion(paymentStatistics.total_amount),
+    numberOfPayments: convertToUnits(paymentStatistics.total_volume),
+    totalPaymentAmount: convertToUnits(paymentStatistics.total_amount / 100),
     numberOfServices: services.length,
     numberOfOrganisations: Object.keys(orderedCountByOrganisation).length,
     serviceCountBySector: countBySector,


### PR DESCRIPTION
## WHAT
- Changes to query ledger for successful payment volumes for performance data
- Extended method to convert units to billion which is fast approaching for total amount and total_amount is returned as pence so converted to pounds