### PR TITLE
PP-9388 Add toggle for allow_authorisation_api

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -259,6 +259,17 @@ const connectorMethods = function connectorMethods(instance) {
     return requiresKycFlag
   }
 
+  async function toggleAllowAuthorisationApi(id) {
+    const gatewayAccount = await account(id)
+    const url = `/v1/api/accounts/${id}`
+    await axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'allow_authorisation_api',
+      value: !gatewayAccount.allow_authorisation_api
+    })
+    return !gatewayAccount.allow_authorisation_api
+  }
+
   function addGatewayAccountCredentialsForSwitch(id, paymentProvider, credentials) {
     const url = `/v1/api/accounts/${id}/credentials`
     return axiosInstance.post(url, {
@@ -311,7 +322,8 @@ const connectorMethods = function connectorMethods(instance) {
     toggleWorldpayExemptionEngine,
     addGatewayAccountCredentialsForSwitch,
     enableSwitchFlagOnGatewayAccount,
-    toggleRequiresAdditionalKycData
+    toggleRequiresAdditionalKycData,
+    toggleAllowAuthorisationApi
   }
 }
 

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -394,6 +394,37 @@
     </div>
   {% endif %}
 
+    {% if account.allow_authorisation_api === false %}
+    <div>
+      <h1 class="govuk-heading-s">Use of the payment authorisation API is disabled</h1>
+      <p class="govuk-body">Allows creating MOTO payments with an authorisation_mode of ‘api‘. These payments are authorised by sending the card details in a POST request to Public API.</p>
+      <p class="govuk-body">Note that corporate card surcharges will not be applied to payments created in this way.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_allow_authorisation_api">
+        {{ govukButton({
+          text: "Enable use of the payment authorisation API",
+          classes: "govuk-button--warning"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
+
+  {% if account.allow_authorisation_api === true %}
+    <div>
+      <h1 class="govuk-heading-s">Use of the payment authorisation API is enabled</h1>
+      <p class="govuk-body">Creating MOTO payments with an authorisation_mode of ‘api‘ is allowed for this account. These payments are authorised by sending the card details in a POST request to Public API.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_allow_authorisation_api">
+        {{ govukButton({
+          text: "Disable use of the payment authorisation API"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
+
+
   {% if account.send_payer_ip_address_to_gateway === true %}
     <div>
       <h1 class="govuk-heading-s">Sending payer IP address to gateway is enabled</h1>

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -353,6 +353,17 @@ async function toggleRequiresAdditionalKycData(
   res.redirect(`/gateway_accounts/${id}`)
 }
 
+async function toggleAllowAuthorisationApi(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const { id } = req.params
+  const enabled = await Connector.toggleAllowAuthorisationApi(id)
+
+  req.flash('info', `Use of the payment authorisation API is ${enabled ? 'enabled' : 'disabled'}`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
 async function updateStripeStatementDescriptorPage(
   req: Request,
   res: Response
@@ -624,5 +635,6 @@ export default {
   agentInitiatedMotoPage: wrapAsyncErrorHandler(agentInitiatedMotoPage),
   createAgentInitiatedMotoProduct: wrapAsyncErrorHandler(createAgentInitiatedMotoProduct),
   toggleWorldpayExemptionEngine: wrapAsyncErrorHandler(toggleWorldpayExemptionEngine),
-  toggleRequiresAdditionalKycData: wrapAsyncErrorHandler(toggleRequiresAdditionalKycData)
+  toggleRequiresAdditionalKycData: wrapAsyncErrorHandler(toggleRequiresAdditionalKycData),
+  toggleAllowAuthorisationApi: wrapAsyncErrorHandler(toggleAllowAuthorisationApi)
 }

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -42,5 +42,6 @@ export default {
   agentInitiatedMotoPage: http.agentInitiatedMotoPage,
   createAgentInitiatedMotoProduct: http.createAgentInitiatedMotoProduct,
   toggleWorldpayExemptionEngine: http.toggleWorldpayExemptionEngine,
-  toggleRequiresAdditionalKycData: http.toggleRequiresAdditionalKycData
+  toggleRequiresAdditionalKycData: http.toggleRequiresAdditionalKycData,
+  toggleAllowAuthorisationApi: http.toggleAllowAuthorisationApi
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -77,6 +77,7 @@ router.post('/gateway_accounts/:id/toggle_send_payer_email_to_gateway', auth.sec
 router.post('/gateway_accounts/:id/toggle_worldpay_exemption_engine', auth.secured, gatewayAccounts.toggleWorldpayExemptionEngine)
 router.post('/gateway_accounts/:id/toggle_send_reference_to_gateway', auth.secured, gatewayAccounts.toggleSendReferenceToGateway)
 router.post('/gateway_accounts/:id/toggle_requires_additional_kyc_data', auth.secured, gatewayAccounts.toggleRequiresAdditionalKycData)
+router.post('/gateway_accounts/:id/toggle_allow_authorisation_api', auth.secured, gatewayAccounts.toggleAllowAuthorisationApi)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)


### PR DESCRIPTION
Add a button on the gateway account page to toggle whether the
allow_authorisation_api flag is enabled.