### PR TITLE
PP-8777 Bump node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.5-alpine3.14@sha256:acda6526d68037e458fecc77df65799aa395185bcb61d01be958ff2a4a1388a0
+FROM node:12.22.7-alpine3.14@sha256:2016c5b7bfef46dd5ee94a9a8d4ddcb302a1f5b6914c35deb0075187e9ff35bd
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "Internal administrative tools service for the GOV.UK Pay products.",
   "engines": {
-    "node": "^12.22.4",
+    "node": "^12.22.7",
     "npm": "^7.5.4"
   },
   "private": true,


### PR DESCRIPTION
Bump node version to latest security release to address a medium CVE
affecting the core HTTP request parser.