### PR TITLE
PP-8438 Populate service ID when creating gateway account

### DIFF
--- a/src/lib/pay-request/types/connector.ts
+++ b/src/lib/pay-request/types/connector.ts
@@ -14,8 +14,10 @@ export interface GatewayAccountRequest {
   credentials?: object;
 
   sector: string,
-  
-  internalFlag: boolean
+
+  internalFlag: boolean,
+
+  service_id: string
 }
 
 export interface GatewayAccount {
@@ -57,7 +59,7 @@ export interface GatewayAccount {
     [key: string]: EmailNotificationSettings;
   };
 
-  notify_settings: { 
+  notify_settings: {
     [key: string]: any;
    }
 }

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -71,7 +71,9 @@ class GatewayAccount extends Validated {
   @IsNotEmpty({ message: 'Please select a sector' })
   public sector: string;
 
-  public internalFlag: boolean; 
+  public internalFlag: boolean;
+
+  public serviceId: string;
 
   public validate(): void {
     super.validate()
@@ -119,7 +121,8 @@ class GatewayAccount extends Validated {
       service_name: this.serviceName,
       analytics_id: this.analyticsId,
       sector: this.sector,
-      internalFlag: this.internalFlag
+      internalFlag: this.internalFlag,
+      service_id: this.serviceId
     }
 
     if (this.isLive() || this.provider === 'stripe' ) {
@@ -132,6 +135,10 @@ class GatewayAccount extends Validated {
       payload.credentials = {
         stripe_account_id: this.credentials
       }
+    }
+
+    if (!this.serviceId) {
+      throw new Error('Service ID must be set for gateway account request')
     }
     return payload
   }

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -121,6 +121,7 @@ async function confirm(req: Request, res: Response): Promise<void> {
 async function writeAccount(req: Request, res: Response): Promise<void> {
   const account = new GatewayAccountFormModel(req.body)
   const linkedService = req.body.systemLinkedService
+  account.serviceId = linkedService
 
   let gatewayAccountIdDerived: string
   let createdAccount: object

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -88,7 +88,7 @@ async function createTestGatewayAccount(serviceId: string, serviceName: string, 
         provider: 'stripe',
         credentials: stripeConnectId
     })
-
+    account.serviceId = serviceId
     const cardAccount: CardGatewayAccount = await Connector.createAccount(account.formatPayload())
     const gatewayAccountIdDerived = String(cardAccount.gateway_account_id)
     logger.info(`Created new Gateway Account ${gatewayAccountIdDerived}`)


### PR DESCRIPTION
Adds service ID to the gateway account creation request. This won't be
used by Connector yet but we can guarantee it's available when needed.

Will throw an error if an account is ever requested without an
associated service ID.