### PR TITLE
PP-8192 Support accounts switching PSP

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -118,7 +118,7 @@ const connectorMethods = function connectorMethods (instance) {
     return axiosInstance.post('/v1/tasks/historical-event-emitter-by-date', null, { params })
   }
 
-  function parityCheck(startId, maxId, doNotReprocessValidRecords, parityCheckStatus, 
+  function parityCheck(startId, maxId, doNotReprocessValidRecords, parityCheckStatus,
     retryDelayInSeconds, recordType) {
     const params = {
       start_id: startId,
@@ -225,6 +225,23 @@ const connectorMethods = function connectorMethods (instance) {
     return toggledValue
   }
 
+  function addGatewayAccountCredentialsForSwitch(id, paymentProvider, credentials) {
+    const url = `/v1/api/accounts/${id}/credentials`
+    return axiosInstance.post(url, {
+      payment_provider: paymentProvider,
+      ...credentials && { credentials }
+    })
+  }
+
+  function enableSwitchFlagOnGatewayAccount(id) {
+    const url = `/v1/api/accounts/${id}`
+    return axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'provider_switch_enabled',
+      value: true
+    })
+  }
+
   return {
     performanceReport,
     gatewayAccountPerformanceReport,
@@ -254,7 +271,9 @@ const connectorMethods = function connectorMethods (instance) {
     toggleAllowTelephonePaymentNotifications,
     toggleSendPayerIpAddressToGateway,
     updateStripeSetupValues,
-    toggleWorldpayExemptionEngine
+    toggleWorldpayExemptionEngine,
+    addGatewayAccountCredentialsForSwitch,
+    enableSwitchFlagOnGatewayAccount
   }
 }
 

--- a/src/lib/pay-request/types/adminUsers.ts
+++ b/src/lib/pay-request/types/adminUsers.ts
@@ -27,7 +27,7 @@ export interface Service {
 
   created_date: string;
 
-  custom_branding: { 
+  custom_branding: {
     [key: string]: any;
    }
 
@@ -66,5 +66,5 @@ export interface User {
 
 export interface StripeAgreement {
   ip_address: string;
-  agreement_time: string;
+  agreement_time: string | number;
 }

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -216,6 +216,11 @@
         href: "/gateway_accounts/" + gatewayAccountId + "/agent_initiated_moto"
       })
       }}
