### PR TITLE
PP-9632 Allow configuruing reply-to email per account

### DIFF
--- a/src/web/modules/gateway_accounts/email_branding.njk
+++ b/src/web/modules/gateway_accounts/email_branding.njk
@@ -34,6 +34,14 @@
       autocomplete: "off"
     })
     }}
+    {{ govukInput({
+      id: "email_reply_to_id",
+      name: "email_reply_to_id",
+      label: { text: "Reply-to email address id (can be empty)" },
+      hint: { html: "This is the id of the reply-to email address to use if the Notify service has multiple reply-to email addresses configured." },
+      autocomplete: "off"
+    })
+    }}
 
     {{ govukButton({
     text: "Update email branding"

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -261,9 +261,13 @@ async function emailBranding(req: Request, res: Response): Promise<void> {
 async function updateEmailBranding(req: Request, res: Response):
   Promise<void> {
   const { id } = req.params
-  const notifySettings = req.body
-  // eslint-disable-next-line no-underscore-dangle
-  delete notifySettings._csrf
+  const { api_token, template_id, refund_issued_template_id, email_reply_to_id } = req.body
+  const notifySettings = {
+    api_token,
+    template_id,
+    refund_issued_template_id,
+    ...email_reply_to_id && { email_reply_to_id }
+  }
 
   await Connector.updateEmailBranding(id, notifySettings)
   req.flash('info', 'Email custom branding successfully updated')


### PR DESCRIPTION
Allow setting the "email_reply_to_id" property on the "notify_settings" object on the gateway account. This allows us to specify different reply-to email addresses for services for the same organisation that require the same email branding whilst using the same Notify service.