### PR TITLE
PP-10277 Add validation that email isn't entered

### DIFF
--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -302,6 +302,11 @@ async function updateEmailBranding(req: Request, res: Response):
   Promise<void> {
   const {id} = req.params
   const {api_token, template_id, refund_issued_template_id, email_reply_to_id} = req.body
+
+  if (email_reply_to_id && email_reply_to_id.includes('@')) {
+    throw new Error('Reply-to email address ID must be an ID or left blank (not an email address)')
+  }
+
   const notifySettings = {
     api_token,
     template_id,


### PR DESCRIPTION
Add simple validation that an email isn't entered for the "Reply-to email address ID" field on the page to update email branding. We've seen it can be quite easy to mis-read this field and enter an email address.