### PR TITLE
PP-9203: Set correct path to update email

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -55,7 +55,7 @@ const adminUsersMethods = function adminUsersMethods(instance) {
     const path = `/v1/api/users/${id}`
     const payload = {
       op: 'replace',
-      path: 'username',
+      path: 'email',
       value: email
     }
     return axiosInstance.patch(path, payload).then(utilExtractData)


### PR DESCRIPTION
To update the email the 'op' is 'replace' and 'path' is 'email'. See https://github.com/alphagov/pay-adminusers/pull/1229.