### PR TITLE
BAU Don't show "Organisation details" stripe task

### DIFF
--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -172,9 +172,8 @@ async function detail(req: Request, res: Response): Promise<void> {
 
   const currentCredential = getCurrentCredential(account)
 
-  delete stripeSetup.additional_kyc_data
   const outstandingStripeSetupTasks = Object.keys(stripeSetup)
-    .filter(task => stripeSetup[task] === false)
+    .filter(task => task != 'additional_kyc_data' && task != 'organisation_details' && stripeSetup[task] === false)
     .map(task => task.replace(/_/g, " "))
 
   res.render('gateway_accounts/detail', {


### PR DESCRIPTION
This task is only completed during switching PSP so most services don't
have this completed. Don't list it in the outstanding Stripe task list
for gateway accounts.