### PR TITLE
Revert "PP-10542: Endpoint to log stripe balance (#1550)"

### DIFF
--- a/src/web/modules/stripe/basic/basic.http.ts
+++ b/src/web/modules/stripe/basic/basic.http.ts
@@ -8,7 +8,6 @@ import {ClientFormError, formatErrorsForTemplate} from '../../common/validationE
 import {Service} from '../../../../lib/pay-request/services/admin_users/types'
 import AccountDetails from './basicAccountDetails.model'
 import {setupProductionStripeAccount} from './account'
-import * as stripeClient from '../../../../lib/stripe/stripe.client'
 
 import Stripe from "stripe";
 const {StripeError} = Stripe.errors
@@ -99,21 +98,7 @@ const submitAccountCreate = async function submitAccountCreate(
   }
 }
 
-const logStripeBalance = async function logStripeBalance(
-  req: Request,
-  res: Response
-): Promise<void> {
-  if (!process.env.STRIPE_ACCOUNT_API_KEY) {
-    throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
-  }
-  const balance = await stripeClient.getStripeApi().balance.retrieve()
-  const { amount, currency } = balance.available.shift()
-  logger.info('Stripe balance retrieved.', { amount, currency })
-  res.sendStatus(200)
-}
-
 export default {
   createAccountForm: wrapAsyncErrorHandler(createAccountForm),
-  submitAccountCreate: wrapAsyncErrorHandler(submitAccountCreate),
-  logStripeBalance: wrapAsyncErrorHandler(logStripeBalance)
+  submitAccountCreate: wrapAsyncErrorHandler(submitAccountCreate)
 }

--- a/src/web/modules/stripe/index.js
+++ b/src/web/modules/stripe/index.js
@@ -3,7 +3,6 @@ const httpBasic = require('./basic/basic.http').default
 const httpBasicTest = require('./basic/test-account.http').default
 
 module.exports = {
-  balance: httpBasic.logStripeBalance,
   basic: httpBasic.createAccountForm,
   basicCreate: httpBasic.submitAccountCreate,
   createTestAccount: httpBasicTest.createTestAccount,

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -111,7 +111,6 @@ router.get('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), 
 router.post('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.getDiscrepancyReport)
 router.post('/discrepancies/resolve/:id', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.resolveDiscrepancy)
 
-router.get('/stripe/balance', stripe.balance)
 router.get('/stripe/basic/create', auth.secured(PermissionLevel.VIEW_ONLY), stripe.basic)
 router.post('/stripe/basic/create', auth.secured(PermissionLevel.USER_SUPPORT), stripe.basicCreate)
 router.get('/stripe/basic/create-test-account', auth.secured(PermissionLevel.VIEW_ONLY), stripe.createTestAccount)


### PR DESCRIPTION
Endpoint `/stripe/balance` is no longer needed as this has been superseded by https://github.com/alphagov/pay-connector/pull/4232

This reverts commit 3c4d46a001b72b88a5dae29ec1e16e80aa61ced1.