### PR TITLE
BAU — Make listing products by type actually filter by type

### DIFF
--- a/src/lib/pay-request/services/products/client.ts
+++ b/src/lib/pay-request/services/products/client.ts
@@ -35,7 +35,7 @@ export default class Products extends Client {
      */
     listProductsByType(id: string, type: ProductType): Promise<Product[] | undefined> {
       return client._axios
-        .get(`/v1/api/gateway-account/${id}/products`)
+        .get(`/v1/api/gateway-account/${id}/products`, {params: {type}})
         .then(response => client._unpackResponseData<Product[]>(response))
         .then(redactProductTokens)
     }


### PR DESCRIPTION
This should make the agent-initiated MOTO configuration page stop telling lies about what’s already set up.