### PR TITLE
PP-8861 Include product_description in the payload to Stripe

### DIFF
--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -55,7 +55,8 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
     },
     business_profile: {
       mcc: 9399,
-      url: service.merchant_details.url
+      url: service.merchant_details.url,
+      product_description: `Payments for public sector services for organisation service.merchant_details.name `
     },
     capabilities: {
       card_payments: {requested: true},


### PR DESCRIPTION
## WHAT
- Added standard product description to the payload sent to stripe when creating live accounts.
- Required as stripe is flagging product_description as mandatory for new accounts although we provide organisation URL.