### PR TITLE
BAU — Update the GitHub teams API URL to a non-deprecated one

### DIFF
--- a/src/lib/auth/github/permissions.js
+++ b/src/lib/auth/github/permissions.js
@@ -5,10 +5,11 @@ const axios = require('axios')
 const config = require('../../../config')
 const logger = require('../../logger')
 
-const GITHUB_TEAMS_API_ENDPOINT = 'https://api.github.com/teams'
+const GITHUB_API_ENDPOINT = `https://api.github.com`
+const GITHUB_ALPHAGOV_ORGANISATION_ID = 596977
 
 const validateUserTeamMembership = async function validateUserTeamMembership(user, token, team) {
-  const url = `${GITHUB_TEAMS_API_ENDPOINT}/${team}/members/${user}`
+  const url = `${GITHUB_API_ENDPOINT}/organizations/${GITHUB_ALPHAGOV_ORGANISATION_ID}/team/${team}/memberships/${user}`
   const githubRestOptions = {
     headers: {
       Authorization: `token ${token}`


### PR DESCRIPTION
See https://developer.github.com/changes/2020-01-21-moving-the-team-api-endpoints/ for details of the API change and https://github.blog/changelog/2022-02-22-sunset-notice-deprecated-teams-api-endpoints/ for why it’s suddenly become pressing right now.