### PR TITLE
BAU unused remove macro placeholder data

### DIFF
--- a/src/web/modules/gateway_accounts/createSuccess.njk
+++ b/src/web/modules/gateway_accounts/createSuccess.njk
@@ -23,21 +23,6 @@ A {{ account.type | upper }} Gateway account has been created through Admin User
 
 {% if isStripe and not isLive %}
     <p class="govuk-body">In Zendesk, respond to the request using "Stripe test account" macro</p>
-    <p class="govuk-body">Replace the placeholders in the macro with the following:</p>
-
-    {{ govukTable({
-            head: [
-                { text: "Zendesk macro placeholder"},
-                { text: "Value"}
-            ],
-            rows:
-            [
-                [ { text: "***STRIPE_TEST_ACCOUNT_URL***" },
-                  { text: selfServiceBaseUrl + "/account/" + account.external_id + "/dashboard", classes: "stripe-go-live-url-table-cell"  } ]
-            ]
-            })
-    }}
-
 {% else %}
     <p class="govuk-body">In Zendesk, respond to the request to go live using the appropriate Zendesk macro (either “Stripe account” or “non-Stripe”).</p>
     <p class="govuk-body">Replace the placeholders in the macro with the following:</p>

--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -64,8 +64,7 @@ const createTestAccountConfirm = async function createTestAccountConfirm(req: Re
             provider: 'stripe',
             isLive: false,
             isStripe: true,
-            stripeConnectAccountId: stripeAccount.id,
-            selfServiceBaseUrl: config.services.SELFSERVICE_URL
+            stripeConnectAccountId: stripeAccount.id
         })
     } catch (error) {
         if (error instanceof StripeError) {


### PR DESCRIPTION
The Zendesk macro for when a Stripe test account is created does not ask
for the dashboard URL, so remove this from the success page as it is
misleading.