### PR TITLE
PP-9925 rename reason to updated_reason for csv update uploads

### DIFF
--- a/src/web/modules/transactions/update/update.http.ts
+++ b/src/web/modules/transactions/update/update.http.ts
@@ -14,14 +14,15 @@ type TransactionRow = {
   event_name: string;
   event_date: string;
   parent_transaction_id: string;
-  reason?: string;
+  updated_reason: string;
   admin_github_id: string;
   captured_date?: string,
   refund_status?: string,
   refund_amount_refunded?: string,
   refund_amount_available?: string,
   reproject_domain_object?: string,
-  requires_3ds?: boolean
+  requires_3ds?: boolean,
+  reason?: string
 }
 
 export async function fileUpload(req: Request, res: Response): Promise<void> {
@@ -150,8 +151,14 @@ const validateAndAddDefaults = async function validateAndAddDefaults(csv: string
         if (!row.event_name) {
           return cb(null, false, 'event_name is missing')
         }
-        if (['payment', 'refund'].includes(row.transaction_type) && !row.reason) {
-          return cb(null, false, 'reason is missing')
+        if (['payment', 'refund', 'dispute'].includes(row.transaction_type) && !row.updated_reason) {
+          return cb(null, false, 'updated_reason is missing')
+        }
+        if (['payment', 'refund'].includes(row.transaction_type) && row.reason) {
+          return cb(null, false, 'reason is not allowed when transaction_type is ‘payment’ or ‘refund’. did you mean to use ‘updated_reason‘?')
+        }
+        if (['dispute'].includes(row.transaction_type) && !row.reason) {
+          return cb(null, false, 'reason is required when transaction_type is ‘dispute’')
         }
 
         row.admin_github_id = formatSessionUserIdentifier(user)

--- a/src/web/modules/transactions/update/upload.njk
+++ b/src/web/modules/transactions/update/upload.njk
@@ -41,6 +41,7 @@
 
     <div>
     <table class="govuk-table">
+     <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">transaction_id</span></th>
           <td class="govuk-table__cell">The external ID of the transaction</td>
@@ -54,8 +55,12 @@
           <td class="govuk-table__cell">The name of the event that will be stored against the transaction. It should be SCREAMING_SNAKE_CASE and describe the action performed against the transaction in the past tense. Do not use names given to system created events.</td>
         </tr>
         <tr class="govuk-table__row">
-          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">reason</span></th>
+          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">updated_reason</span></th>
           <td class="govuk-table__cell">A free text explanation of why the transaction is being updated. This field will only be used internally as a record so should be as detailed as necessary. Reference Zendesk or JIRA ticket IDs where appropriate.</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell" scope="row"><span class="govuk-caption-m">reason</span></th>
+          <td class="govuk-table__cell">Only applies for disputes. If appears on payments or refunds, the upload shall be rejected</td>
         </tr>
       </tbody>
     </table>
@@ -114,7 +119,7 @@
   </p>
   <p class="govuk-body">
     Most administrative updates will not need to move the external state of a transaction and should follow naming advice
-    as per the table above. For example the event name <code>PAYMENT_UPDATED_TO_MATCH_SERVICE_RECORDS</code> with the 'reason'
+    as per the table above. For example the event name <code>PAYMENT_UPDATED_TO_MATCH_SERVICE_RECORDS</code> with the 'updated_reason'
     and 'reference' fields populated.
   </p>
 


### PR DESCRIPTION
- We currently require CSVs to update transactions uploaded to toolbox to have a “reason” column to explain why the transaction was updated for auditing purposes. Disputes are now using a field also called `reason` to store the reason why a payment was disputed. Change the requirement for the CSV upload to have a column named `update_reason` rather than `reason`.