### PR TITLE
PP-9814 Use typed clients for dashboard

### DIFF
--- a/browser/src/dashboard/EventCard.tsx
+++ b/browser/src/dashboard/EventCard.tsx
@@ -50,11 +50,11 @@ const paymentTypeMap: { [key: string]: string } = {
 }
 
 const providerLogoMap: { [key: string]: string } = {
-  '"worldpay"': WorldpayLogo,
-  '"stripe"': StripeLogo,
-  '"epdq"': BarclaysLogo,
-  '"smartpay"': BarclaysLogo,
-  '"sandbox"': SandboxLogo
+  'worldpay': WorldpayLogo,
+  'stripe': StripeLogo,
+  'epdq': BarclaysLogo,
+  'smartpay': BarclaysLogo,
+  'sandbox': SandboxLogo
 }
 
 const profileMap: { [key: string]: CardProfile } = {

--- a/src/lib/pay-request/typed_clients/services/ledger/client.ts
+++ b/src/lib/pay-request/typed_clients/services/ledger/client.ts
@@ -175,7 +175,7 @@ export default class Ledger extends Client {
           .map(event => ({
             ...event,
             resource_type: event.resource_type.toUpperCase() as ResourceType,
-            payment_provider: event.payment_provider.replace(/"/g, '') as PaymentProvider
+            payment_provider: event.payment_provider && event.payment_provider.replace(/"/g, '') as PaymentProvider
           }))
         );
     }

--- a/src/lib/pay-request/typed_clients/services/ledger/client.ts
+++ b/src/lib/pay-request/typed_clients/services/ledger/client.ts
@@ -212,6 +212,12 @@ export default class Ledger extends Client {
         .then(response => client._unpackResponseData<PerformanceReport>(response));
     },
 
+    retrieveLegacyPerformanceSummary(params: PerformanceReportRequest): Promise<PerformanceReport | undefined> {
+      return client._axios
+        .get('/v1/report/performance-report-legacy', {params})
+        .then(response => client._unpackResponseData<PerformanceReport>(response));
+    },
+
     retrievePerformanceSummaryByGateway(params: GatewayPerformanceReportRequest): Promise<GatewayPerformanceReport | undefined> {
       return client._axios
         .get('/v1/report/gateway-performance-report', {params})


### PR DESCRIPTION
Re-applies this with fix for the issue that was causing 500 responses previously:

The issue was that the client method to call the event ticker ledger API endpoint was trying to to manipulate the payment_provider on returned events without checking whether it is present on the event first.