### PR TITLE
BAU Manage dashboard connection state (reconnect on network failures)

### DIFF
--- a/browser/src/dashboard/EventListPanel.tsx
+++ b/browser/src/dashboard/EventListPanel.tsx
@@ -1,23 +1,41 @@
 import React from 'react'
 
 import { Event } from './../../../src/web/modules/transactions/types/ledger'
+import { AggregateSyncStatus } from './Dashboard'
 
 import { EventCard } from './EventCard'
 
 interface EventListPanelProps {
-  events: Event[]
+  sync: AggregateSyncStatus,
+  numberOfAggregateSyncs: number,
+  events: Event[],
+  fetchedServices: boolean,
+  isFetching: boolean
+}
+
+function LoadingCard(props: any): JSX.Element {
+  return <div style={{ backgroundColor: '#f3f2f1', padding: '10px', textAlign: 'center', borderRadius: '3px', marginBottom: '10px', border: '1px solid #b1b4b6' }}>
+      <span style={{ marginRight: '5px' }}>{ props.children }</span>
+      <div className="loader"></div>
+    </div>
 }
 
 export class EventListPanel extends React.Component<EventListPanelProps, {}> {
-
   render() {
-    const events = this.props.events.map((event, index) => {
-      return (
-        // @FIXME(sfount) duplicated event issues being thrown by React - where is this happening?
-        <EventCard key={event.key} event={event} />
-      )
-    })
+    let syncStatus
+    const events = this.props.events.map((event, index) => <EventCard key={event.key} event={event} />)
+    
+    if(this.props.sync && this.props.sync.pending && this.props.numberOfAggregateSyncs <= 1) {
+      syncStatus = <LoadingCard>Sync</LoadingCard>
+    } else if (!this.props.fetchedServices && this.props.isFetching) {
+      syncStatus = <LoadingCard>Getting service data</LoadingCard>
+    } else {
+      syncStatus = ''
+    }
 
-    return <div>{events}</div>
+    return <div>
+      {syncStatus}
+      {events}
+      </div>
   }
 }

--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -258,3 +258,23 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.loader {
+  width: 12px;
+  height: 12px;
+  border: 1px solid $govuk-secondary-text-colour;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+  }
+
+  @keyframes rotation {
+  0% {
+      transform: rotate(0deg);
+  }
+  100% {
+      transform: rotate(360deg);
+  }
+} 

--- a/src/web/modules/transactions/types/ledger.ts
+++ b/src/web/modules/transactions/types/ledger.ts
@@ -76,6 +76,5 @@ export interface Event {
   is_recent?: boolean
   card_brand?: string
   timestamp?: number
-  historic?: boolean
   key?: string
 }


### PR DESCRIPTION
The live payments dashboard currently doesn't handle failures, usually this will result in it "hanging" or no longer showing current events as the main event loop has stopped running.

Common failure scenarios are:
- Intermittent WiFi
- Connecting to another known network not on an allowed domain list
- The tab being unfocussed for a long period of time causing the main event loop to not be run

Introduce a connection state, when there are any failures when communicating with the network, reset the connection and have the dashboard reconnect when possible. Backoff on connection attempts until a specified maximum number of attempts.

This also allows us to appropriately reconnect when crossing a day boundary.

The connection state is reflected visually to help anyone running the dashboard to have some idea of what has happened without digging into the console:
- the header highlight colour
- a pending result component

Connecting

<img width="732" alt="Screenshot 2022-10-24 at 13 08 20" src="https://user-images.githubusercontent.com/2844572/197523183-9997203b-4199-45cb-b30f-f30bc3b7b751.png">

Connected

<img width="731" alt="Screenshot 2022-10-24 at 13 11 13" src="https://user-images.githubusercontent.com/2844572/197523245-3549d78d-5a09-4147-baa3-4ad415d0ef5a.png">

Failed to connect after maximum number of retries

<img width="731" alt="Screenshot 2022-10-24 at 13 11 54" src="https://user-images.githubusercontent.com/2844572/197523284-bd635bb1-88c4-4d42-94e5-33319e0300c3.png">

Using the network or waiting for the event window to catch up with real time

<img width="741" alt="Screenshot 2022-10-24 at 13 10 57" src="https://user-images.githubusercontent.com/2844572/197523316-4655dd6a-cc97-4025-8ab8-910cac2cfd49.png">
<img width="734" alt="Screenshot 2022-10-24 at 13 11 07" src="https://user-images.githubusercontent.com/2844572/197523379-9b79f20f-8e03-40c0-8d4b-dfbab3ccd441.png">




This commit cleans up some of the "event window" logic that has particularly confusing with the current code, there are many more simplifications that can be made but that could be done with further refactoring.

Next steps are to:
- move all of the code for the live payments out of this repository and just include the built version at runtime
- when moved, include basic component and unit tests to give a bit more of a guarantee about health

The code can then be firmed up by:
- moving all the bundled TSX into separate and clear components
- removing any state outside of React state
- adding additional testing to guard against regressions