### PR TITLE
BAU Set government_entity_document flag when Stripe test account created

### DIFF
--- a/src/web/modules/stripe/basic/test-account.http.ts
+++ b/src/web/modules/stripe/basic/test-account.http.ts
@@ -98,7 +98,8 @@ async function createTestGatewayAccount(serviceId: string, serviceName: string, 
         'company_number',
         'responsible_person',
         'vat_number',
-        'director'
+        'director',
+        'government_entity_document'
     ])
     logger.info(`Set Stripe setup values to 'true' for Stripe test Gateway Account ${gatewayAccountIdDerived}`)
 


### PR DESCRIPTION
When we create a Stripe test account, we set all the setup flags to completed so that we don't ask services to provide any additional information, as all dummy information required to verify a test account is provided upfront.

We recently added the government_entity_document flag, but weren't setting this when creating test accounts.

<img width="1270" alt="Screenshot 2022-05-04 at 12 11 25" src="https://user-images.githubusercontent.com/5648592/166670985-7cbe8109-f4f1-4c74-90d0-843c89277304.png">

