### PR TITLE
PP-10635 Fix: allow multiple accounts for agreement

### DIFF
--- a/src/web/modules/agreements/agreements.http.ts
+++ b/src/web/modules/agreements/agreements.http.ts
@@ -15,14 +15,14 @@ if (common.development) {
 export async function detail(req: Request, res: Response, next: NextFunction) {
   try {
     const agreement = await Ledger.agreements.retrieve(req.params.id, { override_account_or_service_id_restriction: true })
-    const account = await Connector.accounts.retrieveForService({
+    const { accounts } = await Connector.accounts.list({
       service_id: agreement.service_id, 
       type: agreement.live ? AccountType.Live : AccountType.Test
     })
     const service = await AdminUsers.services.retrieve(agreement.service_id)
     
     
-    res.render('agreements/detail', { agreement, service, account })
+    res.render('agreements/detail', { agreement, service, accounts })
   } catch (error) {
     next(error)
   }

--- a/src/web/modules/agreements/detail.njk
+++ b/src/web/modules/agreements/detail.njk
@@ -55,7 +55,9 @@
 
   <h2 class="govuk-heading-s">Service</h2>
   {% set accountLink %}
-  <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ account.gateway_account_id }}">{{ account.type | capitalize }} {{ account.payment_provider | capitalize }} ({{ account.gateway_account_id }})</a>
+  {% for account in accounts %}
+  <a class="govuk-link govuk-link--no-visited-state" style="margin-right: 10px" href="/gateway_accounts/{{ account.gateway_account_id }}">{{ account.type | capitalize }} {{ account.payment_provider | capitalize }} ({{ account.gateway_account_id }}) </a>
+  {% endfor %}
   {% endset %}
   {% set serviceLink %}
   <a class="govuk-link govuk-link--no-visited-state" href="/services/{{ service.external_id }}">{{ service.name }}</a> 


### PR DESCRIPTION
The Pay data model has not yet been updated to ensure one service only has one test and one live integration per service. When this work is done we can get integrations/ accounts from connector by using the service identifier.

For now support getting multiple accounts back and present these to the user.