### PR TITLE
Revert "Bump @sentry/node from 6.12.0 to 6.13.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-ecs": "~3.17.0",
         "@aws-sdk/client-s3": "~3.17.0",
         "@govuk-pay/pay-js-commons": "3.2.3",
-        "@sentry/node": "^6.13.1",
+        "@sentry/node": "^6.12.0",
         "axios": "0.21.4",
         "class-validator": "0.13.1",
         "client-sessions": "^0.8.0",
@@ -1700,14 +1700,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.1.tgz",
-      "integrity": "sha512-IGitAHYtsDPhPPcSTDqL/NMOwTbrqPezQOo4rlU1p1lpyZKSKrgzn/8LCrb+eRV2ffaio6+3kwqjCN2SvU8S7A==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
+      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
       "dependencies": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/minimal": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1715,12 +1715,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.1.tgz",
-      "integrity": "sha512-O7bR5suyVNTNyr6tm0IjhZ7NvxSHIbHoy5KYbVv05HQ/DmvAbYWq4dtOMvYQuuTD9krGkZdwPg4Gm6KnFaKqoQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
+      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
       "dependencies": {
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1728,12 +1728,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.1.tgz",
-      "integrity": "sha512-waRLPRFT1G95LsklH25LvfJy4vSe54PPRSeAGNPa4xVLCP56CnbNXGEXGDyPUewtqESwVpRG6GPL1QRV67IixA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
+      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
       "dependencies": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/types": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1741,15 +1741,15 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.1.tgz",
-      "integrity": "sha512-uSAsRPGeTNb6pEzHQ4/RkaylO95f6SmS1yzMizlMkgZq5qPDkmKgN+sZ04g58XlZ6nDKTxYoLSZsfxdaIZNTcw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
       "dependencies": {
-        "@sentry/core": "6.13.1",
-        "@sentry/hub": "6.13.1",
-        "@sentry/tracing": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/core": "6.12.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/tracing": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -1760,14 +1760,14 @@
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.1.tgz",
-      "integrity": "sha512-UF0yHtWXi5SfDa5oKCSw463P3AyAf635w6zFMiLV6kt8DDjnOwJRcT7dekRIU8F4Du+2nWJFPoXsmt1sablycw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
       "dependencies": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/minimal": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1775,19 +1775,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.1.tgz",
-      "integrity": "sha512-dYm8qv/O6QhOCmWi5rlJBX9rjEqvnjnZH1zqhQCWhMmF9aYS151Y41P1C0TS0o17Z0ClonLiYMG1J+zE/Pmtqg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.1.tgz",
-      "integrity": "sha512-qFDup/nBj2u2rAcQADFG3njVYUCo4XOQkCT7XdA5Flg1a++r6tIBdjiRyyjb8nqwHZ/OQsKr/V/EQaJiW29ETA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
+      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
       "dependencies": {
-        "@sentry/types": "6.13.1",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -9062,47 +9062,47 @@
       }
     },
     "@sentry/core": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.1.tgz",
-      "integrity": "sha512-IGitAHYtsDPhPPcSTDqL/NMOwTbrqPezQOo4rlU1p1lpyZKSKrgzn/8LCrb+eRV2ffaio6+3kwqjCN2SvU8S7A==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
+      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
       "requires": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/minimal": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.1.tgz",
-      "integrity": "sha512-O7bR5suyVNTNyr6tm0IjhZ7NvxSHIbHoy5KYbVv05HQ/DmvAbYWq4dtOMvYQuuTD9krGkZdwPg4Gm6KnFaKqoQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
+      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
       "requires": {
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.1.tgz",
-      "integrity": "sha512-waRLPRFT1G95LsklH25LvfJy4vSe54PPRSeAGNPa4xVLCP56CnbNXGEXGDyPUewtqESwVpRG6GPL1QRV67IixA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
+      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
       "requires": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/types": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.1.tgz",
-      "integrity": "sha512-uSAsRPGeTNb6pEzHQ4/RkaylO95f6SmS1yzMizlMkgZq5qPDkmKgN+sZ04g58XlZ6nDKTxYoLSZsfxdaIZNTcw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
       "requires": {
-        "@sentry/core": "6.13.1",
-        "@sentry/hub": "6.13.1",
-        "@sentry/tracing": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/core": "6.12.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/tracing": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -9110,28 +9110,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.1.tgz",
-      "integrity": "sha512-UF0yHtWXi5SfDa5oKCSw463P3AyAf635w6zFMiLV6kt8DDjnOwJRcT7dekRIU8F4Du+2nWJFPoXsmt1sablycw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
       "requires": {
-        "@sentry/hub": "6.13.1",
-        "@sentry/minimal": "6.13.1",
-        "@sentry/types": "6.13.1",
-        "@sentry/utils": "6.13.1",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.1.tgz",
-      "integrity": "sha512-dYm8qv/O6QhOCmWi5rlJBX9rjEqvnjnZH1zqhQCWhMmF9aYS151Y41P1C0TS0o17Z0ClonLiYMG1J+zE/Pmtqg=="
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
     },
     "@sentry/utils": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.1.tgz",
-      "integrity": "sha512-qFDup/nBj2u2rAcQADFG3njVYUCo4XOQkCT7XdA5Flg1a++r6tIBdjiRyyjb8nqwHZ/OQsKr/V/EQaJiW29ETA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
+      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
       "requires": {
-        "@sentry/types": "6.13.1",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/client-ecs": "~3.17.0",
     "@aws-sdk/client-s3": "~3.17.0",
     "@govuk-pay/pay-js-commons": "3.2.3",
-    "@sentry/node": "^6.13.1",
+    "@sentry/node": "^6.12.0",
     "axios": "0.21.4",
     "class-validator": "0.13.1",
     "client-sessions": "^0.8.0",


### PR DESCRIPTION
Reverts alphagov/pay-toolbox#1215

Observed something in the stack unexpectedly throwing
```
error: {
    code: ERR_INVALID_PROTOCOL
}
```

Suspect it's related to additional protocol parsing added to the sentry client with partial commit `88b96f6c401`  but further investigation would be needed.