### PR TITLE
PP-9626 Display related transaction type

### DIFF
--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -98,6 +98,11 @@
             <a class="govuk-link govuk-link--no-visited-state" href="/transactions/{{transaction.transaction_id}}">{{ transaction.transaction_id }}
           </td>
           <td class="govuk-table__cell payment__cell">
+            <th class="govuk-table__cell payment__cell" scope="row">
+              <span class="govuk-caption-m">{{ transaction.transaction_type | capitalize }}</span>
+            </th>
+          </td>
+          <td class="govuk-table__cell payment__cell">
             <th class="govuk-table__cell payment__cell text-right" scope="row">
               <span class="govuk-caption-m">{{ transaction.created_date | formatDateLong }}</span>
             </th>


### PR DESCRIPTION
In the "Related transactions" table on the payment page, add a column for the transaction type. This will currently be either "Refund" or "Dispute"

<img width="770" alt="Screenshot 2022-07-11 at 17 35 24" src="https://user-images.githubusercontent.com/5648592/178313883-11f822fa-308e-4504-b0b4-b784cbf704ec.png">
