### PR TITLE
BAU Show PSP account ID for active credential

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -63,17 +63,17 @@
       <dd class="govuk-summary-list__value">{{ account.payment_provider | capitalize }}</dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
-    {% if account.credentials and account.credentials.merchant_id %}
+    {% if activeCredential and activeCredential.credentials.merchant_id %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">PSP merchant ID</dt>
-      <dd class="govuk-summary-list__value">{{ account.credentials.merchant_id }}</dd>
+      <dd class="govuk-summary-list__value">{{ activeCredential.credentials.merchant_id }}</dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
     {% endif %}
-    {% if account.credentials and account.credentials.stripe_account_id %}
+    {% if activeCredential and activeCredential.credentials.stripe_account_id %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Connected Stripe account</dt>
-      <dd class="govuk-summary-list__value">{{ account.credentials.stripe_account_id }}</dd>
+      <dd class="govuk-summary-list__value">{{ activeCredential.credentials.stripe_account_id }}</dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
     {% endif %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -178,11 +178,16 @@ async function detail(req: Request, res: Response): Promise<void> {
     logger.warn(`Services request for gateway account ${id} returned "${error.message}"`)
   }
 
+  const activeCredential = account.gateway_account_credentials && account.gateway_account_credentials.find((credential: any) => {
+    return credential.state === 'ACTIVE'
+  })
+
   res.render('gateway_accounts/detail', {
     account,
     acceptedCards,
     gatewayAccountId: id,
     services,
+    activeCredential,
     messages: req.flash('info'),
     csrf: req.csrfToken()
   })


### PR DESCRIPTION
This stopped displaying when we implemented PSP switching. Display the
connected Stripe account ID or the PSP merchant ID for the ACTIVE
credential.