### PR TITLE
BAU Use Stripe production key for creating production accounts

### DIFF
--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -9,9 +9,6 @@ import HTTPSProxyAgent from "https-proxy-agent"
 const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
 
 const Stripe = require('stripe-latest')
-const {StripeError} = Stripe.errors
-
-const STRIPE_ACCOUNT_TEST_API_KEY: string = process.env.STRIPE_ACCOUNT_TEST_API_KEY || ''
 
 const stripeConfig = {}
 if (config.server.HTTPS_PROXY) {
@@ -19,7 +16,7 @@ if (config.server.HTTPS_PROXY) {
   stripeConfig.httpAgent = new HTTPSProxyAgent(config.server.HTTPS_PROXY)
 }
 
-const stripe = new Stripe(STRIPE_ACCOUNT_TEST_API_KEY, {...stripeConfig, 'apiVersion': '2020-08-27'})
+const stripe = new Stripe(STRIPE_ACCOUNT_API_KEY, {...stripeConfig, 'apiVersion': '2020-08-27'})
 
 // @ts-ignore
 export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails, stripeAgreement: StripeAgreement): Promise<Stripe.accounts.IAccount> {


### PR DESCRIPTION
A recent change introduced a mistake where the Stripe test API key is
being used to create accounts that should be in Stripe production.