### PR TITLE
BAU — Update agent-initiated MOTO form field hints

### DIFF
--- a/src/web/modules/gateway_accounts/agent_initiated_moto.njk
+++ b/src/web/modules/gateway_accounts/agent_initiated_moto.njk
@@ -83,7 +83,7 @@
         classes: "govuk-label--s"
       },
       hint: {
-        text: "Shown to the agent while taking the payment and included in the payment confirmation email sent to the paying user. "
+        text: "A description of the purpose of the payment. The agent sees the payment description while taking the payment and it is included in the payment confirmation email sent to the paying user. "
       },
       spellcheck: true,
       value: formValues.name,
@@ -99,7 +99,7 @@
         classes: "govuk-label--s"
       },
       hint: {
-        text: "Shown to the agent at the beginning of the payment process."
+        text: "Additional details about the payment. The agent sees these details at the beginning of the payment process."
       },
       spellcheck: true,
       value: formValues.description,
@@ -114,7 +114,7 @@
         classes: "govuk-label--s"
       },
       hint: {
-        text: "Shown to the agent at the point they need to enter the paying user’s reference. For example, ‘Invoice number’ ."
+        text: "The name that a service uses for their reference, such as ‘Invoice number’. The agent sees the reference name at the point they need to enter the paying user’s reference."
       },
       spellcheck: true,
       value: formValues.reference_label,
@@ -130,7 +130,7 @@
         classes: "govuk-label--s"
       },
       hint: {
-        text: "Shown to the agent at the point they need to enter the paying user’s reference. This could describe what the payment reference looks like and where the paying user can find it."
+        text: "Can be used to describe what the payment reference looks like and where a paying user can find it. The agent sees the reference hint text at the point they need to enter the paying user’s reference."
       },
       spellcheck: true,
       value: formValues.reference_hint,


### PR DESCRIPTION
Update the hint text for the form fields used to create an agent-initiated MOTO product (telephone payment link) to match those used in the team manual, which have the benefit of being reworded by a professional writer.