### PR TITLE
BAU Fix stripe account success template business name

### DIFF
--- a/src/web/modules/stripe/success.njk
+++ b/src/web/modules/stripe/success.njk
@@ -28,7 +28,7 @@
  </div>
 
  {{ govukButton({
-    text: "Create Pay Live Gateway Account for " + response.business_name + "(" + service.name + ")",
+    text: "Create Pay Live Gateway Account for " + response.business_profile.name + "(" + service.name + ")",
     href: "/gateway_accounts/create?service=" + systemLinkService + "&credentials=" + response.id
     })
     }}


### PR DESCRIPTION
The Stripe account API was updated over a number of major version
numbers. JS references were updated to the new format, update this
template reference to the Stripe account object.

Reference https://github.com/alphagov/pay-toolbox/pull/1255