### PR TITLE
PP-9958 Fix permission checks for VIEW_ONLY users

### DIFF
--- a/src/lib/auth.spec.js
+++ b/src/lib/auth.spec.js
@@ -55,9 +55,9 @@ describe('Authorisation middleware', () => {
     it('should allow authenticated requests if user permission level is equal to the required permission level', () => {
       requestMock.isAuthenticated = () => true
       requestMock.user = {
-        permissionLevel: PermissionLevel.USER_SUPPORT
+        permissionLevel: PermissionLevel.VIEW_ONLY
       }
-      auth.secured(PermissionLevel.USER_SUPPORT)(requestMock, responseSpy, nextSpy)
+      auth.secured(PermissionLevel.VIEW_ONLY)(requestMock, responseSpy, nextSpy)
 
       sinon.assert.calledWithExactly(nextSpy)
       sinon.assert.notCalled(responseSpy.render)

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,9 +1,9 @@
 export enum PermissionLevel {
   // VIEW_ONLY users should have access to most routes that allow viewing data but not to routes that update resources
-  VIEW_ONLY = 0,
+  VIEW_ONLY = 1,
   // USER_SUPPORT users should have access to all routes except routes where accessing or editing a resource poses a
   // high security risk - such as the potential to gain privilege escalation, steal funds, or obtain card numbers.
-  USER_SUPPORT = 1,
+  USER_SUPPORT = 2,
   // ADMIN users should have access to all routes
-  ADMIN = 2
+  ADMIN = 3
 }


### PR DESCRIPTION
Modify the enum so that VIEW_ONLY has a value of 1 rather than 0.

This means checks like the following won't evaluate to false because the permission level has a value of 0:

```
if (req.user.permissionLevel && req.user.permissionLevel >= permissionLevel) {
```