### PR TITLE
PP-9814 Use typed clients for administrative tasks

### DIFF
--- a/src/lib/pay-request/typed_clients/base.ts
+++ b/src/lib/pay-request/typed_clients/base.ts
@@ -1,8 +1,9 @@
 import http from 'http'
 import https from 'https'
-import axios, { AxiosInstance, AxiosResponse, AxiosError, AxiosRequestConfig, Method } from 'axios'
-import { App } from './shared'
-const { RESTClientError } = require('../../errors')
+import axios, {AxiosInstance, AxiosResponse, AxiosError, AxiosRequestConfig, Method} from 'axios'
+import {App} from './shared'
+
+const {RESTClientError} = require('../../errors')
 
 /** Base HTTP client with common helpers for all microservices */
 export default class Client {
@@ -35,18 +36,21 @@ export default class Client {
       httpsAgent: new https.Agent({
         keepAlive: true,
         rejectUnauthorized: process.env.NODE_ENV === 'production'
-      })
+      }),
+      headers: {
+        'Content-Type': 'application/json'
+      },
     })
     this._axios.interceptors.request.use((request): AxiosRequestConfigWithMetadata => {
       const headers = options.transformRequestAddHeaders ? options.transformRequestAddHeaders() : {}
       Object.entries(headers)
-        .forEach(([ headerKey, headerValue ]) => {
+        .forEach(([headerKey, headerValue]) => {
           request.headers[headerKey] = headerValue
         })
 
       return {
         ...request,
-        metadata: { start: Date.now() }
+        metadata: {start: Date.now()}
       }
     })
 
@@ -85,7 +89,7 @@ export default class Client {
     try {
       await this._axios.get('/healthcheck')
       return true
-    } catch(e) {
+    } catch (e) {
       return false
     }
   }
@@ -111,7 +115,9 @@ interface AxiosRequestConfigWithMetadata extends AxiosRequestConfig {
 export type PayRequestHeaders = { [key: string]: string }
 
 export interface PayHooks {
- transformRequestAddHeaders?(): PayRequestHeaders;
- successResponse?(context: PayRequestContext): void;
- failureResponse?(context: PayRequestContext): void;
+  transformRequestAddHeaders?(): PayRequestHeaders;
+
+  successResponse?(context: PayRequestContext): void;
+
+  failureResponse?(context: PayRequestContext): void;
 }

--- a/src/lib/pay-request/typed_clients/services/connector/client.ts
+++ b/src/lib/pay-request/typed_clients/services/connector/client.ts
@@ -167,4 +167,52 @@ export default class Connector extends Client {
         .then(response => client._unpackResponseData<ListCardTypesResponse>(response));
     }
   }))(this)
+
+
+  eventEmitter = ((client: Connector) => ({
+    emitByIdRange(startId: number, maxId: number, recordType: string, retryDelayInSeconds: number): Promise<void> {
+      const params = {
+        start_id: startId,
+        max_id: maxId,
+        record_type: recordType,
+        do_not_retry_emit_until: retryDelayInSeconds
+      }
+      return client._axios
+        .post('/v1/tasks/historical-event-emitter', null, { params })
+        .then(() => { return })
+    },
+
+    emitByDate(startDate: string, endDate: string, retryDelayInSeconds: number): Promise<void> {
+      const params = {
+        start_date: startDate,
+        end_date: endDate,
+        do_not_retry_emit_until: retryDelayInSeconds
+      }
+      return client._axios
+        .post('/v1/tasks/historical-event-emitter-by-date', null, { params })
+        .then(() => { return })
+    }
+  }))(this)
+
+  parityChecker = ((client: Connector) => ({
+    runParityCheck(
+      startId: number,
+      maxId: number,
+      doNotReprocessValidRecords: boolean,
+      parityCheckStatus: string,
+      retryDelayInSeconds: number,
+      recordType: string) : Promise<void> {
+        const params = {
+          start_id: startId,
+          max_id: maxId,
+          do_not_reprocess_valid_records: doNotReprocessValidRecords,
+          parity_check_status: parityCheckStatus,
+          do_not_retry_emit_until: retryDelayInSeconds,
+          record_type: recordType
+        }
+        return client._axios
+        .post('/v1/tasks/parity-checker', null, { params })
+        .then(() => { return })
+      }
+  }))(this)
 }

--- a/src/web/modules/events/events.http.js
+++ b/src/web/modules/events/events.http.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const { Connector } = require('../../../lib/pay-request')
+const { Connector } = require('../../../lib/pay-request/typed_clients/client')
 const logger = require('../../../lib/logger')
 
 async function emitByIdPage(req, res) {
@@ -31,7 +31,7 @@ async function emitById(req, res) {
   }
 
   try{
-    await Connector.historicalEventEmitter(startId, maxId, recordType, retryDelay)
+    await Connector.eventEmitter.emitByIdRange(startId, maxId, recordType, retryDelay)
     logger.info(`Emitting events successful between ${startId} and ${maxId}`)
 
     res.render('events/success', { startParam: startId, endParam: maxId, action: "emit" })
@@ -62,7 +62,7 @@ async function emitByDate(req, res) {
   }
 
   try{
-    await Connector.historicalEventEmitterByDate(startDate, endDate, retryDelay)
+    await Connector.eventEmitter.emitByDate(startDate, endDate, retryDelay)
     logger.info(`Emitting events successful between ${startDate} and ${endDate}`)
 
     res.render('events/success', { startParam: startDate, endParam: endDate, action: "emit" })
@@ -89,7 +89,7 @@ async function parityCheck(req, res) {
   }
 
   try{
-    await Connector.parityCheck(startId, maxId, doNotReprocessValidRecords, parityCheckStatus, retryDelay, recordType)
+    await Connector.parityChecker.runParityCheck(startId, maxId, doNotReprocessValidRecords, parityCheckStatus, retryDelay, recordType)
     logger.info(`Parity checking events successful between ${startId} and ${maxId}`)
 
     res.render('events/success', { startParam: startId, endParam: maxId, action: "parity check" })


### PR DESCRIPTION
Use typed clients in events.http.js
Send Content-Type header with value 'application/json' for all requests.