### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": "package-lock.json",
-    "lines": null
-  },
-  "generated_at": "2021-05-19T12:23:33Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,47 +53,94 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "dev.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "63160a20b1937342bcd1a6ecd4585a6637b47dda",
         "is_verified": false,
-        "line_number": 9,
-        "type": "Secret Keyword"
+        "line_number": 3
       }
     ],
     "src/tests/.env": [
       {
-        "hashed_secret": "4545f2690c8bf204bda667896487f059be642f4b",
-        "is_verified": false,
-        "line_number": 11,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/tests/.env",
         "hashed_secret": "50081c5ee375630f2a933961e49e90f80284ffda",
         "is_verified": false,
-        "line_number": 11,
-        "type": "Base64 High Entropy String"
+        "line_number": 12
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/tests/.env",
+        "hashed_secret": "50081c5ee375630f2a933961e49e90f80284ffda",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tests/.env",
         "hashed_secret": "ea06090a0b9590add823ade2334090fa216acb2b",
         "is_verified": false,
-        "line_number": 14,
-        "type": "Secret Keyword"
-      }
-    ],
-    "src/web/modules/gateway_accounts/index.ts": [
-      {
-        "hashed_secret": "1c66e85b1cf24974eaf4d53e576c39c489a76812",
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword"
+        "line_number": 15
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T15:18:45Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`