### PR TITLE
PP-9958 Fix permission level check for VIEW_ONLY users

### DIFF
--- a/src/lib/auth/github/permissions.spec.js
+++ b/src/lib/auth/github/permissions.spec.js
@@ -29,8 +29,8 @@ describe('Permissions util', () => {
   it('should return ADMIN permission level when user is a member of the admin GitHub team', async () => {
     mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_ADMIN_TEAM_ID)
 
-    const permissionLevel = await permissions.getPermissionLevel(username, token);
-    expect(permissionLevel).to.equal(PermissionLevel.ADMIN)
+    const result = await permissions.checkUserAccess(username, token);
+    expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.ADMIN})
   })
 
   it('should return ADMIN permission level when user is a member of multiple GitHub teams including the admin team', async () => {
@@ -38,27 +38,27 @@ describe('Permissions util', () => {
     mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)
     mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)
 
-    const permissionLevel = await permissions.getPermissionLevel(username, token);
-    expect(permissionLevel).to.equal(PermissionLevel.ADMIN)
+    const result = await permissions.checkUserAccess(username, token);
+    expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.ADMIN})
   })
 
   it('should return USER_SUPPORT permission level when user is a member of the user support GitHub team', async () => {
     mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)
 
-    const permissionLevel = await permissions.getPermissionLevel(username, token);
-    expect(permissionLevel).to.equal(PermissionLevel.USER_SUPPORT)
+    const result = await permissions.checkUserAccess(username, token);
+    expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.USER_SUPPORT})
   })
 
   it('should return VIEW_ONLY permission level when user is a member of the view-only GitHub team', async () => {
     mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)
 
-    const permissionLevel = await permissions.getPermissionLevel(username, token);
-    expect(permissionLevel).to.equal(PermissionLevel.VIEW_ONLY)
+    const result = await permissions.checkUserAccess(username, token);
+    expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.VIEW_ONLY})
   })
 
   it('should return false when user is not a member of any permitted GitHub team', async () => {
-    const permissionLevel = await permissions.getPermissionLevel(username, token);
-    expect(permissionLevel).to.equal(false)
+    const result = await permissions.checkUserAccess(username, token);
+    expect(result).to.deep.equal({permitted: false})
   })
 })
 

--- a/src/lib/auth/github/permissions.ts
+++ b/src/lib/auth/github/permissions.ts
@@ -17,20 +17,22 @@ async function isUserMemberOfGitHubTeam(username: string, token: string, team: s
   logger.info(`Requesting team ${team} permissions for ${username}`)
   try {
     await axios.get(url, githubRestOptions)
+    logger.info(`User ${username} is a member of team ${team}`)
     return true
   } catch (err) {
+    logger.info(`User ${username} is not a member of team ${team}`)
     return false
   }
 }
 
-export async function getPermissionLevel(username: string, token: string): Promise<PermissionLevel | boolean> {
+export async function checkUserAccess(username: string, token: string) {
   if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_ADMIN_TEAM_ID)) {
-    return PermissionLevel.ADMIN
+    return {permitted: true, permissionLevel: PermissionLevel.ADMIN}
   } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)) {
-    return PermissionLevel.USER_SUPPORT
+    return {permitted: true, permissionLevel: PermissionLevel.USER_SUPPORT}
   } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)) {
-    return PermissionLevel.VIEW_ONLY
+    return {permitted: true, permissionLevel: PermissionLevel.VIEW_ONLY}
   } else {
-    return false
+    return {permitted: false}
   }
 }

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -3,7 +3,7 @@ const { Strategy } = require('passport-github')
 const config = require('../../../config')
 const logger = require('../../logger')
 
-const { getPermissionLevel} = require('./permissions')
+const { checkUserAccess} = require('./permissions')
 const {PermissionLevel} = require("../types");
 
 const githubAuthCredentials = {
@@ -26,10 +26,10 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
   logger.info(`Successful account auth from GitHub for user ${username}`)
 
   try {
-    const permissionLevel = await getPermissionLevel(username, accessToken)
-    if (permissionLevel) {
-      sessionProfile.permissionLevel = permissionLevel
-      logger.info(`User is authorised with permission level ${PermissionLevel[permissionLevel]}, setting session for ${username}`)
+    const userAccessCheckResult = await checkUserAccess(username, accessToken)
+    if (userAccessCheckResult.permitted) {
+      sessionProfile.permissionLevel = userAccessCheckResult.permissionLevel
+      logger.info(`User is authorised with permission level ${PermissionLevel[userAccessCheckResult.permissionLevel]}, setting session for ${username}`)
       callback(null, sessionProfile)
     } else {
       logger.warn(`User ${username} is not a member of any GitHub groups granting access`)

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,5 +1,9 @@
 export enum PermissionLevel {
+  // VIEW_ONLY users should have access to most routes that allow viewing data but not to routes that update resources
   VIEW_ONLY = 0,
+  // USER_SUPPORT users should have access to all routes except routes where accessing or editing a resource poses a
+  // high security risk - such as the potential to gain privilege escalation, steal funds, or obtain card numbers.
   USER_SUPPORT = 1,
+  // ADMIN users should have access to all routes
   ADMIN = 2
 }


### PR DESCRIPTION
We were attempting to return false if the user was not a member of any group, and 0 if the user was a member of the VIEW_ONLY group. We were then checking the truthy value of the result, which evaluates as false for both results.

Make the interface of the permission check function clearer to return a result for whether the user is permitted, as well as their permission level.

Also add some code comments explaining the different permission levels.