### PR TITLE
BAU — Put requirements for statement descriptors in more places

### DIFF
--- a/src/web/modules/gateway_accounts/stripe_payout_descriptor.njk
+++ b/src/web/modules/gateway_accounts/stripe_payout_descriptor.njk
@@ -24,7 +24,7 @@
       name: "statement_descriptor",
       label: { text: "Stripe payout descriptor" },
       hint: {
-        text: "Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
+        text: "Latin characters only. Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
       },
       autocomplete: "off"
     })

--- a/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
+++ b/src/web/modules/gateway_accounts/stripe_statement_descriptor.njk
@@ -11,7 +11,7 @@
   </div>
 
   <p class="govuk-body">
-    The Stripe statement descriptor is what the user paying a service will see in their bank account. It's important that this
+    The Stripe statement descriptor is what the user paying a service will see in their bank account. It’s important that this
     correctly identifies the service to avoid chargebacks from confused users. This tool will update the Stripe Connect account.
   </p>
 
@@ -29,7 +29,7 @@
       name: "statement_descriptor",
       label: { text: "Stripe statement descriptor" },
       hint: {
-        text: "Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
+        text: "Latin characters only. Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
       },
       autocomplete: "off"
     })

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -42,7 +42,7 @@
           text: "Statement descriptor"
         },
         hint: {
-          text: "This is the description to appear on a paying user's bank statement and is usally the name of the organisation accepting payments."
+          text: "This is the description to appear on a paying user’s bank statement and is usally the name of the organisation accepting payments. Latin characters only. Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *"
         }
       }) }}
     {% endset %}

--- a/src/web/modules/stripe/basic/basic.njk
+++ b/src/web/modules/stripe/basic/basic.njk
@@ -37,7 +37,7 @@
   <form method="POST" action="/stripe/basic/create">
     {{ govukInput({
       label: { text: "Statement descriptor" },
-      hint: { text: "Payment description to appear on user's bank statement" },
+      hint: { text: "Payment description to appear on user’s bank statement. Latin characters only. Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *" },
       id: "statementDescriptor",
       name: "statementDescriptor",
       value: formValues.statementDescriptor,


### PR DESCRIPTION
Several forms in toolbox ask for a bank statement descriptor for Stripe services, either to appear on the paying user’s statement, or the service’s statement when they receive a payout, or both.

Consistently specify the requirements for the length and allowed characters for statement descriptors.

Source: https://stripe.com/docs/statement-descriptors#requirements