### PR TITLE
PP-8280 Reduce authorised client session duration to 30 minutes

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -84,11 +84,11 @@ const configureServingPublicStaticFiles = function configureServingPublicStaticF
 
 const configureClientSessions = function configureClientSessions(instance) {
   const serverBehindProxy = server.HTTP_PROXY
-  const twelveHoursInMillis = 12 * 60 * 60 * 1000
+  const thirtyMinutesInMillis = 30 * 60 * 1000
   instance.use(sessions({
     cookieName: 'session',
     secret: server.COOKIE_SESSION_ENCRYPTION_SECRET,
-    duration: server.SESSION_COOKIE_DURATION_IN_MILLIS || twelveHoursInMillis,
+    duration: server.SESSION_COOKIE_DURATION_IN_MILLIS || thirtyMinutesInMillis,
     activeDuration: 5 * 60 * 1000,
     cookie: {
       secureProxy: serverBehindProxy


### PR DESCRIPTION
Following recommendation that a timeout of 15-30 minutes should be used
for data on this application, reduce the duration property for session
expiration.