### PR TITLE
PP-8865 Create stripe accounts with new capabilities

### DIFF
--- a/src/lib/pay-request/types/adminUsers.ts
+++ b/src/lib/pay-request/types/adminUsers.ts
@@ -45,6 +45,7 @@ export interface Service {
     address_postcode: string;
     telephone_number: string;
     email: string;
+    url: string
   };
 }
 

--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -1,13 +1,27 @@
-import Stripe from 'stripe'
 import { AdminUsers } from '../../../../lib/pay-request'
 import AccountDetails from './basicAccountDetails.model'
 import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
 import { ValidationError as CustomValidationError } from '../../../../lib/errors'
-
+import * as config from '../../../../config'
 import logger from '../../../../lib/logger'
-import * as stripeClient from '../../../../lib/stripe/stripe.client'
+import HTTPSProxyAgent from "https-proxy-agent"
+
 const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
 
+const Stripe = require('stripe-latest')
+const {StripeError} = Stripe.errors
+
+const STRIPE_ACCOUNT_TEST_API_KEY: string = process.env.STRIPE_ACCOUNT_TEST_API_KEY || ''
+
+const stripeConfig = {}
+if (config.server.HTTPS_PROXY) {
+  // @ts-ignore
+  stripeConfig.httpAgent = new HTTPSProxyAgent(config.server.HTTPS_PROXY)
+}
+
+const stripe = new Stripe(STRIPE_ACCOUNT_TEST_API_KEY, {...stripeConfig, 'apiVersion': '2020-08-27'})
+
+// @ts-ignore
 export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails, stripeAgreement: StripeAgreement): Promise<Stripe.accounts.IAccount> {
   if (!STRIPE_ACCOUNT_API_KEY) {
     throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
@@ -18,16 +32,21 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
   }
 
   logger.info('Requesting new Stripe account from stripe API')
-  const stripeAccount = await stripeClient.getStripeLegacyApiVersion().accounts.create({
+
+  const stripeAccount = await stripe.accounts.create({
     type: 'custom',
     country: 'GB',
-    business_name: service.merchant_details.name,
-    payout_statement_descriptor: stripeAccountDetails.statementDescriptor,
-    statement_descriptor: stripeAccountDetails.statementDescriptor,
-    support_phone: service.merchant_details.telephone_number,
-    legal_entity: {
-      type: 'government_agency',
-      business_name: service.merchant_details.name,
+    business_type: 'government_entity',
+    settings: {
+      payments: {
+        statement_descriptor: stripeAccountDetails.statementDescriptor,
+      },
+      payouts: {
+        statement_descriptor: stripeAccountDetails.statementDescriptor,
+      }
+    },
+    company: {
+      name: service.merchant_details.name,
       address: {
         line1: service.merchant_details.address_line1,
         line2: service.merchant_details.address_line2,
@@ -35,7 +54,15 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
         postal_code: service.merchant_details.address_postcode,
         country: service.merchant_details.address_country
       },
-      additional_owners: ''
+      phone: service.merchant_details.telephone_number
+    },
+    business_profile: {
+      mcc: 9399,
+      url: service.merchant_details.url
+    },
+    capabilities: {
+      card_payments: {requested: true},
+      transfers: {requested: true},
     },
     tos_acceptance: {
       ip: stripeAgreement.ip_address,

--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -1,4 +1,3 @@
-import Stripe from 'stripe'
 import { Request, Response } from 'express'
 
 import logger from '../../../../lib/logger'
@@ -9,6 +8,7 @@ import { formatErrorsForTemplate, ClientFormError } from '../../common/validatio
 import { Service, StripeAgreement } from '../../../../lib/pay-request/types/adminUsers'
 import AccountDetails from './basicAccountDetails.model'
 import { setupProductionStripeAccount } from './account'
+const Stripe = require('stripe-latest')
 const { StripeError } = Stripe.errors
 
 const createAccountForm = async function createAccountForm(


### PR DESCRIPTION
## WHAT 
- Creates Stripe live accounts with new capabilities (`card_payments` & `transfers`)
- Updated to latest Stripe version (`2020-08-27`) to create accounts

- Stripe client initialisation be moved in separate .client js when legacy version has been removed fully

