### PR TITLE
BAU Remember and redirect to URL after authorisation

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -7,10 +7,14 @@ const { disableAuth } = require('./../config')
 // `secured` will be rejected without these headers.
 const secured = function secured(req, res, next) {
   if ((req.session && req.isAuthenticated()) || disableAuth) {
+    delete req.session.authBlockedRedirectUrl
     next()
     return
   }
   logger.info('Unauthenticated request to resource, redirecting to auth')
+  if (req.session) {
+    req.session.authBlockedRedirectUrl = req.originalUrl
+  }
   res.redirect('/auth')
 }
 

--- a/src/lib/auth.spec.js
+++ b/src/lib/auth.spec.js
@@ -25,10 +25,18 @@ describe('Authorisation middleware', () => {
     }
     const nextSpy = chai.spy()
 
+    requestMock.originalUrl = '/path/to/some/resource'
     requestMock.isAuthenticated = () => false
     auth.secured(requestMock, responseSpy, nextSpy)
 
+    expect(requestMock.session.authBlockedRedirectUrl).to.equal('/path/to/some/resource')
     expect(responseSpy.redirect).to.have.been.called.with('/auth')
+  })
+
+  it('secured middleware should clear redirect url on successful auth to avoid sessin pollution', () => {
+    requestMock.isAuthenticated = () => true
+    auth.secured(requestMock, chai.spy(), chai.spy())
+    expect(requestMock.session.authBlockedRedirectUrl).to.equal(undefined)
   })
 
   it('unauthorised HTTP route should reject with 403 given aunauthenticated request', () => {

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -35,7 +35,12 @@ const storage = multer.memoryStorage()
 const upload = multer({ storage })
 
 router.get('/auth', passport.authenticate('github'))
-router.get('/auth/github/callback', passport.authenticate('github', { failureRedirect: '/auth/unauthorised', successRedirect: '/' }))
+router.get('/auth/github/callback', (req, res, next) => {
+  passport.authenticate('github', {
+    failureRedirect: '/auth/unauthorised',
+    successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
+  })(req, res, next)
+})
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured, landing.root)


### PR DESCRIPTION
Store the URL being accessed when fetching tokens from GitHub to refresh
sessions. Redirect to this if authorisation is successful.

Add coverage for the session being cleared up to avoid session pollution.