### PR TITLE
PP-8255 Toggle - For sending payer email to Worldpay for fraud protection

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -213,6 +213,17 @@ const connectorMethods = function connectorMethods (instance) {
     return !gatewayAccount.send_payer_ip_address_to_gateway
   }
 
+  async function toggleSendPayerEmailToGateway (id) {
+    const gatewayAccount = await accountWithCredentials(id)
+    const url = `/v1/api/accounts/${gatewayAccount.gateway_account_id}`
+    await axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'send_payer_email_to_gateway',
+      value: !gatewayAccount.send_payer_email_to_gateway
+    })
+    return !gatewayAccount.send_payer_email_to_gateway
+  }
+
   async function toggleWorldpayExemptionEngine(id) {
     const gatewayAccount = await account(id)
     const url = `/v1/api/accounts/${gatewayAccount.gateway_account_id}`
@@ -270,6 +281,7 @@ const connectorMethods = function connectorMethods (instance) {
     toggleMotoPayments,
     toggleAllowTelephonePaymentNotifications,
     toggleSendPayerIpAddressToGateway,
+    toggleSendPayerEmailToGateway,
     updateStripeSetupValues,
     toggleWorldpayExemptionEngine,
     addGatewayAccountCredentialsForSwitch,

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
 
@@ -316,7 +317,7 @@
     </div>
   {% endif %}
 
-    {% if account.send_payer_ip_address_to_gateway === true %}
+  {% if account.send_payer_ip_address_to_gateway === true %}
     <div>
       <h1 class="govuk-heading-s">Sending payer IP address to gateway is enabled</h1>
       <p class="govuk-body">If enabled, the paying user's IP address is sent to the payment gateway for fraud prevention purposes. This is not implemented for Stripe accounts.</p>
@@ -331,7 +332,7 @@
     </div>
   {% endif %}
 
-    {% if account.send_payer_ip_address_to_gateway === false %}
+  {% if account.send_payer_ip_address_to_gateway === false %}
     <div>
       <h1 class="govuk-heading-s">Enable sending payer IP address to gateway</h1>
       <p class="govuk-body">If enabled, the paying user's IP address is sent to the payment gateway for fraud prevention purposes. This is not implemented for Stripe accounts.</p>
@@ -346,6 +347,39 @@
       </form>
     </div>
   {% endif %}
+
+  <div>
+    <h1 class="govuk-heading-s">
+      {% if account.send_payer_email_to_gateway %}
+        Sending payer email to gateway is enabled
+      {% else %}
+        Enable sending payer email to gateway
+      {% endif %}
+    </h1>
+
+    <p class="govuk-body">If enabled, the paying user's email is sent to the payment gateway for fraud prevention purposes. This is not implemented for Stripe accounts.</p>
+
+    {{ govukWarningText({
+      text: "Ensure that the service does not have the setting enabled in Worldpay that will send emails to the payer.",
+      iconFallbackText: "Warning"
+    }) }}
+
+    <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_send_payer_email_to_gateway">
+      {% if account.send_payer_email_to_gateway %}
+        {{ govukButton({
+          text: "Disable sending payer email to gateway"
+          })
+        }}
+      {% else %}
+        {{ govukButton({
+          text: "Enable sending payer email to gateway",
+          classes: "govuk-button--warning"
+          })
+        }}
+      {% endif %}  
+      <input type="hidden" name="_csrf" value="{{ csrf }}">
+    </form>
+  </div>
 
   {% if account.payment_provider === 'worldpay' %}
     {% set 3dsFlexEnabled = account.worldpay_3ds_flex %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -323,6 +323,17 @@ async function toggleSendPayerIpAddressToGateway(
   res.redirect(`/gateway_accounts/${id}`)
 }
 
+async function toggleSendPayerEmailToGateway(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const { id } = req.params
+  const enabled = await Connector.toggleSendPayerEmailToGateway(id)
+
+  req.flash('info', `Sending payer email to gateway ${enabled ? 'enabled' : 'disabled'}`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
 async function updateStripeStatementDescriptorPage(
   req: Request,
   res: Response
@@ -564,6 +575,7 @@ export default {
   toggleMotoPayments: wrapAsyncErrorHandler(toggleMotoPayments),
   toggleAllowTelephonePaymentNotifications: wrapAsyncErrorHandler(toggleAllowTelephonePaymentNotifications),
   toggleSendPayerIpAddressToGateway: wrapAsyncErrorHandler(toggleSendPayerIpAddressToGateway),
+  toggleSendPayerEmailToGateway: wrapAsyncErrorHandler(toggleSendPayerEmailToGateway),
   updateStripeStatementDescriptorPage: wrapAsyncErrorHandler(updateStripeStatementDescriptorPage),
   updateStripeStatementDescriptor: wrapAsyncErrorHandler(updateStripeStatementDescriptor),
   updateStripePayoutDescriptorPage: wrapAsyncErrorHandler(updateStripePayoutDescriptorPage),

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -32,6 +32,7 @@ export default {
   toggleMotoPayments: http.toggleMotoPayments,
   toggleAllowTelephonePaymentNotifications: http.toggleAllowTelephonePaymentNotifications,
   toggleSendPayerIpAddressToGateway: http.toggleSendPayerIpAddressToGateway,
+  toggleSendPayerEmailToGateway: http.toggleSendPayerEmailToGateway,
   updateStripeStatementDescriptorPage: http.updateStripeStatementDescriptorPage,
   updateStripeStatementDescriptor: http.updateStripeStatementDescriptor,
   updateStripePayoutDescriptorPage: http.updateStripePayoutDescriptorPage,

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -70,6 +70,7 @@ router.post('/gateway_accounts/:id/email_branding', auth.secured, gatewayAccount
 router.post('/gateway_accounts/:id/toggle_moto_payments', auth.secured, gatewayAccounts.toggleMotoPayments)
 router.post('/gateway_accounts/:id/toggle_allow_telephone_payment_notifications', auth.secured, gatewayAccounts.toggleAllowTelephonePaymentNotifications)
 router.post('/gateway_accounts/:id/toggle_send_payer_ip_address_to_gateway', auth.secured, gatewayAccounts.toggleSendPayerIpAddressToGateway)
+router.post('/gateway_accounts/:id/toggle_send_payer_email_to_gateway', auth.secured, gatewayAccounts.toggleSendPayerEmailToGateway)
 router.post('/gateway_accounts/:id/toggle_worldpay_exemption_engine', auth.secured, gatewayAccounts.toggleWorldpayExemptionEngine)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)


### PR DESCRIPTION
- For the Gateway Detail page
  - Add `toggle` to send payer email to Worldpay
- Update router with new route to toggle sending payer email to Worldpay
- Update the gateway account module with new methods.
- Update connector util with new method to call new connector method to update this toggle.

## Toggle in FALSE state

![image](https://user-images.githubusercontent.com/59831992/122960311-347d5800-d37b-11eb-8f43-5ef9ca6a3cb6.png)

## Toggle in TRUE state

![image](https://user-images.githubusercontent.com/59831992/122960551-6d1d3180-d37b-11eb-9cbb-9322701df63d.png)
