### PR TITLE
BAU Dispute dispute fee and net amount correctly

### DIFF
--- a/src/web/modules/transactions/dispute.njk
+++ b/src/web/modules/transactions/dispute.njk
@@ -42,12 +42,18 @@
             <span>{{ (transaction.total_amount or transaction.amount) | currency }} </span>
           </td>
         </tr>
+        {% if transaction.fee %}
         <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Dispute fee</span></th>
           <td class="govuk-table__cell payment__cell">
             <span>{{ transaction.fee | currency }} </span>
           </td>
         </tr>
+        <tr class="govuk-table__row ">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Net</span></th>
+          <td class="govuk-table__cell payment__cell">{{ transaction.net_amount | currency }}</td>
+        </tr>
+        {% endif %}
         <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Disputed reason</span></th>
           <td class="govuk-table__cell payment__cell">{{ transaction.reason | capitalize }}</td>


### PR DESCRIPTION
Only display a fee row on the dispute details page when a fee exits. Add a row for the net amount.

Without fee:
<img width="894" alt="Screenshot 2022-07-29 at 16 52 27" src="https://user-images.githubusercontent.com/5648592/181797608-be596a35-a5d1-4193-bac1-a790bd751aef.png">

With fee:
<img width="894" alt="Screenshot 2022-07-29 at 16 53 12" src="https://user-images.githubusercontent.com/5648592/181797622-d3f3bec9-1ccc-43bb-bf0c-e67cfcfc5b6d.png">

