### PR TITLE
BAU Callout new services on the payments dashboard

### DIFF
--- a/browser/src/dashboard/EventCard.tsx
+++ b/browser/src/dashboard/EventCard.tsx
@@ -91,16 +91,20 @@ export class EventCard extends React.Component<EventCardProps, {}> {
     }
 
     let icon: JSX.Element
+    let recentTag: JSX.Element
 
     if (this.props.event.event_type === 'PAYMENT_CREATED') {
       icon = <CardImage image={paymentProviderIcon} />
     } else {
       icon = <CardIcon icon={statusIcon} />
     }
-
+    if (this.props.event.is_recent) {
+      recentTag = <div style={{ textAlign: 'left', marginBottom: '8px', marginLeft: '8px', marginTop: '16px' }}><span className="govuk-tag govuk-tag--blue">new service</span></div>
+    }
     return (
       <div>
         <OpacitySpring>
+          { recentTag }
           <div className="event-card govuk-!-margin-bottom-2" style={{ backgroundColor: profile.backgroundColour }}>
             <div style={{ textAlign: 'right', width: '100%' }}>
               <span className="govuk-body-s" style={{ color: profile.colour, opacity: 0.7 }}>

--- a/browser/src/dashboard/ledgerResource.ts
+++ b/browser/src/dashboard/ledgerResource.ts
@@ -29,7 +29,7 @@ export interface DailyVolumeReport {
 }
 
 export const cachedSuccess: {[ key: string]: boolean} = {}
-export let services: {[key: string]: string} = {}
+export let services: {[key: string]: { name: string, went_live_date?: string, is_recent?: boolean } } = {}
 
 export async function fetchTransactionVolumesByHour(
   date: moment.Moment,
@@ -103,7 +103,10 @@ export async function fetchEventTicker(fromDate: moment.Moment, toDate: moment.M
         return !cachedSuccess[event.resource_external_id]
       })
       .map((event: Event) => {
-        event.service_name = services[event.gateway_account_id]
+        const service = services[event.gateway_account_id]
+        event.service_name = service.name
+        event.went_live_date = service.went_live_date
+        event.is_recent = service.is_recent
         event.timestamp = moment(event.event_date).valueOf()
         event.historic = historicFetch
         event.key = event.resource_external_id + event.timestamp + event.event_type + event.historic

--- a/src/web/modules/platform/dashboard.http.ts
+++ b/src/web/modules/platform/dashboard.http.ts
@@ -78,10 +78,19 @@ export async function services(req: Request, res: Response, next: NextFunction):
     const services = await AdminUsers.services()
 
     const index = services.reduce((aggregate: any, service: any) => {
+      const now = moment()
+      if (service.went_live_date) {
+        const numberOfDaysOld = now.diff(moment(service.went_live_date), 'days')
+        service.is_recent = numberOfDaysOld < 30
+      }
       const mapped = {
         ...aggregate,
         ...service.gateway_account_ids.reduce((aggregate: any, accountId: string) => {
-          aggregate[accountId] = service.service_name.en
+          aggregate[accountId] = {
+            name: service.service_name.en,
+            went_live_date: service.went_live_date,
+            is_recent: service.is_recent
+          }
           return aggregate
         }, {})
       }

--- a/src/web/modules/transactions/types/ledger.ts
+++ b/src/web/modules/transactions/types/ledger.ts
@@ -71,6 +71,8 @@ export interface Event {
   payment_provider: string
   type: string,
   service_name?: string
+  went_live_date?: string
+  is_recent?: boolean
   card_brand?: string
   timestamp?: number
   historic?: boolean


### PR DESCRIPTION
Decorate service names that are passed to the browser with an
`is_recent` property if they have gone live within the last 30 days.

Callout recent services with a tag associated with each event.

<img width="362" alt="Screenshot 2021-05-21 at 18 43 31" src="https://user-images.githubusercontent.com/2844572/119178300-6beba280-ba65-11eb-87aa-39a613c715b2.png">