+      {{ govukButton({
+        text: "Switch PSP",
+        href: "/gateway_accounts/" + gatewayAccountId + "/switch_psp"
+      })
+      }}
    {% endif %}
   </div>
 

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -1,0 +1,46 @@
+import { NextFunction, Request, Response } from 'express'
+import { Connector, AdminUsers } from '../../../../lib/pay-request'
+import AccountDetails from '../../stripe/basic/basicAccountDetails.model'
+import { setupProductionStripeAccount } from '../../stripe/basic/account'
+import { StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
+
+export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
+  const account = await Connector.accountWithCredentials(req.params.id)
+  const service = await AdminUsers.gatewayAccountServices(account.gateway_account_id)
+  res.render('gateway_accounts/switch_psp/switch_psp', { account, service, flash: req.flash(), csrf: req.csrfToken() })
+}
+
+export async function postSwitchPSP(req: Request, res: Response, next: NextFunction) {
+  const gatewayAccountId = req.params.id
+  let credentials: { stripe_account_id?: string }
+
+  try {
+    const service = await AdminUsers.gatewayAccountServices(gatewayAccountId)
+
+    if (!req.body.paymentProvider) {
+      req.flash('error', 'Payment provider is required')
+      return res.redirect(`/gateway_accounts/${gatewayAccountId}/switch_psp`)
+    }
+
+    if (req.body.paymentProvider === 'stripe') {
+      if (!req.body.statementDescriptor) {
+        req.flash('error', 'Statement descriptor is required for switching to Stripe')
+        return res.redirect(`/gateway_accounts/${req.params.id}/switch_psp`)
+      }
+      const accountDetails = new AccountDetails(req.body)
+      const ipAddress = (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].toString()) || (req.socket.remoteAddress && req.socket.remoteAddress.toString())
+      const switchProxyAgreement: StripeAgreement = { ip_address: ipAddress, agreement_time: Date.now() }
+      const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, switchProxyAgreement)
+      credentials = { stripe_account_id: stripeAccount.id }
+    }
+
+    await Connector.addGatewayAccountCredentialsForSwitch(gatewayAccountId, req.body.paymentProvider, credentials)
+    await Connector.enableSwitchFlagOnGatewayAccount(gatewayAccountId)
+
+    req.flash('info', 'Switching PSP enabled for gateway account')
+    res.redirect(`/gateway_accounts/${req.params.id}`)
+  } catch (error) {
+    req.flash('error', `Error during setup: ${error.message}`)
+    res.redirect(`/gateway_accounts/${req.params.id}/switch_psp`)
+  }
+}

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -1,0 +1,73 @@
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+  <span class="govuk-caption-m">{{ service.service_name and service.service_name.en }} ({{ account.payment_provider | capitalize }})
+  <h1 class="govuk-heading-m">Set up provider switching</h1>
+
+  <p class="govuk-body">You can set an account up for switching payment service provider.</p>
+
+  <p class="govuk-body">This will add a new credentials record to the account and enable the switching feature flag.</p>
+  <p class="govuk-body">The service should have been contacted and requested moving to a selected provider specifically.</p>
+
+  {% if account.provider_switch_enabled %}
+  {{ govukWarningText({
+    text: "This account is already flagged as switching payment service provider.",
+    iconFallbackText: "Warning"
+  }) }}
+  {% endif %}
+
+  {% if account.payment_provider === 'sandbox' %}
+  {{ govukWarningText({
+    text: "This is a sandbox account. Switching payment service provider is designed for live provider accounts.",
+    iconFallbackText: "Warning"
+  }) }}
+  {% endif %}
+
+  <form method="POST">
+    {% set statementDescriptorHtml %}
+      {{ govukInput({
+        id: "statementDescriptor",
+        name: "statementDescriptor",
+        classes: "govuk-!-width-one-third",
+        type: "text",
+        value: service.merchant_details and service.merchant_details.name,
+        label: {
+          text: "Statement descriptor"
+        },
+        hint: {
+          text: "This is the description to appear on a paying user's bank statement and is usally the name of the organisation accepting payments."
+        }
+      }) }}
+    {% endset %}
+    {{ govukRadios({
+      idPrefix: "paymentProvider",
+      name: "paymentProvider",
+      fieldset: {
+        legend: {
+          text: "Payment provider",
+          isPageHeading: false
+        }
+      },
+      hint: {
+        text: "The payment provider that the service will be moving to."
+      },
+      items: [
+        { value: "worldpay", text: "Worldpay", hint: { text: "Government Banking’s provider. The service needs an agreement with Government Banking to use their contract." } },
+        { value: "stripe", text: "Stripe", hint: { text: "GOV.UK Pay’s provider." }, conditional: { html: statementDescriptorHtml } }
+      ]
+    }) }}
+
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+    {{ govukButton({ text: "Enable provider switching" }) }}
+  </form>
+
+  <script src="/javascripts/govuk-frontend.js"></script>
+  <script>GOVUKFrontend.initAll()</script>
+{% endblock %}
+

--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -1,0 +1,57 @@
+import Stripe from 'stripe'
+import HTTPSProxyAgent from 'https-proxy-agent'
+import * as config from '../../../../config'
+import { AdminUsers } from '../../../../lib/pay-request'
+import AccountDetails from './basicAccountDetails.model'
+import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
+import { ValidationError as CustomValidationError } from '../../../../lib/errors'
+
+import logger from '../../../../lib/logger'
+const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
+const stripe = new Stripe(STRIPE_ACCOUNT_API_KEY)
+
+if (config.server.HTTPS_PROXY) {
+  // @ts-ignore
+  stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+}
+stripe.setApiVersion('2018-09-24')
+
+export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails): Promise<Stripe.accounts.IAccount> {
+  if (!STRIPE_ACCOUNT_API_KEY) {
+    throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
+  }
+  const service: Service = await AdminUsers.service(serviceExternalId)
+  if (!service.merchant_details) {
+    throw new CustomValidationError('Service has no organisation details set')
+  }
+
+  const stripeAgreement: StripeAgreement = await AdminUsers.serviceStripeAgreement(serviceExternalId)
+
+  logger.info('Requesting new Stripe account from stripe API')
+  const stripeAccount = await stripe.accounts.create({
+    type: 'custom',
+    country: 'GB',
+    business_name: service.merchant_details.name,
+    payout_statement_descriptor: stripeAccountDetails.statementDescriptor,
+    statement_descriptor: stripeAccountDetails.statementDescriptor,
+    support_phone: service.merchant_details.telephone_number,
+    legal_entity: {
+      type: 'government_agency',
+      business_name: service.merchant_details.name,
+      address: {
+        line1: service.merchant_details.address_line1,
+        line2: service.merchant_details.address_line2,
+        city: service.merchant_details.address_city,
+        postal_code: service.merchant_details.address_postcode,
+        country: service.merchant_details.address_country
+      },
+      additional_owners: ''
+    },
+    tos_acceptance: {
+      ip: stripeAgreement.ip_address,
+      date: Math.floor(new Date(stripeAgreement.agreement_time).getTime() / 1000)
+    }
+  })
+  logger.info(`Stripe API responded with success, account ${stripeAccount.id} created.`)
+  return stripeAccount
+}

