### PR TITLE
PP-9442 link payments and gateway accounts to stripe dashboard where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules
 *.log
 
 .idea
+
+# ST4
+*.sublime-*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5894,9 +5894,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -8669,9 +8669,9 @@
       }
     },
     "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -10971,7 +10971,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
       "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.4.1",
@@ -10986,7 +10987,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -11024,13 +11026,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -11056,7 +11060,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "0.0.4",
@@ -11401,7 +11406,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
       "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "chalk": {
       "version": "4.1.2",
@@ -13589,9 +13595,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -14440,7 +14446,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.6.1.tgz",
       "integrity": "sha512-7aAZx7LhRnmR51W5XtmTBYHGFl2n1AdEk1uoXLuzHa1OoGXrxOW/iwLcudvgp6BGX/l4Yh1rtMrIzvhlvbVddg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-inlinesvg": {
       "version": "2.3.0",
@@ -15649,9 +15656,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/src/lib/pay-request/types/connector.ts
+++ b/src/lib/pay-request/types/connector.ts
@@ -64,6 +64,10 @@ export interface GatewayAccount {
    }
 }
 
+export interface Credentials {
+  stripe_account_id?: string;
+}
+
 export interface GatewayAccountCredential {
   external_id: string;
 
@@ -71,7 +75,7 @@ export interface GatewayAccountCredential {
 
   state: string;
 
-  credentials: object;
+  credentials: Credentials;
 }
 
 export interface EmailNotificationSettings {

--- a/src/tests/fixtures/payment.ts
+++ b/src/tests/fixtures/payment.ts
@@ -44,7 +44,8 @@ const transaction: Transaction = {
     amount_submitted: 0
   },
   transaction_id: 'rs7l0c6ka8b0hr2ho7omkpo6ot',
-  transaction_type: 'PAYMENT'
+  transaction_type: 'PAYMENT',
+  live: true
 }
 
 export default transaction

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -110,7 +110,11 @@
       {% if currentCredential and currentCredential.credentials.stripe_account_id %}
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Connected Stripe account</span></dt>
-        <dd class="govuk-summary-list__value"><a href="https://dashboard.stripe.com/connect/accounts/{{ currentCredential.credentials.stripe_account_id }}" class="govuk-link govuk-link--no-visited-state">{{ currentCredential.credentials.stripe_account_id }}</a></dd>
+        <dd class="govuk-summary-list__value">
+          <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ stripeDashboardUri }}">
+            {{ currentCredential.credentials.stripe_account_id }}
+          </a>
+        </dd>
         <dd class="govuk-summary-list__actions"></dd>
       </div>
       {% endif %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -153,6 +153,9 @@ async function writeAccount(req: Request, res: Response): Promise<void> {
 }
 
 async function detail(req: Request, res: Response): Promise<void> {
+
+  let stripeDashboardUri = ''
+
   const { id } = req.params
   let services = {}
   const isDirectDebitID = id.match(/^DIRECT_DEBIT:/)
@@ -176,6 +179,10 @@ async function detail(req: Request, res: Response): Promise<void> {
     .filter(task => task != 'additional_kyc_data' && task != 'organisation_details' && stripeSetup[task] === false)
     .map(task => task.replace(/_/g, " "))
 
+  if (currentCredential && currentCredential.credentials.stripe_account_id) {
+    stripeDashboardUri = `https://dashboard.stripe.com/${account.live ? '' : 'test/'}connect/accounts/${currentCredential.credentials.stripe_account_id}`
+  }
+
   res.render('gateway_accounts/detail', {
     account,
     acceptedCards,
@@ -183,6 +190,7 @@ async function detail(req: Request, res: Response): Promise<void> {
     services,
     currentCredential,
     outstandingStripeSetupTasks,
+    stripeDashboardUri,
     messages: req.flash('info'),
     csrf: req.csrfToken()
   })

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -69,10 +69,10 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for id in service.gateway_account_ids %}
+        {% for account in serviceGatewayAccounts %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ id }}">{{id}}</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ account.gateway_account_id }}">{{account.payment_provider}} ({{account.type}})</a>
           </td>
         </tr>
         {% endfor %}

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -132,7 +132,13 @@
         {% if transaction.gateway_transaction_id %}
         <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Provider transaction</span></th>
-          <td class="govuk-table__cell payment__cell">{{ transaction.gateway_transaction_id }}</td>
+          <td class="govuk-table__cell payment__cell">
+            {% if stripeDashboardUri %}
+              <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ stripeDashboardUri }}">{{ transaction.gateway_transaction_id }}</a>
+            {% else %}
+              {{ transaction.gateway_transaction_id }}
+            {% endif %}
+          </td>
         </tr>
         {% endif %}
         <tr class="govuk-table__row">

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -100,6 +100,7 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     const account = await Connector.account(transaction.gateway_account_id)
     const service = await AdminUsers.gatewayAccountServices(transaction.gateway_account_id)
     const relatedTransactions = []
+    let stripeDashboardUri = ''
 
     const transactionEvents = await Ledger.events(
       transaction.transaction_id,
@@ -122,12 +123,18 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     }
 
     const renderKey = transaction.transaction_type.toLowerCase()
+
+    if (transaction.gateway_transaction_id && account.payment_provider === 'stripe') {
+      stripeDashboardUri = `https://dashboard.stripe.com/${transaction.live ? '' : 'test/'}payments/${transaction.gateway_transaction_id}`
+    }
+
     res.render(`transactions/${renderKey}`, {
       transaction,
       relatedTransactions,
       account,
       service,
-      events
+      events,
+      stripeDashboardUri
     })
   } catch (error) {
     next(error)

--- a/src/web/modules/transactions/types/ledger.ts
+++ b/src/web/modules/transactions/types/ledger.ts
@@ -60,6 +60,7 @@ export interface Transaction {
   transaction_type: string;
   parent_transaction_id?: string;
   parent?: Transaction;
+  live: boolean;
 }
 
 export interface Event {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -59,7 +59,7 @@ const configureSecureHeaders = function configureSecureHeaders(instance) {
       styleSrc: [ '\'self\'', '\'unsafe-inline\'' ]
     }
   }))
-
+  instance.use(helmet.crossOriginResourcePolicy({ policy: "cross-origin" }))
   instance.use(csurf())
 }
 


### PR DESCRIPTION
### WHAT

Toolbox now provides links to corresponding entities in the stripe dashboard for payments and gateway accounts. These links are context aware and will route to the correct Stripe environment.

Additionally:
- Toolbox now provides a [CORP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)), this fixes a bug preventing GitHub avatars loading
- Toolbox now shows the payment provider and type when listing gateway accounts associated with a service (previously just id was shown)
