### PR TITLE
PP-10434 Include internal flag in go live notification

### DIFF
--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -147,7 +147,8 @@ async function writeAccount(req: Request, res: Response): Promise<void> {
       sector: account.sector,
       service_went_live_date: moment.utc().format(),
       service_created_date: moment.utc(service.created_date).format(),
-      service_using_provider: account.provider
+      service_using_provider: account.provider,
+      service_is_internal_service: service.internal
     })
   }
 


### PR DESCRIPTION
Include if a service is internal (for Pay team testing) or not when recording that a new service has gone live.

This will optionally allow reporting to exclude these entries.