### PR TITLE
PP-9239: Separate post-merge into file

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,13 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,7 @@
 name: Github Actions Tests
 
 on:
-  push:
-    branches:
-      - master
+  workflow_call:
   pull_request:
 
 permissions:


### PR DESCRIPTION
This PR follows the pattern of separating out post-merge into a separate workflow for future use in release tagging in GHA.

There are no pact-tests to port into GHA for toolbox