### PR TITLE
BAU Show Stripe account ID for only or active credential

### DIFF
--- a/src/lib/pay-request/types/connector.ts
+++ b/src/lib/pay-request/types/connector.ts
@@ -53,6 +53,8 @@ export interface GatewayAccount {
 
   corporate_debit_card_surcharge_amount: number;
 
+  gateway_account_credentials: GatewayAccountCredential[]
+
   email_notifications: {
     [key: string]: EmailNotificationSettings;
   };
@@ -60,6 +62,16 @@ export interface GatewayAccount {
   notify_settings: {
     [key: string]: any;
    }
+}
+
+export interface GatewayAccountCredential {
+  external_id: string;
+
+  payment_provider: string;
+
+  state: string;
+
+  credentials: object;
 }
 
 export interface EmailNotificationSettings {

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -63,17 +63,17 @@
       <dd class="govuk-summary-list__value">{{ account.payment_provider | capitalize }}</dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
-    {% if activeCredential and activeCredential.credentials.merchant_id %}
+    {% if currentCredential and currentCredential.credentials.merchant_id %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">PSP merchant ID</dt>
-      <dd class="govuk-summary-list__value">{{ activeCredential.credentials.merchant_id }}</dd>
+      <dd class="govuk-summary-list__value">{{ currentCredential.credentials.merchant_id }}</dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
     {% endif %}
-    {% if activeCredential and activeCredential.credentials.stripe_account_id %}
+    {% if currentCredential and currentCredential.credentials.stripe_account_id %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Connected Stripe account</dt>
-      <dd class="govuk-summary-list__value"><a href="https://dashboard.stripe.com/connect/accounts/{{ activeCredential.credentials.stripe_account_id }}" class="govuk-link govuk-link--no-visited-state">{{ activeCredential.credentials.stripe_account_id }}</a></dd>
+      <dd class="govuk-summary-list__value"><a href="https://dashboard.stripe.com/connect/accounts/{{ currentCredential.credentials.stripe_account_id }}" class="govuk-link govuk-link--no-visited-state">{{ currentCredential.credentials.stripe_account_id }}</a></dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
     {% endif %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -177,19 +177,23 @@ async function detail(req: Request, res: Response): Promise<void> {
     logger.warn(`Services request for gateway account ${id} returned "${error.message}"`)
   }
 
-  const activeCredential = account.gateway_account_credentials && account.gateway_account_credentials.find((credential: any) => {
-    return credential.state === 'ACTIVE'
-  })
+  const currentCredential = getCurrentCredential(account)
+
 
   res.render('gateway_accounts/detail', {
     account,
     acceptedCards,
     gatewayAccountId: id,
     services,
-    activeCredential,
+    currentCredential,
     messages: req.flash('info'),
     csrf: req.csrfToken()
   })
+}
+
+function getCurrentCredential(account: CardGatewayAccount) {
+  const credentials = account.gateway_account_credentials || []
+  return credentials.find(credential => credential.state === 'ACTIVE') || credentials[0]
 }
 
 async function apiKeys(req: Request, res: Response): Promise<void> {
@@ -287,7 +291,7 @@ async function toggleWorldpayExemptionEngine(req: Request, res: Response): Promi
   const { id } = req.params
 
   const result = await Connector.toggleWorldpayExemptionEngine(id)
-  req.flash('info', `Worldpay Exception Engine ${result ? 'enabled' : 'disabled' }`)
+  req.flash('info', `Worldpay Exception Engine ${result ? 'enabled' : 'disabled'}`)
   res.redirect(`/gateway_accounts/${id}`)
 }
 
@@ -336,8 +340,8 @@ async function toggleSendReferenceToGateway(
 }
 
 async function toggleRequiresAdditionalKycData(
-    req: Request,
-    res: Response
+  req: Request,
+  res: Response
 ): Promise<void> {
   const { id } = req.params
   const account = await getAccount(id)


### PR DESCRIPTION
Now that stripe accounts are created with the credential having a state
of CREATED rather than ACTIVE, display the connect account id or PSP
merchant ID for the  only credential if there is only 1 credential, else
for the active credential