### PR TITLE
PP-8218 Allow switch to setup stripe test accounts

### DIFF
--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -1,4 +1,3 @@
-import logger from '../../../../lib/logger'
 import { NextFunction, Request, Response } from 'express'
 import { Connector, AdminUsers } from '../../../../lib/pay-request'
 import AccountDetails from '../../stripe/basic/basicAccountDetails.model'
@@ -50,8 +49,7 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
           return res.redirect(`/gateway_accounts/${req.params.id}/switch_psp`)
         }
         const accountDetails = new AccountDetails(req.body)
-        const ipAddress = (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].toString()) || (req.socket.remoteAddress && req.socket.remoteAddress.toString())
-        const switchProxyAgreement: StripeAgreement = { ip_address: ipAddress, agreement_time: Date.now() }
+        const switchProxyAgreement: StripeAgreement = { ip_address: req.ip, agreement_time: Date.now() }
         const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, switchProxyAgreement)
         credentials = { stripe_account_id: stripeAccount.id }
       } else {
@@ -78,7 +76,6 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
       new_payment_provider: req.body.paymentProvider
     })
 
-    logger.info(`Switching PSP enabled for gateway account ${req.params.id}`)
     req.flash('info', 'Switching PSP enabled for gateway account')
     res.redirect(`/gateway_accounts/${req.params.id}`)
   } catch (error) {

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -1,9 +1,12 @@
+import logger from '../../../../lib/logger'
 import { NextFunction, Request, Response } from 'express'
 import { Connector, AdminUsers } from '../../../../lib/pay-request'
 import AccountDetails from '../../stripe/basic/basicAccountDetails.model'
 import { setupProductionStripeAccount } from '../../stripe/basic/account'
 import { StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
 import logger from "../../../../lib/logger";
+
+import stripeTestAccount from '../../stripe/basic/test-account.http'
 
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
   const account = await Connector.accountWithCredentials(req.params.id)
@@ -40,15 +43,29 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
     }
 
     if (req.body.paymentProvider === 'stripe') {
-      if (!req.body.statementDescriptor) {
-        req.flash('error', 'Statement descriptor is required for switching to Stripe')
-        return res.redirect(`/gateway_accounts/${req.params.id}/switch_psp`)
+      if (account.live) {
+        // use legacy production stripe account setup, not possible in non-live production environment
+        if (!req.body.statementDescriptor) {
+          req.flash('error', 'Statement descriptor is required for switching to Stripe')
+          return res.redirect(`/gateway_accounts/${req.params.id}/switch_psp`)
+        }
+        const accountDetails = new AccountDetails(req.body)
+        const ipAddress = (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].toString()) || (req.socket.remoteAddress && req.socket.remoteAddress.toString())
+        const switchProxyAgreement: StripeAgreement = { ip_address: ipAddress, agreement_time: Date.now() }
+        const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, switchProxyAgreement)
+        credentials = { stripe_account_id: stripeAccount.id }
+      } else {
+        // use new stripe account setup and fully configure it for
+        const stripeAccount = await stripeTestAccount.createStripeTestAccount(service.service_name.en)
+
+        await Connector.updateStripeSetupValues(account.gateway_account_id, [
+          'bank_account',
+          'company_number',
+          'responsible_person',
+          'vat_number'
+        ])
+        credentials = { stripe_account_id: stripeAccount.id }
       }
-      const accountDetails = new AccountDetails(req.body)
-      const ipAddress = (req.headers['x-forwarded-for'] && req.headers['x-forwarded-for'].toString()) || (req.socket.remoteAddress && req.socket.remoteAddress.toString())
-      const switchProxyAgreement: StripeAgreement = { ip_address: ipAddress, agreement_time: Date.now() }
-      const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, switchProxyAgreement)
-      credentials = { stripe_account_id: stripeAccount.id }
     }
 
     await Connector.enableSwitchFlagOnGatewayAccount(gatewayAccountId)
@@ -61,6 +78,7 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
       new_payment_provider: req.body.paymentProvider
     })
 
+    logger.info(`Switching PSP enabled for gateway account ${req.params.id}`)
     req.flash('info', 'Switching PSP enabled for gateway account')
     res.redirect(`/gateway_accounts/${req.params.id}`)
   } catch (error) {

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -3,8 +3,9 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-
 {% extends "layout/layout.njk" %}
+
+{% set isTestData = not account.live %}
 
 {% block main %}
   <span class="govuk-caption-m">{{ service.service_name and service.service_name.en }} ({{ account.payment_provider | capitalize }})

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -60,7 +60,7 @@
       },
       items: [
         { value: "worldpay", text: "Worldpay", hint: { text: "Government Banking’s provider. The service needs an agreement with Government Banking to use their contract." } },
-        { value: "stripe", text: "Stripe", hint: { text: "GOV.UK Pay’s provider." }, conditional: { html: statementDescriptorHtml } }
+        { value: "stripe", text: "Stripe", hint: { text: "GOV.UK Pay’s provider." }, conditional: { html: statementDescriptorHtml } if not isTestData }
       ]
     }) }}
 

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -127,5 +127,6 @@ async function createRepresentative(connectAccountId: string) {
 
 export default {
     createTestAccount: wrapAsyncErrorHandler(createTestAccount),
-    createTestAccountConfirm: wrapAsyncErrorHandler(createTestAccountConfirm)
+    createTestAccountConfirm: wrapAsyncErrorHandler(createTestAccountConfirm),
+    createStripeTestAccount
 }


### PR DESCRIPTION
Setup stripe test account if gateway acount is test, set all account
stripe flags to true as the admin tool currently has no way of
configuring stripe test accounts (access to test key etc.)

For production accounts, favour `req.ip` instead of manually parsing socket connection and
headers. `req.ip` will take the left most address if behind a proxy and
receiving multiple x-forwarded-for addresses.