### PR TITLE
PP-8827: Implement remove user from service functionality

### DIFF
--- a/src/lib/pay-request/api_utils/adminUsers.js
+++ b/src/lib/pay-request/api_utils/adminUsers.js
@@ -87,10 +87,8 @@ const adminUsersMethods = function adminUsersMethods(instance) {
 
   const removeUserFromService = function removeUserFromService(serviceId, userId) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    // const path = `/v1/api/services/${serviceId}/users/${userId}`
-
-    // @TODO(sfount) make sure admin headers are correctly set to allow user to be removed
-    throw new NotImplementedError(`Remove user from service end point not configured [user=${userId}] [service=${serviceId}]`)
+    const path = `/v1/api/toolbox/services/${serviceId}/users/${userId}`
+    return axiosInstance.delete(path)
   }
 
   const resetUserSecondFactor = function resetUserSecondFactor(id) {

--- a/src/web/modules/users/deleteUserFromService.njk
+++ b/src/web/modules/users/deleteUserFromService.njk
@@ -6,7 +6,7 @@
   <h1 class="govuk-heading-m">Are you sure you want to remove {{ payUser.email }} from {{ service.name }}?</h1>
   <div id="confirm-remove-user-dialog" class="govuk-body">
     <form id="remove-team-member-form" method="post" action="/users/{{ userId }}/service/{{ serviceId }}/delete">
-      <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}"/>
+      <input id="csrf" name="_csrf" type="hidden" value="{{ csrf }}"/>
 
       {{
         govukButton({

--- a/src/web/modules/users/users.http.ts
+++ b/src/web/modules/users/users.http.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { wrapAsyncErrorHandler } from '../../../lib/routes'
 import { AdminUsers } from '../../../lib/pay-request'
+import logger from '../../../lib/logger'
 
 import UpdateEmailFormRequest from './UpdateEmailForm'
 import UpdatePhoneNumberFormRequest from './UpdatePhoneNumberForm'
@@ -145,8 +146,10 @@ const removeUserFromService = async function removeUserFromService(
   res: Response
 ): Promise<void> {
   const { serviceId, userId } = req.params
+  logger.info("Removing user from service.", { user_external_id: userId, service_external_id: serviceId })
   await AdminUsers.removeUserFromService(serviceId, userId)
-
+  logger.info("Removed user from service.", { user_external_id: userId, service_external_id: serviceId })
+  
   req.flash('info', `User ${userId} removed from service ${serviceId}`)
   res.redirect(`/users/${userId}`)
 }

--- a/src/web/modules/users/users.http.ts
+++ b/src/web/modules/users/users.http.ts
@@ -10,7 +10,7 @@ import { EntityNotFoundError, IOValidationError } from '../../../lib/errors'
 
 const show = async function show(req: Request, res: Response): Promise<void> {
   const payUser = await AdminUsers.user(req.params.id)
-  const context = { payUser, messages: req.flash('info'), _csrf: req.csrfToken() }
+  const context = { payUser, messages: req.flash('info'), csrf: req.csrfToken() }
 
   res.render('users/users.show.njk', context)
 }
@@ -158,7 +158,7 @@ const confirmRemoveUserFromService = async function confirmRemoveUserFromService
   const { serviceId, userId } = req.params
   const payUser = await AdminUsers.user(userId)
   const service = await AdminUsers.service(serviceId)
-  const context = { payUser, serviceId, userId, service, _csrf: req.csrfToken() }
+  const context = { payUser, serviceId, userId, service, csrf: req.csrfToken() }
 
   res.render('users/deleteUserFromService.njk', context)
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -131,7 +131,7 @@ router.post('/users/:id/email', auth.secured, users.updateEmail)
 
 // @TODO(sfount) PATCH and DELETE respectively
 router.get('/users/:id/toggle', auth.secured, users.toggleUserEnabled)
-router.get('/users/:userId/service/:serviceId/delete', auth.secured, users.removeUserFromService)
+router.post('/users/:userId/service/:serviceId/delete', auth.secured, auth.administrative, users.removeUserFromService)
 router.get('/users/:userId/service/:serviceId/delete-confirm', auth.secured, users.confirmRemoveUserFromService)
 router.get('/users/:id/2FA/reset', auth.secured, users.resetUserSecondFactor)
 


### PR DESCRIPTION
As this is destructive functionality we're adding the `auth.administrative` middleware to the `/users/:userId/service/:serviceId/delete` endpoint.