### PR TITLE
BAU Add list refunds page

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -237,8 +237,13 @@
     {% endif %}
     {% if account.payment_method !== "DIRECT_DEBIT" %}
       {{ govukButton({
-        text: "View transactions",
+        text: "View payments",
         href: "/transactions?account=" + gatewayAccountId
+      })
+      }}
+      {{ govukButton({
+        text: "View refunds",
+        href: "/transactions?account=" + gatewayAccountId + "&type=REFUND"
       })
       }}
       {{ govukButton({

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -13,13 +13,13 @@
     {% endif %}
   </span>
 
-  <h1 class="govuk-heading-m">Transactions</h1>
+  <h1 class="govuk-heading-m">{% if transactionType == "REFUND" %}Refunds{% else %}Payments{% endif %}</h1>
 
   <div class="transactions-filter__container govuk-body">
     {% for status in ["succeeded", "failed", "in-progress", "all"] %}
       <a
         class="transactions-filter__item {% if selectedStatus === status %}selected{% endif %} no-decoration"
-        href="/transactions?status={{ status }}{% if service %}&account={{ accountId }}{% endif %}">
+        href="/transactions?status={{ status }}{% if service %}&account={{ accountId }}{% endif %}{% if transactionType %}&type={{ transactionType }}{% endif %}">
         <span>{{ status | capitalize }}</span>
       </a>
     {% endfor %}

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -68,12 +68,13 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
     let service, account
     const accountId = req.query.account
     const selectedStatus = req.query.status || PaymentListFilterStatus[PaymentListFilterStatus.all]
+    const transactionType = req.query.type && req.query.type.toString().toUpperCase() || 'PAYMENT'
     const filters = {
       ...req.query.reference && { reference: req.query.reference },
       ...req.query.gateway_transaction_id && { gateway_transaction_id: req.query.gateway_transaction_id },
       ...req.query.gateway_payout_id && { gateway_payout_id: req.query.gateway_payout_id }
     }
-    const response = await Ledger.transactions(accountId, req.query.page, selectedStatus, filters)
+    const response = await Ledger.transactions(accountId, req.query.page, selectedStatus, filters, false, transactionType)
 
     if (req.query.account) {
       service = await AdminUsers.gatewayAccountServices(accountId)
@@ -87,7 +88,8 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
       set: response,
       account,
       service,
-      accountId
+      accountId,
+      transactionType
     })
   } catch (error) {
     next(error)


### PR DESCRIPTION
Add a "View refunds" link on the gateway account details page to list
all refunds for a gateway filtered by state.

This uses the same page as the payments list, and just changes the
ledger transaction search query based on a query parameter.

Rename the "View transactions" link to be "View payments".