### PR TITLE
PP-9873 Allow updating dispute transactions

### DIFF
--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -159,11 +159,11 @@ const validateAndAddDefaults = async function validateAndAddDefaults(csv: string
         if (!moment(row.event_date, moment.ISO_8601).isValid()) {
           return cb(null, false, 'event_date is not a valid ISO_8601 string')
         }
-        if (!['payment', 'refund'].includes(row.transaction_type)) {
-          return cb(null, false, 'transaction_type must be one of \'payment\' or \'refund\'')
+        if (!['payment', 'refund', 'dispute'].includes(row.transaction_type)) {
+          return cb(null, false, 'transaction_type must be one of ‘payment’, ‘refund’ or ‘dispute’')
         }
-        if (row.transaction_type === 'refund' && !row.parent_transaction_id) {
-          return cb(null, false, 'parent_transaction_id is required when transaction_type is \'refund\'')
+        if (['refund', 'dispute'].includes(row.transaction_type) && !row.parent_transaction_id) {
+          return cb(null, false, 'parent_transaction_id is required when transaction_type is ‘refund’ or ‘dispute’')
         }
         if (row.captured_date && !moment(row.captured_date, moment.ISO_8601).isValid()) {
           return cb(null, false, 'captured_date is not a valid ISO_8601 string')
@@ -179,25 +179,25 @@ const validateAndAddDefaults = async function validateAndAddDefaults(csv: string
 
         if (row.event_name === 'PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN') {
           if (!row.captured_date) {
-            return cb(null, false, `captured_date is required when event_name is '${row.event_name}'`)
+            return cb(null, false, `captured_date is required when event_name is ‘${row.event_name}’`)
           }
 
           if (!row.refund_status) {
-            return cb(null, false, `refund_status is required when event_name is '${row.event_name}'`)
+            return cb(null, false, `refund_status is required when event_name is ‘${row.event_name}’`)
           }
 
           if (!row.refund_amount_refunded) {
-            return cb(null, false, `refund_amount_refunded is required when event_name is '${row.event_name}'`)
+            return cb(null, false, `refund_amount_refunded is required when event_name is ‘${row.event_name}’`)
           }
 
           if (!row.refund_amount_available) {
-            return cb(null, false, `refund_amount_available is required when event_name is '${row.event_name}'`)
+            return cb(null, false, `refund_amount_available is required when event_name is ‘${row.event_name}’`)
           }
         }
 
         if (row.reproject_domain_object) {
           if (!['true', 'false'].includes(row.reproject_domain_object)) {
-            return cb(null, false, 'reproject_domain_object must be one of \'true\' or \'false\'')
+            return cb(null, false, 'reproject_domain_object must be one of ‘true’ or ‘false’')
           }
         }
 

--- a/src/web/modules/transactions/update/upload.njk
+++ b/src/web/modules/transactions/update/upload.njk
@@ -43,11 +43,11 @@
     <table class="govuk-table">
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">transaction_id</span></th>
-          <td class="govuk-table__cell">The external ID of the payment/refund</td>
+          <td class="govuk-table__cell">The external ID of the transaction</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">transaction_type</span></th>
-          <td class="govuk-table__cell">The type of the transaction, one of ‘payment’ or ‘refund’.</td>
+          <td class="govuk-table__cell">The type of the transaction, one of ‘payment’, ‘refund’ or 'dispute'.</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">event_name</span></th>
@@ -77,11 +77,19 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">parent_transaction_id</span></th>
-          <td class="govuk-table__cell">Required for refunds only, this is the payment external ID.</td>
+          <td class="govuk-table__cell">Required for refunds and disputes, this is the payment external ID.</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">reproject_domain_object</span></th>
           <td class="govuk-table__cell">Whether the event should cause the domain object to be re-projected from previous events, one of ‘true’ or ‘false’. If true, no event will be persisted to the ledger database and any transaction data provided for the row in the CSV will be ignored.</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">service_id</span></th>
+          <td class="govuk-table__cell">The external ID of the service that the transaction belongs to.</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">live</span></th>
+          <td class="govuk-table__cell">Whether the transaction is for a live service. One of ‘true’ or ‘false’.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Edit validation for the transaction update CSV upload to allow for `transaction_type` of dispute, and require the `parent_transaction_id` to be present for a dispute.

Add `live` and service_id` to the optional headers in the instructions for creating the CSV