### PR TITLE
PP-10542: Endpoint to log stripe balance

### DIFF
--- a/src/web/modules/stripe/index.js
+++ b/src/web/modules/stripe/index.js
@@ -3,6 +3,7 @@ const httpBasic = require('./basic/basic.http').default
 const httpBasicTest = require('./basic/test-account.http').default
 
 module.exports = {
+  balance: httpBasic.logStripeBalance,
   basic: httpBasic.createAccountForm,
   basicCreate: httpBasic.submitAccountCreate,
   createTestAccount: httpBasicTest.createTestAccount,

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -109,6 +109,7 @@ router.get('/discrepancies/search', auth.secured, discrepancies.search)
 router.post('/discrepancies/search', auth.secured, discrepancies.getDiscrepancyReport)
 router.post('/discrepancies/resolve/:id', auth.secured, discrepancies.resolveDiscrepancy)
 
+router.get('/stripe/balance', auth.secured, stripe.balance)
 router.get('/stripe/basic/create', auth.secured, stripe.basic)
 router.post('/stripe/basic/create', auth.secured, stripe.basicCreate)
 router.get('/stripe/basic/create-test-account', auth.secured, stripe.createTestAccount)


### PR DESCRIPTION
Testing this locally, I get the following log from doing a `curl http://localhost:3000/stripe/balalnce`:
```
info: Stripe balance retrieved. {"amount":"-446235","currency":"\"gbp\"","timestamp":"08:48:37","toolboxId":"73041147"}
```