### PR TITLE
PP-9553 Add button to enable recurring payments on gateway account

### DIFF
--- a/src/lib/pay-request/api_utils/connector.js
+++ b/src/lib/pay-request/api_utils/connector.js
@@ -270,6 +270,17 @@ const connectorMethods = function connectorMethods(instance) {
     return !gatewayAccount.allow_authorisation_api
   }
 
+  async function toggleRecurringEnabled(id) {
+    const gatewayAccount = await account(id)
+    const url = `/v1/api/accounts/${id}`
+    await axiosInstance.patch(url, {
+      op: 'replace',
+      path: 'recurring_enabled',
+      value: !gatewayAccount.recurring_enabled
+    })
+    return !gatewayAccount.recurring_enabled
+  }
+
   function addGatewayAccountCredentialsForSwitch(id, paymentProvider, credentials) {
     const url = `/v1/api/accounts/${id}/credentials`
     return axiosInstance.post(url, {
@@ -323,7 +334,8 @@ const connectorMethods = function connectorMethods(instance) {
     addGatewayAccountCredentialsForSwitch,
     enableSwitchFlagOnGatewayAccount,
     toggleRequiresAdditionalKycData,
-    toggleAllowAuthorisationApi
+    toggleAllowAuthorisationApi,
+    toggleRecurringEnabled
   }
 }
 

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -433,6 +433,34 @@
     </div>
   {% endif %}
 
+    {% if account.recurring_enabled === false %}
+    <div>
+      <h1 class="govuk-heading-s">Recurring card payments disabled</h1>
+      <p class="govuk-body">If enabled, recurring card payments can be taken, and agreements and their payment instruments show in the admin tool.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_recurring_enabled">
+        {{ govukButton({
+          text: "Enable recurring card payments",
+          classes: "govuk-button--warning"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
+
+  {% if account.recurring_enabled === true %}
+    <div>
+      <h1 class="govuk-heading-s">Recurring card payments enabled</h1>
+      <p class="govuk-body">Recurring card payments can be taken, and agreements and their payment instruments show in the admin tool.</p>
+      <form method="POST" action="/gateway_accounts/{{ gatewayAccountId }}/toggle_recurring_enabled">
+        {{ govukButton({
+          text: "Disable recurring card payments"
+          })
+        }}
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+      </form>
+    </div>
+  {% endif %}
 
   {% if account.send_payer_ip_address_to_gateway === true %}
     <div>

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -372,6 +372,17 @@ async function toggleAllowAuthorisationApi(
   res.redirect(`/gateway_accounts/${id}`)
 }
 
+async function toggleRecurringEnabled(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const { id } = req.params
+  const enabled = await Connector.toggleRecurringEnabled(id)
+
+  req.flash('info', `Recurring card payments ${enabled ? 'enabled' : 'disabled'}`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
 async function updateStripeStatementDescriptorPage(
   req: Request,
   res: Response
@@ -644,5 +655,6 @@ export default {
   createAgentInitiatedMotoProduct: wrapAsyncErrorHandler(createAgentInitiatedMotoProduct),
   toggleWorldpayExemptionEngine: wrapAsyncErrorHandler(toggleWorldpayExemptionEngine),
   toggleRequiresAdditionalKycData: wrapAsyncErrorHandler(toggleRequiresAdditionalKycData),
-  toggleAllowAuthorisationApi: wrapAsyncErrorHandler(toggleAllowAuthorisationApi)
+  toggleAllowAuthorisationApi: wrapAsyncErrorHandler(toggleAllowAuthorisationApi),
+  toggleRecurringEnabled: wrapAsyncErrorHandler(toggleRecurringEnabled)
 }

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -43,5 +43,6 @@ export default {
   createAgentInitiatedMotoProduct: http.createAgentInitiatedMotoProduct,
   toggleWorldpayExemptionEngine: http.toggleWorldpayExemptionEngine,
   toggleRequiresAdditionalKycData: http.toggleRequiresAdditionalKycData,
-  toggleAllowAuthorisationApi: http.toggleAllowAuthorisationApi
+  toggleAllowAuthorisationApi: http.toggleAllowAuthorisationApi,
+  toggleRecurringEnabled: http.toggleRecurringEnabled
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -78,6 +78,7 @@ router.post('/gateway_accounts/:id/toggle_worldpay_exemption_engine', auth.secur
 router.post('/gateway_accounts/:id/toggle_send_reference_to_gateway', auth.secured, gatewayAccounts.toggleSendReferenceToGateway)
 router.post('/gateway_accounts/:id/toggle_requires_additional_kyc_data', auth.secured, gatewayAccounts.toggleRequiresAdditionalKycData)
 router.post('/gateway_accounts/:id/toggle_allow_authorisation_api', auth.secured, gatewayAccounts.toggleAllowAuthorisationApi)
+router.post('/gateway_accounts/:id/toggle_recurring_enabled', auth.secured, gatewayAccounts.toggleRecurringEnabled)
 router.get('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptorPage)
 router.post('/gateway_accounts/:id/stripe_statement_descriptor', auth.secured, gatewayAccounts.updateStripeStatementDescriptor)
 router.get('/gateway_accounts/:id/stripe_payout_descriptor', auth.secured, gatewayAccounts.updateStripePayoutDescriptorPage)


### PR DESCRIPTION
Add a fine button to enable or disable recurring payments for a gateway account. Button comes in both red (to enable) and green (to disable) with other colours available for a custom development fee.

Tested this locally and it flipped that boolean in the database real good.