### PR TITLE
PP-8192 Restrict account provider switching if already enabled

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -153,7 +153,12 @@
         <dd class="govuk-summary-list__actions"></dd>
       </div>
     {% endif %}
-  </dl>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Switching PSP</dt>
+        <dd class="govuk-summary-list__value">{{ 'Enabled' if account.provider_switch_enabled else 'Disabled' }}</dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+    </dl>
 
   <div>
     {{ govukButton({

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -15,10 +15,16 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
   let credentials: { stripe_account_id?: string }
 
   try {
+    const account = await Connector.accountWithCredentials(req.params.id)
     const service = await AdminUsers.gatewayAccountServices(gatewayAccountId)
 
     if (!req.body.paymentProvider) {
       req.flash('error', 'Payment provider is required')
+      return res.redirect(`/gateway_accounts/${gatewayAccountId}/switch_psp`)
+    }
+
+    if (account.provider_switch_enabled) {
+      req.flash('error', 'Cannot configure account that is already switching provider')
       return res.redirect(`/gateway_accounts/${gatewayAccountId}/switch_psp`)
     }
 


### PR DESCRIPTION
Add backend validation to top new credentials being added when the
account is already set up for switching. There is already a warning
but this should prevent any possibility of multiple non-terminal
(pre-ACTIVE) credentials existing on any given account.

Show the status of an accounts switching on the account detail page.