### PR TITLE
PP-10399 Handle not found errors for connector charges

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -37,12 +37,14 @@ export default class Connector extends Client {
       return client._axios
         .get(`/v1/frontend/charges/${id}`)
         .then(response => client._unpackResponseData<Charge>(response))
+        .catch(handleEntityNotFound("Charge", id))
     },
 
     retrieveAPI(externalChargeId: string, accountId: string): Promise<Charge | undefined> {
       return client._axios
         .get(`/v1/api/accounts/${accountId}/charges/${externalChargeId}`)
         .then(response => client._unpackResponseData<Charge>(response))
+        .catch(handleEntityNotFound("Charge", externalChargeId))
     },
 
     /**


### PR DESCRIPTION
The payment parity checker (between Connector and Ledger) is returning a 500 if the payment is missing from Connector (has been expunged).

Add the standard handler on the client so that the correct error (404) is propegated.