### PR TITLE
PP-9814 Configure typed clients

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -28,13 +28,13 @@ export class RESTClientError extends Error {
 
   public data: AxiosError
 
-  public service: { key: string; name: string }
+  public service: string
 
-  public constructor(error: AxiosError, serviceKey: string, serviceName: string) {
+  public constructor(error: AxiosError, serviceName: string) {
     super(error.message)
     this.name = this.constructor.name
     this.data = error
-    this.service = { key: serviceKey, name: serviceName }
+    this.service = serviceName
     this.stack = error.stack
   }
 }

--- a/src/lib/pay-request/config.ts
+++ b/src/lib/pay-request/config.ts
@@ -1,0 +1,47 @@
+import { getNamespace } from 'cls-hooked'
+
+import { config } from './typed_clients/client'
+import { PayRequestContext } from './typed_clients/base'
+const logger = require('../logger')
+
+function transformRequestAddHeaders() {
+  const session = getNamespace('govuk-pay-logging')
+
+  const correlationId = session.get('correlation_id')
+  return {
+    ...(correlationId && { 'x-request-id': correlationId })
+  }
+}
+
+function successResponse(context: PayRequestContext) {
+  const logContext = {
+    service: context.service,
+    method: context.method,
+    status_code: context.status,
+    url: context.url,
+    response_time: context.responseTime,
+    excludeFromBreadcrumb: true
+  }
+  logger.info(`Pay request ${context.service} success from ${context.method} ${context.url}`, logContext)
+}
+
+function failureResponse(context: PayRequestContext) {
+  const logContext = {
+    service: context.service,
+    method: context.method,
+    status_code: context.status,
+    error_code: context.code,
+    url: context.url,
+    response_time: context.responseTime,
+    excludeFromBreadcrumb: true
+  }
+  logger.info(`Pay request ${context.service} failed from ${context.method} ${context.url}`, logContext)
+}
+
+export function configureClients() {
+  config(process.env, {
+    transformRequestAddHeaders,
+    successResponse,
+    failureResponse
+  })
+} 

--- a/src/lib/pay-request/typed_clients/client.ts
+++ b/src/lib/pay-request/typed_clients/client.ts
@@ -12,11 +12,11 @@ const clients: {
   PublicAuth: _PublicAuth;
   AdminUsers: _AdminUsers;
 } = {
-  Connector: new _Connector(process.env.CONNECTOR_URL || '', {}),
-  Ledger: new _Ledger(process.env.LEDGER_URL || '', {}),
-  Products: new _Products(process.env.PRODUCTS_URL || '', {}),
-  PublicAuth: new _PublicAuth(process.env.PUBLICAUTH_URL || '', {}),
-  AdminUsers: new _AdminUsers(process.env.ADMINUSERS_URL || '', {})
+  Connector: new _Connector(),
+  Ledger: new _Ledger(),
+  Products: new _Products(),
+  PublicAuth: new _PublicAuth(),
+  AdminUsers: new _AdminUsers()
 }
 
 export const Connector = clients.Connector

--- a/src/lib/pay-request/typed_clients/services/admin_users/client.ts
+++ b/src/lib/pay-request/typed_clients/services/admin_users/client.ts
@@ -18,8 +18,8 @@ import { App } from '../../shared'
  * service.
  */
 export default class AdminUsers extends Client {
-  constructor(baseUrl: string, options: PayHooks) {
-    super(baseUrl, App.AdminUsers, options)
+  constructor() {
+    super(App.AdminUsers)
   }
 
   services = ((client: AdminUsers): {
@@ -48,15 +48,13 @@ export default class AdminUsers extends Client {
         : {}
       return client._axios
         .get(url, config)
-        .then(response => client._unpackResponseData<Service>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<Service>(response));
     },
 
     list(): Promise<Service[] | undefined> {
       return client._axios
         .get('/v1/api/services/list')
-        .then(response => client._unpackResponseData<Service[]>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<Service[]>(response));
     },
 
     /**
@@ -76,15 +74,13 @@ export default class AdminUsers extends Client {
 
       return client._axios
         .patch(`/v1/api/services/${id}`, payload)
-        .then(response => client._unpackResponseData<Service>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<Service>(response));
     },
 
     listUsers(id: string): Promise<User[] | undefined> {
       return client._axios
         .get(`/v1/api/services/${id}/users`)
-        .then(response => client._unpackResponseData<User[]>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<User[]>(response));
     }
   }))(this)
 
@@ -101,8 +97,7 @@ export default class AdminUsers extends Client {
 
       return action
         .then(response => client._unpackResponseData<User>(response))
-        .then(user => { console.log('redact otp'); return redactOTP(user) })
-        .catch(client._unpackErrorResponse)
+        .then(user => { console.log('redact otp'); return redactOTP(user) });
     },
 
     /**
@@ -119,15 +114,13 @@ export default class AdminUsers extends Client {
 
       return client._axios
         .patch(`/v1/api/users/${id}`, payload)
-        .then(response => client._unpackResponseData<User>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<User>(response));
     },
 
     resetSecondFactor(id: string): Promise<User | undefined> {
       return client._axios
         .post(`/v1/api/users/${id}/reset-second-factor`)
-        .then(response => client._unpackResponseData<User>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<User>(response));
     }
   }))(this)
 }

--- a/src/lib/pay-request/typed_clients/services/connector/client.ts
+++ b/src/lib/pay-request/typed_clients/services/connector/client.ts
@@ -22,8 +22,8 @@ import { App } from '../../shared'
  * service.
  */
 export default class Connector extends Client {
-  constructor(baseUrl: string, options: PayHooks) {
-    super(baseUrl, App.Connector, options)
+  constructor() {
+    super(App.Connector)
   }
 
   charges = ((client: Connector) => ({
@@ -36,7 +36,6 @@ export default class Connector extends Client {
         return client._axios
           .get(`/v1/frontend/charges/${id}`)
           .then(response => client._unpackResponseData<Charge>(response))
-          .catch(error => client._unpackErrorResponse(error, 'Charge', id))
     }
   }))(this)
 
@@ -50,7 +49,6 @@ export default class Connector extends Client {
       return client._axios
         .get(`/v1/api/accounts/${id}`)
         .then(response => client._unpackResponseData<GatewayAccount>(response))
-        .catch(client._unpackErrorResponse)
     },
 
     /**
@@ -62,7 +60,6 @@ export default class Connector extends Client {
       return client._axios
         .get(`/v1/frontend/accounts/${id}`)
         .then(response => client._unpackResponseData<GatewayAccountFrontend>(response))
-        .catch(client._unpackErrorResponse)
     },
 
     /**
@@ -75,7 +72,6 @@ export default class Connector extends Client {
       return client._axios
         .get(`/v1/api/accounts/${id}/stripe-account`)
         .then(response => client._unpackResponseData<StripeCredentials>(response))
-        .catch(client._unpackErrorResponse)
     },
 
     /**
@@ -88,7 +84,6 @@ export default class Connector extends Client {
       return client._axios
         .get(`/v1/frontend/accounts/${id}/card-types`)
         .then(response => client._unpackResponseData<ListCardTypesResponse>(response))
-        .catch(client._unpackErrorResponse)
     },
 
     /*
@@ -100,7 +95,6 @@ export default class Connector extends Client {
       return client._axios
         .get('/v1/api/accounts', { params: filters})
         .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
-        .catch(client._unpackErrorResponse)
     },
 
     /**
@@ -111,8 +105,7 @@ export default class Connector extends Client {
     create(params: CreateGatewayAccountRequest): Promise<CreateGatewayAccountResponse | undefined> {
       return client._axios
         .post('/v1/api/accounts', params)
-        .then(response => client._unpackResponseData<CreateGatewayAccountResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<CreateGatewayAccountResponse>(response));
     },
 
     /**
@@ -132,10 +125,9 @@ export default class Connector extends Client {
 
       return client._axios
         .patch(`/v1/api/accounts/${id}`, payload)
-        .then(() => { return })
+        .then(() => { return });
         // @TODO(sfount) decide if this should return the updated account -- could determine through uses of it
         // .then(() => this.retrieveAPI(id))
-        .catch(client._unpackErrorResponse)
     }
 
   }))(this)
@@ -148,8 +140,7 @@ export default class Connector extends Client {
     list(): Promise<ListCardTypesResponse | undefined> {
       return client._axios
         .get('/v1/api/card-types')
-        .then(response => client._unpackResponseData<ListCardTypesResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<ListCardTypesResponse>(response));
     }
   }))(this)
 }

--- a/src/lib/pay-request/typed_clients/services/ledger/client.ts
+++ b/src/lib/pay-request/typed_clients/services/ledger/client.ts
@@ -37,8 +37,8 @@ import {
 } from '../../shared'
 
 export default class Ledger extends Client {
-  constructor(baseUrl: string, options: PayHooks) {
-    super(baseUrl, App.Ledger, options)
+  constructor() {
+    super(App.Ledger)
   }
 
   payments = ((client: Ledger) => ({
@@ -52,8 +52,7 @@ export default class Ledger extends Client {
     ): Promise<Payment | undefined> {
       return client._axios
         .get(`/v1/transaction/${id}`, { params })
-        .then(response => client._unpackResponseData<Payment>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<Payment>(response));
     },
 
     list(
@@ -70,8 +69,7 @@ export default class Ledger extends Client {
       }
       return client._axios
         .get('/v1/transaction', { params: paymentFilters })
-        .then(response => client._unpackResponseData<SearchResponse<Payment>>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<SearchResponse<Payment>>(response));
     },
 
     /**
@@ -81,8 +79,7 @@ export default class Ledger extends Client {
     listRefunds(id: string, params: ListPaymentRefundsRequest): Promise<ListPaymentRefundsResponse | undefined> {
       return client._axios
         .get(`/v1/transaction/${id}/transaction`, { params })
-        .then(response => client._unpackResponseData<ListPaymentRefundsResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<ListPaymentRefundsResponse>(response));
     }
   }))(this)
 
@@ -97,8 +94,7 @@ export default class Ledger extends Client {
     ): Promise<Refund | undefined> {
       return client._axios
         .get(`/v1/transaction/${id}`, { params })
-        .then(response => client._unpackResponseData<Refund>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<Refund>(response));
     },
 
     list(
@@ -113,8 +109,7 @@ export default class Ledger extends Client {
 
       return client._axios
         .get('/v1/transaction', { params: refundFilters })
-        .then(response => client._unpackResponseData<SearchResponse<Refund>>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<SearchResponse<Refund>>(response));
     }
   }))(this)
 
@@ -128,8 +123,7 @@ export default class Ledger extends Client {
     listEvents(id: string, params: ListTransactionEventsRequest): Promise<ListTransactionEventsResponse | undefined> {
       return client._axios
         .get(`/v1/transaction/${id}/event`, { params })
-        .then(response => client._unpackResponseData<ListTransactionEventsResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<ListTransactionEventsResponse>(response));
     }
   }))(this)
 
@@ -151,8 +145,7 @@ export default class Ledger extends Client {
             resource_type: event.resource_type.toUpperCase() as ResourceType,
             payment_provider: event.payment_provider.replace(/"/g, '') as PaymentProvider
           }))
-        )
-        .catch(client._unpackErrorResponse)
+        );
     }
   }))(this)
 
@@ -160,15 +153,13 @@ export default class Ledger extends Client {
     retrievePaymentSummaryByState(params: PaymentsByStateWithAccountOverrideRequest | PaymentsByStateForAccountRequest): Promise<PaymentCountByStateReport | undefined> {
       return client._axios
         .get('/v1/report/payments_by_state', { params })
-        .then(response => client._unpackResponseData<PaymentCountByStateReport>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<PaymentCountByStateReport>(response));
     },
 
     retrieveTransactionSummary(params: TransactionSummaryWithAccountOverrideRequest | TransactionSummaryForAccountRequest): Promise<TransactionSummaryReport | undefined> {
       return client._axios
         .get('/v1/report/transactions-summary', { params })
-        .then(response => client._unpackResponseData<TransactionSummaryReport>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<TransactionSummaryReport>(response));
     },
 
     /**
@@ -180,22 +171,19 @@ export default class Ledger extends Client {
     listTransactionSummaryByHour(params: TransactionsByHourRequest): Promise<TransactionsByHourReport | undefined> {
       return client._axios
         .get('/v1/report/transactions-by-hour', { params })
-        .then(response => client._unpackResponseData<TransactionsByHourReport>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<TransactionsByHourReport>(response));
     },
 
     retrievePerformanceSummary(params: PerformanceReportRequest): Promise<PerformanceReport | undefined> {
       return client._axios
         .get('/v1/report/performance-report', { params })
-        .then(response => client._unpackResponseData<PerformanceReport>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<PerformanceReport>(response));
     },
 
     retrievePerformanceSummaryByGateway(params: GatewayPerformanceReportRequest): Promise<GatewayPerformanceReport | undefined> {
       return client._axios
         .get('/v1/report/gateway-performance-report', { params })
-        .then(response => client._unpackResponseData<GatewayPerformanceReport>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<GatewayPerformanceReport>(response));
     }
   }))(this)
 
@@ -209,8 +197,7 @@ export default class Ledger extends Client {
 
       return client._axios
         .get('/v1/payout', { params: payoutParams })
-        .then(response => client._unpackResponseData<SearchResponse<Payout>>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<SearchResponse<Payout>>(response));
     }
   }))(this)
 }

--- a/src/lib/pay-request/typed_clients/services/products/client.ts
+++ b/src/lib/pay-request/typed_clients/services/products/client.ts
@@ -8,8 +8,8 @@ import {
 import { App } from '../../shared'
 
 export default class Products extends Client {
-  constructor(baseUrl: string, options: PayHooks) {
-    super(baseUrl, App.Products, options)
+  constructor() {
+    super(App.Products)
   }
 
   accounts = ((client: Products) => ({
@@ -20,8 +20,7 @@ export default class Products extends Client {
       return client._axios
         .get(`/v1/api/gateway-account/${id}/products`)
         .then(response => client._unpackResponseData<Product[]>(response))
-        .then(redactProductTokens)
-        .catch(client._unpackErrorResponse)
+        .then(redactProductTokens);
     }
   }))(this)
 
@@ -30,8 +29,7 @@ export default class Products extends Client {
       return client._axios
         .get('/v1/api/stats/products', { params })
         .then(response => client._unpackResponseData<ProductStat[]>(response))
-        .then(redactProductStatTokens)
-        .catch(client._unpackErrorResponse)
+        .then(redactProductStatTokens);
     }
   }))(this)
 }

--- a/src/lib/pay-request/typed_clients/services/public_auth/client.ts
+++ b/src/lib/pay-request/typed_clients/services/public_auth/client.ts
@@ -8,8 +8,8 @@ import {
 import { App } from '../../shared'
 
 export default class PublicAuth extends Client {
-  constructor(baseUrl: string, options: PayHooks) {
-    super(baseUrl, App.PublicAuth, options)
+  constructor() {
+    super(App.PublicAuth)
   }
 
   tokens = ((client: PublicAuth) => ({
@@ -19,16 +19,14 @@ export default class PublicAuth extends Client {
     list(params: ListTokenRequest): Promise<ListTokenResponse | undefined> {
       return client._axios
         .get(`/v1/frontend/auth/${params.gateway_account_id}`)
-        .then(response => client._unpackResponseData<ListTokenResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<ListTokenResponse>(response));
     },
 
     delete(params: DeleteTokenRequest): Promise<DeleteTokenResponse | undefined> {
       const data = { token_link: params.token_link }
       return client._axios
         .delete(`/v1/frontend/auth/${params.gateway_account_id}`, { data })
-        .then(response => client._unpackResponseData<DeleteTokenResponse>(response))
-        .catch(client._unpackErrorResponse)
+        .then(response => client._unpackResponseData<DeleteTokenResponse>(response));
     }
   }))(this)
 }

--- a/src/web/errorHandler.ts
+++ b/src/web/errorHandler.ts
@@ -28,7 +28,7 @@ const handleRequestErrors = function handleRequestErrors(
   // could not access end point - gracefully show service that we were trying to access
   if (error instanceof RESTClientError) {
     if (error.data.code === 'ECONNREFUSED' || error.data.code === 'ECONNRESET') {
-      const message = `${error.service.name} API endpoint is unavailable (${error.data.code})`
+      const message = `${error.service} API endpoint is unavailable (${error.data.code})`
       Sentry.captureException(error)
       res.status(503).render('common/error', { message })
       return
@@ -36,7 +36,7 @@ const handleRequestErrors = function handleRequestErrors(
 
     if (error.data.response && error.data.response.data && error.data.response.data.errors) {
       // take the first data response and present as error
-      const message = `${error.service.name}: ${error.data.response.data.errors[0]}`
+      const message = `${error.service}: ${error.data.response.data.errors[0]}`
 
       // all 5xx responses should be triaged in Sentry
       if (String(error.data.response.status).startsWith('5')) {


### PR DESCRIPTION
When the server starts, configure the typed clients to:
- pull the correlation id out of the logging context stored using
cls-hooked and use this to set the `x-request-id` header on requests.
- log the details of the request on success/failure.

Ensure that the Axios interceptors are only added once, when the `config`
method of `src/lib/pay-request/typed_clients/client.ts` is called, which
is done in the server startup. To do this, remove configuring Axios from
the constructor for the Clients.

Handle errors thrown by Axios when making requests in the way toolbox
currently handles these errors from the old client code.

The typed clients were previously wrapping errors using the `HttpError`
per request. Instead, wrap the AxoisError into the RESTClientError type
already used by toolbox, which the error handling middleware already
handles correctly. Do this wrapping in the Axios response interceptor,
rather than per request.