### PR TITLE
PP-8834 Mark director task as done for Stripe test accounts

### DIFF
--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -97,7 +97,8 @@ async function createTestGatewayAccount(serviceId: string, serviceName: string, 
         'bank_account',
         'company_number',
         'responsible_person',
-        'vat_number'
+        'vat_number',
+        'director'
     ])
     logger.info(`Set Stripe setup values to 'true' for Stripe test Gateway Account ${gatewayAccountIdDerived}`)
 


### PR DESCRIPTION
For test accounts we don't need to provide director information for them
to be enabled. Mark the `director` setup task in connector as done so
that users will never be shown the banner on the dashboard to add these
details.