### PR TITLE
BAU Allow users to be added to internal services

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -93,6 +93,15 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     throw new NotImplementedError(`Remove user from service end point not configured [user=${userId}] [service=${serviceId}]`)
   }
 
+  const addAdminUserToService = function addAdminUserToService(serviceId, userId) {
+    const path = `/v1/api/users/${userId}/services`
+    const request = {
+      service_external_id: serviceId,
+      role_name: 'super-admin'
+    }
+    return axiosInstance.post(path, request).then(utilExtractData)
+  }
+
   const resetUserSecondFactor = function resetUserSecondFactor(id) {
     const path = `/v1/api/users/${id}/reset-second-factor`
     return axiosInstance.post(path).then(utilExtractData)
@@ -273,7 +282,8 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     toggleExperimentalFeaturesEnabledFlag,
     toggleAgentInitiatedMotoEnabledFlag,
     adminEmailsForGatewayAccounts,
-    toggleArchiveService
+    toggleArchiveService,
+    addAdminUserToService
   }
 }
 

--- a/src/web/modules/users/users.http.ts
+++ b/src/web/modules/users/users.http.ts
@@ -188,6 +188,26 @@ const search = async function search(
   
 }
 
+const addAdminUserToServicePage = async function addAdminUserToServicePage(req: Request, res: Response) {
+  const { userId } = req.params
+  const payUser = await AdminUsers.user(userId)
+  res.render('users/addToServices.njk', { payUser, csrf: req.csrfToken() })
+}
+
+const addAdminUserToService = async function addAdminUserToService(req: Request, res: Response, next: NextFunction) {
+  const { userId } = req.params
+  const { serviceId } = req.body
+  const service = await AdminUsers.service(serviceId)
+
+  if (service.internal !== true) {
+    throw new Error('You cannot add an admin user to a non-internal service')
+  }
+
+  await AdminUsers.addAdminUserToService(serviceId, userId)
+  req.flash(`Added user to ${service.service_name.en}`)
+  res.redirect(`/users/${userId}`)
+}
+
 export default {
   show: wrapAsyncErrorHandler(show),
   updateEmailForm: wrapAsyncErrorHandler(updateEmailForm),
@@ -198,5 +218,7 @@ export default {
   search: wrapAsyncErrorHandler(search),
   searchPage: wrapAsyncErrorHandler(searchPage),
   updateEmail,
-  updatePhoneNumber
+  updatePhoneNumber,
+  addAdminUserToServicePage: wrapAsyncErrorHandler(addAdminUserToServicePage),
+  addAdminUserToService: wrapAsyncErrorHandler(addAdminUserToService),
 }

--- a/src/web/modules/users/users.show.njk
+++ b/src/web/modules/users/users.show.njk
@@ -54,6 +54,10 @@
   {% endfor %}
 </dl>
 
+<div>
+  <a class="govuk-button govuk-button--secondary" href="/users/{{ payUser.external_id }}/addToService">Add user to internal service</a>
+</div>
+
 {{ json("User details source", payUser) }}
 
 {% endblock %}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -132,6 +132,9 @@ router.post('/users/:id/phone', auth.secured, users.updatePhoneNumber)
 router.get('/users/:id/email', auth.secured, users.updateEmailForm)
 router.post('/users/:id/email', auth.secured, users.updateEmail)
 
+router.get('/users/:userId/addToService', auth.secured, users.addAdminUserToServicePage)
+router.post('/users/:userId/addToService', auth.secured, users.addAdminUserToService)
+
 // @TODO(sfount) PATCH and DELETE respectively
 router.get('/users/:id/toggle', auth.secured, users.toggleUserEnabled)
 router.get('/users/:userId/service/:serviceId/delete', auth.secured, users.removeUserFromService)


### PR DESCRIPTION
Add page to allow support and pay administrators to add users to
internal services.

It is often useful to use an existing internal service to test a
specific feature in each of the test, staging and production
environments. Access to those accounts currently involves asking someone
else to sign in and invite you through the admin tool.

Toolbox will restrict the operation to:
- services that have the `internal` flag set to true

Admin users will throw an appropriate error if:
- the service doesn't exist
- the user already has access to the servic

![Screenshot 2021-08-19 at 17 00 48](https://user-images.githubusercontent.com/2844572/130103601-c8dad786-1bc1-4761-86fc-c923e4c36088.png)
![Screenshot 2021-08-19 at 17 00 41](https://user-images.githubusercontent.com/2844572/130103599-5cc6e095-673d-4696-a10f-96a3d84be3cd.png)