### PR TITLE
BAU: Search transactions by email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "passport": "^0.5.3",
         "passport-github": "1.1.0",
         "qs": "6.10.3",
+        "rfc822-validate": "^1.0.0",
         "sass": "^1.55.0",
         "stripe": "^8.174.0",
         "winston": "^3.8.2"
@@ -15078,7 +15079,7 @@
     "node_modules/rfc822-validate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rfc822-validate/-/rfc822-validate-1.0.0.tgz",
-      "integrity": "sha1-aRBPXfnGOjS+A02lQoVq9P9b2Pc=",
+      "integrity": "sha512-FWFY2H1jgdALCel/BfTeTbUrf3AEStTmPD0bOvDIqg1RPGGOizoRLFuQmG9jGDCvOc7do4DBx1wnOlSot+jrsg==",
       "dependencies": {
         "amdefine": "0.0.4"
       }
@@ -29730,7 +29731,7 @@
     "rfc822-validate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rfc822-validate/-/rfc822-validate-1.0.0.tgz",
-      "integrity": "sha1-aRBPXfnGOjS+A02lQoVq9P9b2Pc=",
+      "integrity": "sha512-FWFY2H1jgdALCel/BfTeTbUrf3AEStTmPD0bOvDIqg1RPGGOizoRLFuQmG9jGDCvOc7do4DBx1wnOlSot+jrsg==",
       "requires": {
         "amdefine": "0.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "passport": "^0.5.3",
     "passport-github": "1.1.0",
     "qs": "6.10.3",
+    "rfc822-validate": "^1.0.0",
     "sass": "^1.55.0",
     "stripe": "^8.174.0",
     "winston": "^3.8.2"

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -4,7 +4,7 @@
 
 {% set isTestData = account and not (account.type === "live") %}
 
-{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if transactionType %}&type={{ transactionType }}{% endif %}{% endset %}
+{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if transactionType %}&type={{ transactionType }}{% endif %}{% if filters.reference %}&reference={{ filters.reference }}{% endif %}{% if filters.email %}&email={{ filters.email }}{% endif %}{% endset %}
 
 {% block main %}
   <span class="govuk-caption-m">
@@ -27,13 +27,19 @@
     {% endfor %}
   </div>
 
-  {% if filters.reference or filters.gateway_payout_id %}
+  {% if filters.email or filters.reference or filters.gateway_payout_id %}
     <div class="govuk-body">
       <h4 class="govuk-heading-s">Filtered by</h4>
       {% if filters.reference %}
         <div class="govuk-body">
           <div class="govuk-grid-column-one-third">Reference: </div>
           <span><strong class="govuk-tag">{{ filters.reference }}</strong></span>
+        </div>
+      {% endif %}
+      {% if filters.email %}
+        <div class="govuk-body">
+          <div class="govuk-grid-column-one-third">Email:</div>
+          <span><strong class="govuk-tag">{{ filters.email }}</strong></span>
         </div>
       {% endif %}
       {% if filters.gateway_payout_id %}

--- a/src/web/modules/transactions/search.njk
+++ b/src/web/modules/transactions/search.njk
@@ -10,7 +10,7 @@
     {{ govukInput({
       id: "id",
       name: "id",
-      hint: { text: "GOV.UK Pay external ID, gateway transaction ID or transaction reference" },
+      hint: { text: "GOV.UK Pay external ID, gateway transaction ID, transaction reference or email" },
       label: { text: "Search" }
       })
       }}


### PR DESCRIPTION
## WHAT
- Often on support we get queries from paying users about their transactions. So it would be useful to search transactions by email to offer advice to users or find services to redirect users to.
- Extended functionality to search transactions by email. If no transactions are found continue the search by reference or transaction ID.
- Preview
<img width="527" alt="image" src="https://user-images.githubusercontent.com/40598480/196423166-26cbe065-37bf-431a-af16-5a3e31de2733.png">
