### PR TITLE
PP-8861 Send product description when creating Stripe accounts

### DIFF
--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -55,7 +55,8 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
     },
     business_profile: {
       mcc: 9399,
-      url: service.merchant_details.url
+      url: service.merchant_details.url,
+      product_description: `Payments for public sector services for organisation ${service.merchant_details.name}`
     },
     capabilities: {
       card_payments: {requested: true},


### PR DESCRIPTION
This is a required field before accounts can begin taking payments, so set when creating an account.