### PR TITLE
BAU Use new ledger performance report endpoint

### DIFF
--- a/src/lib/pay-request/api_utils/ledger.js
+++ b/src/lib/pay-request/api_utils/ledger.js
@@ -131,7 +131,10 @@ const ledgerMethods = function ledgerMethods(instance) {
       .then(utilExtractData)
   }
 
-  const paymentVolumesAggregate = function paymentVolumesAggregate(fromDate, toDate, state) {
+  // This is used by live payments dashboard to get accurate inflight payment data. This should not
+  // be used for querying over a large date range as this directly queries the transaction table
+  // in ledger which will result in poor performance.
+  function paymentVolumesAggregateLegacy(fromDate, toDate, state) {
     const params = {
       from_date: fromDate,
       to_date: toDate,
@@ -139,6 +142,17 @@ const ledgerMethods = function ledgerMethods(instance) {
 
     }
     return axiosInstance.get('/v1/report/performance-report-legacy', { params })
+      .then(utilExtractData)
+  }
+
+   function paymentVolumesAggregate(fromDate, toDate, state) {
+    const params = {
+      from_date: fromDate,
+      to_date: toDate,
+      ...state && { state }
+
+    }
+    return axiosInstance.get('/v1/report/performance-report', { params })
       .then(utilExtractData)
   }
 
@@ -185,6 +199,7 @@ const ledgerMethods = function ledgerMethods(instance) {
     transactionsByGatewayTransactionId,
     relatedTransactions,
     paymentVolumesByHour,
+    paymentVolumesAggregateLegacy,
     paymentVolumesAggregate,
     eventTicker,
     gatewayMonthlyPerformanceReport,

--- a/src/web/modules/platform/dashboard.http.ts
+++ b/src/web/modules/platform/dashboard.http.ts
@@ -51,7 +51,7 @@ export async function aggregate(req: Request, res: Response, next: NextFunction)
       limit :
       baseDate.utc().endOf('day').format()
 
-    const result = await Ledger.paymentVolumesAggregate(
+    const result = await Ledger.paymentVolumesAggregateLegacy(
       baseDate.utc().startOf('day').format(),
       toDate,
       state


### PR DESCRIPTION
A new endpoint was added to get performance statistics using the ledger
`transaction_summary` table.

We had reverted to using the legacy endpoint for the performance page
JSON download, which queries the `transaction` table resulting in poor
performance and burst balance drops. This was done by mistake as the
same ledger client method is used by the live payments dashboard.

Create a separate client method that will query the legacy endpoint just
for use by the live payments dashboard.

with @SandorArpa