### PR TITLE
PP-8555 Add Stripe client

### DIFF
--- a/src/lib/stripe/stripe.client.js
+++ b/src/lib/stripe/stripe.client.js
@@ -1,0 +1,18 @@
+import HTTPSProxyAgent from "https-proxy-agent";
+
+const StripeLegacy = require('stripe')
+import * as config from '../../config'
+
+const STRIPE_ACCOUNT_API_KEY = process.env.STRIPE_ACCOUNT_API_KEY || ''
+
+let stripeConfig = {}
+
+if (config.server.HTTPS_PROXY) {
+  stripeConfig.httpAgent = new HTTPSProxyAgent(config.server.HTTPS_PROXY)
+}
+
+const stripeLegacyLib = new StripeLegacy(STRIPE_ACCOUNT_API_KEY, {...stripeConfig, 'apiVersion': '2018-09-24'})
+
+export function getStripeLegacyApiVersion() {
+  return stripeLegacyLib
+}

--- a/src/web/modules/payouts/page.ts
+++ b/src/web/modules/payouts/page.ts
@@ -1,15 +1,8 @@
 import Stripe from 'stripe'
-import HTTPSProxyAgent from 'https-proxy-agent'
-
-import * as config from '../../../config'
 
 import logger = require('../../../lib/logger');
 
-const stripe = new Stripe(process.env.STRIPE_ACCOUNT_API_KEY)
-stripe.setApiVersion('2018-09-24')
-
-// @ts-ignore
-if (config.server.HTTPS_PROXY) stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+import * as stripeClient from '../../../lib/stripe/stripe.client'
 
 const MAX_PAGE_SIZE = 100
 
@@ -26,7 +19,7 @@ const getPage = async function getPage(
   }
 
   // @ts-ignore
-  const result = await stripe.balanceTransactions.list(limits, { stripe_account: accountId })
+  const result = await stripeClient.getStripeLegacyApiVersion().balanceTransactions.list(limits, { stripe_account: accountId })
 
   logger.info(`[pages] fetched ${result.data.length} transactions for ${payoutId} [has_more=${result.has_more}]`)
   return result

--- a/src/web/modules/payouts/reconcile.ts
+++ b/src/web/modules/payouts/reconcile.ts
@@ -1,19 +1,13 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-restricted-syntax */
 import Stripe from 'stripe'
-import HTTPSProxyAgent from 'https-proxy-agent'
 import _ from 'lodash'
 
-import * as config from '../../../config'
 import { renderCSV, PayTransactionCSVEntity, PaymentType } from './csv'
 import { reconcilePayment, reconcileRefund } from './payTransaction'
 import { getTransactionsForPayout } from './page'
 
-const stripe = new Stripe(process.env.STRIPE_ACCOUNT_API_KEY)
-stripe.setApiVersion('2018-09-24')
-
-// @ts-ignore
-if (config.server.HTTPS_PROXY) stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+import * as stripeClient from '../../../lib/stripe/stripe.client'
 
 const verifyReconciledTotals = async function verifyReconciledTotals(
   payout: Stripe.payouts.IPayout,
@@ -88,12 +82,12 @@ export async function getPayoutsForAccount(
     ...endingBefore && { ending_before: endingBefore }
   }
 
-  return stripe.payouts.list(options, { stripe_account: stripeAccountId })
+  return stripeClient.getStripeLegacyApiVersion().payouts.list(options, { stripe_account: stripeAccountId })
 }
 
 export async function getPayout(
   payoutId: string,
   stripeAccountId: string
 ): Promise<Stripe.payouts.IPayout> {
-  return stripe.payouts.retrieve(payoutId, { stripe_account: stripeAccountId })
+  return stripeClient.getStripeLegacyApiVersion().payouts.retrieve(payoutId, { stripe_account: stripeAccountId })
 }

--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -1,20 +1,12 @@
 import Stripe from 'stripe'
-import HTTPSProxyAgent from 'https-proxy-agent'
-import * as config from '../../../../config'
 import { AdminUsers } from '../../../../lib/pay-request'
 import AccountDetails from './basicAccountDetails.model'
 import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
 import { ValidationError as CustomValidationError } from '../../../../lib/errors'
 
 import logger from '../../../../lib/logger'
+import * as stripeClient from '../../../../lib/stripe/stripe.client'
 const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
-const stripe = new Stripe(STRIPE_ACCOUNT_API_KEY)
-
-if (config.server.HTTPS_PROXY) {
-  // @ts-ignore
-  stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
-}
-stripe.setApiVersion('2018-09-24')
 
 export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails, stripeAgreement: StripeAgreement): Promise<Stripe.accounts.IAccount> {
   if (!STRIPE_ACCOUNT_API_KEY) {
@@ -26,7 +18,7 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
   }
 
   logger.info('Requesting new Stripe account from stripe API')
-  const stripeAccount = await stripe.accounts.create({
+  const stripeAccount = await stripeClient.getStripeLegacyApiVersion().accounts.create({
     type: 'custom',
     country: 'GB',
     business_name: service.merchant_details.name,

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -16,15 +16,16 @@ import { stripeTestResponsiblePersonDetails } from '../model/person.model'
 
 const Stripe = require('stripe-latest')
 const { StripeError } = Stripe.errors
-const STRIPE_ACCOUNT_TEST_API_KEY: string = process.env.STRIPE_ACCOUNT_TEST_API_KEY || ''
-const stripe = new Stripe(STRIPE_ACCOUNT_TEST_API_KEY, {
-    apiVersion: '2020-08-27',
-})
 
+const STRIPE_ACCOUNT_TEST_API_KEY: string = process.env.STRIPE_ACCOUNT_TEST_API_KEY || ''
+
+const stripeConfig = {}
 if (config.server.HTTPS_PROXY) {
-    // @ts-ignore
-    stripe.setHttpAgent(new HTTPSProxyAgent(config.server.HTTPS_PROXY))
+  // @ts-ignore
+  stripeConfig.httpAgent = new HTTPSProxyAgent(config.server.HTTPS_PROXY)
 }
+
+const stripe = new Stripe(STRIPE_ACCOUNT_TEST_API_KEY, {...stripeConfig, 'apiVersion': '2020-08-27'})
 
 const createTestAccount = async function createTestAccount(req: Request, res: Response): Promise<void> {
     if (!STRIPE_ACCOUNT_TEST_API_KEY) {


### PR DESCRIPTION
## WHAT 
- Added stripe client which returns stripe legacy module (supporting stripe api version 2018-09-24). This can be extended to abstract stripe sdk methods from toolbox services or web modules.
- Also uses Stripe constructor to set httpAgent instead of using deprecated `setHttpAgent`