--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -16,7 +16,7 @@ if (config.server.HTTPS_PROXY) {
 }
 stripe.setApiVersion('2018-09-24')
 
-export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails): Promise<Stripe.accounts.IAccount> {
+export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails, stripeAgreement: StripeAgreement): Promise<Stripe.accounts.IAccount> {
   if (!STRIPE_ACCOUNT_API_KEY) {
     throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
   }
@@ -24,8 +24,6 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
   if (!service.merchant_details) {
     throw new CustomValidationError('Service has no organisation details set')
   }
-
-  const stripeAgreement: StripeAgreement = await AdminUsers.serviceStripeAgreement(serviceExternalId)
 
   logger.info('Requesting new Stripe account from stripe API')
   const stripeAccount = await stripe.accounts.create({

--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -6,7 +6,7 @@ import { AdminUsers } from '../../../../lib/pay-request'
 import { ValidationError as CustomValidationError, IOValidationError } from '../../../../lib/errors'
 import { wrapAsyncErrorHandler } from '../../../../lib/routes'
 import { formatErrorsForTemplate, ClientFormError } from '../../common/validationErrorFormat'
-import { Service } from '../../../../lib/pay-request/types/adminUsers'
+import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
 import AccountDetails from './basicAccountDetails.model'
 import { setupProductionStripeAccount } from './account'
 const { StripeError } = Stripe.errors
@@ -78,7 +78,8 @@ const submitAccountCreate = async function submitAccountCreate(
     const service: Service = await AdminUsers.service(systemLinkService)
     const accountDetails: AccountDetails = new AccountDetails(req.body)
 
-    const stripeAccount = await setupProductionStripeAccount(systemLinkService, accountDetails)
+    const stripeAgreement: StripeAgreement = await AdminUsers.serviceStripeAgreement(systemLinkService)
+    const stripeAccount = await setupProductionStripeAccount(systemLinkService, accountDetails, stripeAgreement)
     res.render('stripe/success', { response: stripeAccount, systemLinkService, service })
   } catch (error) {
     let errors

--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -1,33 +1,20 @@
 import Stripe from 'stripe'
-import HTTPSProxyAgent from 'https-proxy-agent'
 import { Request, Response } from 'express'
 
 import logger from '../../../../lib/logger'
-import * as config from '../../../../config'
 import { AdminUsers } from '../../../../lib/pay-request'
 import { ValidationError as CustomValidationError, IOValidationError } from '../../../../lib/errors'
 import { wrapAsyncErrorHandler } from '../../../../lib/routes'
 import { formatErrorsForTemplate, ClientFormError } from '../../common/validationErrorFormat'
-import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
+import { Service } from '../../../../lib/pay-request/types/adminUsers'
 import AccountDetails from './basicAccountDetails.model'
-
-const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
-const stripe = new Stripe(STRIPE_ACCOUNT_API_KEY)
+import { setupProductionStripeAccount } from './account'
 const { StripeError } = Stripe.errors
-
-if (config.server.HTTPS_PROXY) {
-  // @ts-ignore
-  stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
-}
-stripe.setApiVersion('2018-09-24')
 
 const createAccountForm = async function createAccountForm(
   req: Request,
   res: Response
 ): Promise<void> {
-  if (!STRIPE_ACCOUNT_API_KEY) {
-    throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
-  }
   if (!req.query.service) {
     throw new CustomValidationError('Expected \'service\' query parameter')
   }
@@ -88,44 +75,10 @@ const submitAccountCreate = async function submitAccountCreate(
   const { systemLinkService } = req.body
 
   try {
+    const service: Service = await AdminUsers.service(systemLinkService)
     const accountDetails: AccountDetails = new AccountDetails(req.body)
 
-    const service: Service = await AdminUsers.service(systemLinkService)
-    if (!service.merchant_details) {
-      throw new CustomValidationError('Service has no organisation details set')
-    }
-
-    const stripeAgreement: StripeAgreement = await AdminUsers.serviceStripeAgreement(
-      systemLinkService
-    )
-
-    logger.info('Requesting new Stripe account from stripe API')
-    const stripeAccount = await stripe.accounts.create({
-      type: 'custom',
-      country: 'GB',
-      business_name: service.merchant_details.name,
-      payout_statement_descriptor: accountDetails.statementDescriptor,
-      statement_descriptor: accountDetails.statementDescriptor,
-      support_phone: service.merchant_details.telephone_number,
-      legal_entity: {
-        type: 'government_agency',
-        business_name: service.merchant_details.name,
-        address: {
-          line1: service.merchant_details.address_line1,
-          line2: service.merchant_details.address_line2,
-          city: service.merchant_details.address_city,
-          postal_code: service.merchant_details.address_postcode,
-          country: service.merchant_details.address_country
-        },
-        additional_owners: ''
-      },
-      tos_acceptance: {
-        ip: stripeAgreement.ip_address,
-        date: Math.floor(new Date(stripeAgreement.agreement_time).getTime() / 1000)
-      }
-    })
-    logger.info(`Stripe API responded with success, account ${stripeAccount.id} created.`)
-
+    const stripeAccount = await setupProductionStripeAccount(systemLinkService, accountDetails)
     res.render('stripe/success', { response: stripeAccount, systemLinkService, service })
   } catch (error) {
     let errors

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -11,6 +11,7 @@ const healthcheck = require('./../lib/healthcheck')
 const landing = require('./modules/landing/landing.http')
 const statistics = require('./modules/statistics/statistics.http')
 const gatewayAccounts = require('./modules/gateway_accounts').default
+const switchPSP = require('./modules/gateway_accounts/switch_psp/switch_psp.http')
 const services = require('./modules/services').default
 const charges = require('./modules/transactions/legacy')
 const discrepancies = require('./modules/discrepancies')
@@ -76,6 +77,8 @@ router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatew
 router.post('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptor)
 router.get('/gateway_accounts/:id/agent_initiated_moto', auth.secured, gatewayAccounts.agentInitiatedMotoPage)
 router.post('/gateway_accounts/:id/agent_initiated_moto', auth.secured, gatewayAccounts.createAgentInitiatedMotoProduct)
+router.get('/gateway_accounts/:id/switch_psp', auth.secured, switchPSP.switchPSPPage)
+router.post('/gateway_accounts/:id/switch_psp', auth.secured, switchPSP.postSwitchPSP)
 
 router.get('/gateway_accounts/:accountId/payment_links', auth.secured, paymentLinks.list)
 router.get('/gateway_accounts/:accountId/payment_links/csv', auth.secured, paymentLinks.listCSV)

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -45,11 +45,16 @@ const configureSecureHeaders = function configureSecureHeaders(instance) {
     hsts: false,
     xssFilter: false
   } : {}
+  const initGOVUKFrontendSnippet = '\'sha256-tqCUU2yHjDH9fiULK1QKKUFdNg//3tfcIB2bl/5yKI4=\''
   instance.use(helmet(helmetOptions))
   instance.use(helmet.contentSecurityPolicy({
     directives: {
       defaultSrc: [ '\'self\'' ],
-      scriptSrc: [ '\'self\'', '\'unsafe-eval\'' ],
+      scriptSrc: [
+        '\'self\'',
+        '\'unsafe-eval\'',
+        initGOVUKFrontendSnippet
+      ],
       imgSrc: [ '*.githubusercontent.com', '\'self\'', 'data:' ],
       styleSrc: [ '\'self\'', '\'unsafe-inline\'' ]
     }
@@ -74,6 +79,7 @@ const configureServingPublicStaticFiles = function configureServingPublicStaticF
   instance.use('/public', express.static(path.join(__dirname, '../public'), cache))
   instance.use('/assets/fonts', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/assets/fonts'), cache))
   instance.use('/images/favicon.ico', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/assets/images/', 'favicon.ico'), cache))
+  instance.use('/javascripts/govuk-frontend.js', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/all.js'), cache))
 }
 
 const configureClientSessions = function configureClientSessions(instance) {


### PR DESCRIPTION
Add page to configure card accounts for switching payment service provider.

- add helper methods for new connector endpoints
- separate out provisioning stripe production account so it can be used both by go live and switch psp routes
- add page controller and template for switching psp
- expose gov uk frontend JavaScripts to the browser to make use of conditional radios on the page

**Switch PSP page**

![Screenshot 2021-06-11 at 13 27 06](https://user-images.githubusercontent.com/2844572/121686939-b044ee00-cab9-11eb-9cba-7e389ff85f24.png)
 
**Stripe requires basic information not provided during initial go live**

![Screenshot 2021-06-11 at 13 27 19](https://user-images.githubusercontent.com/2844572/121686947-b33fde80-cab9-11eb-97df-7a503a3cf1c3.png)

**Warn about accounts that are already switching**

![Screenshot 2021-06-11 at 13 26 43](https://user-images.githubusercontent.com/2844572/121686958-b509a200-cab9-11eb-8d88-343ae654b8c3.png)

