### PR TITLE
BAU — Include time with refunds list on payment page

### DIFF
--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -104,7 +104,7 @@
           </td>
           <td class="govuk-table__cell payment__cell">
             <th class="govuk-table__cell payment__cell text-right" scope="row">
-              <span class="govuk-caption-m">{{ transaction.created_date | formatDateLong }}</span>
+              <span class="govuk-caption-m">{{ transaction.created_date | formatDate }}</span>
             </th>
           </td>
         </tr>


### PR DESCRIPTION
On the page for a payment, include the time next to each refund in the related transactions list because it is common for several refund attempts to be made in quick succession.

This will change the displayed timestamp from something like “Mon Oct 03 2022” to something like “3 Oct 2022, 16:45:12 UTC”.