### PR TITLE
PP-10249 Rename '3DS enabled' to '3DS Flex enabled'

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -147,27 +147,22 @@
     </dl>
   </div>
   <div>
-    <h2 class="govuk-heading-s payment__header">Self-serve settings</h1>
+    <h2 class="govuk-heading-s payment__header">Self-serve settings</h2>
     <dl class="govuk-summary-list">
-    {% if account.requires3ds != undefined %}
+      {% if is3DSFlexApplicable %}
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">3DS enabled</span></dt>
-          <dd class="govuk-summary-list__value">{{ account.requires3ds | string | capitalize }}</dd>
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">3DS Flex enabled</span></dt>
+          <dd class="govuk-summary-list__value">{{ threeDSFlexEnabled | string | capitalize }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
+      {% endif %}
+      {% if account.payment_provider === 'worldpay' %}
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">3DS version</span></dt>
-          <dd class="govuk-summary-list__value">{{ account.integration_version_3ds | string }}</dd>
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Exemption Engine</span></dt>
+          <dd class="govuk-summary-list__value">{{ "Enabled" if account.worldpay_3ds_flex and account.worldpay_3ds_flex.exemption_engine_enabled else "Disabled" }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
-        {% if account.payment_provider === 'worldpay' %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Exemption Engine</span></dt>
-            <dd class="govuk-summary-list__value">{{ "Enabled" if account.worldpay_3ds_flex and account.worldpay_3ds_flex.exemption_engine_enabled else "Disabled" }}</dd>
-            <dd class="govuk-summary-list__actions"></dd>
-          </div>
-        {% endif %}
-    {% endif %}
+      {% endif %}
     {% if account.allow_apple_pay != undefined %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Apple Pay enabled</span></dt>

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -198,6 +198,9 @@ async function detail(req: Request, res: Response): Promise<void> {
     stripeDashboardUri = `https://dashboard.stripe.com/${account.live ? '' : 'test/'}connect/accounts/${stripeCredentials.stripe_account_id}`
   }
 
+  const is3DSFlexApplicable = (currentCredential.payment_provider === PaymentProvider.Worldpay && !account.allow_moto)
+  const threeDSFlexEnabled = (account.integration_version_3ds === 2)
+
   res.render('gateway_accounts/detail', {
     account,
     acceptedCards,
@@ -206,6 +209,8 @@ async function detail(req: Request, res: Response): Promise<void> {
     currentCredential,
     outstandingStripeSetupTasks,
     stripeDashboardUri,
+    is3DSFlexApplicable,
+    threeDSFlexEnabled,
     messages: req.flash('info'),
     csrf: req.csrfToken()
   })


### PR DESCRIPTION
## WHAT
- 'integration_version_3ds' is displayed for all accounts (including stripe) in Toolbox but it is only required for Worldpay accounts.
- For Stripe accounts, `integration_version_3ds` is never used anywhere (by Connector or any other processes)
- So re-purposed 3DS enabled & integration version 3ds fields on the UI to '3DS Flex' and only displaying for Worldpay accounts.
