### PR TITLE
BAU: Create Stripe connect account as government_agency

### DIFF
--- a/src/web/modules/stripe/basic/account.ts
+++ b/src/web/modules/stripe/basic/account.ts
@@ -28,7 +28,7 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
   const stripeAccount = await stripeClient.getStripeApi().accounts.create({
     type: 'custom',
     country: 'GB',
-    business_type: 'government_entity',
+    business_type: 'government_agency',
     settings: {
       payments: {
         statement_descriptor: stripeAccountDetails.statementDescriptor,


### PR DESCRIPTION
## WHAT
- Since the new Stripe contract, we have been creating Stripe accounts as government_entity. But verification checks seem different as Stripe has moved the existing connect accounts to `government_agency` to stop triggering additional checks/deadlines on their side.
- Although we got mixed info from Stripe and no confirmation yet for the type of account, we think we should just change it to `government_agency` as it is what Stripe has done for accounts.