### PR TITLE
PP-10635 Fix get account for agreement

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -157,7 +157,7 @@ export default class Connector extends Client {
     },
 
     /*
-     * Get one gateway account given service ID. This is a polyfill method until service ID and live/ test are the primary index for accounts on the backend. 
+     * Get one gateway account given service ID. This is a polyfill method until service ID and live/ test are the primary index for accounts on the backend.
      */
     async retrieveForService(filters: ListGatewayAccountsRequest = {}): Promise<GatewayAccount | undefined> {
       const params = _.omitBy(filters, _.isEmpty)
@@ -166,11 +166,11 @@ export default class Connector extends Client {
         .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
 
       if (accounts.length > 1) {
-        throw new Error(`Multiple accounts for service ${filters.service_id} ${filters.type}, this is a legacy configuration`)
+        throw new Error(`Multiple accounts for service ${filters.serviceIds} ${filters.type}, this is a legacy configuration`)
       }
 
       if (!accounts.length) {
-        throw new EntityNotFoundError('Account for service', filters.service_id)
+        throw new EntityNotFoundError('Account for service', filters.serviceIds)
       }
 
       return accounts[0]

--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -151,7 +151,7 @@ export interface ListGatewayAccountsRequest {
   payment_provider?: string;
   payment_provider_account_id?: string;
   provider_switch_enabled?: string;
-  service_id?: string;
+  serviceIds?: string;
 }
 
 export interface ListGatewayAccountsResponse {

--- a/src/lib/pay-request/services/ledger/types.ts
+++ b/src/lib/pay-request/services/ledger/types.ts
@@ -305,7 +305,7 @@ export interface ListAgreementRequest {
   */
   exact_reference_match?: boolean;
   limit_total?: boolean;
-  limit_total_size?: number; 
+  limit_total_size?: number;
 }
 
 export interface ListTransactionForAccountRequest extends ListTransactionRequest {

--- a/src/web/modules/agreements/agreements.http.ts
+++ b/src/web/modules/agreements/agreements.http.ts
@@ -16,12 +16,11 @@ export async function detail(req: Request, res: Response, next: NextFunction) {
   try {
     const agreement = await Ledger.agreements.retrieve(req.params.id, { override_account_or_service_id_restriction: true })
     const { accounts } = await Connector.accounts.list({
-      service_id: agreement.service_id, 
+      serviceIds: agreement.service_id,
       type: agreement.live ? AccountType.Live : AccountType.Test
     })
     const service = await AdminUsers.services.retrieve(agreement.service_id)
-    
-    
+
     res.render('agreements/detail', { agreement, service, accounts })
   } catch (error) {
     next(error)
@@ -33,7 +32,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
     let service, account
     const accountId = req.query.account
     const selectedStatus = req.query.status as AgreementListFilterStatus || AgreementListFilterStatus.All
-    
+
     const filters = {
       ...req.query.reference && {reference: req.query.reference as string}
     }

--- a/src/web/modules/agreements/detail.njk
+++ b/src/web/modules/agreements/detail.njk
@@ -19,10 +19,10 @@
       { key : { html: captionCell("Description") }, value: { text: agreement.description } },
       { key : { text: captionCell("Reference") }, value: { text: agreement.reference } },
       { key : { text: captionCell("User identifier") }, value: { text: agreement.user_identifier or "(None set)" } } ,
-      { key : { text: captionCell("Date created") }, value: { text: agreement.created_date | formatDate } } 
+      { key : { text: captionCell("Date created") }, value: { text: agreement.created_date | formatDate } }
     ]
   }) }}
-  
+
   {% set cardBrandLabelMap = {
     "visa": "Visa",
     "master-card": "Mastercard",
@@ -43,7 +43,7 @@
         { key : { text: captionCell("Card brand") }, value: { text: cardBrandLabelMap[agreement.payment_instrument.card_details.card_brand] } },
         { key : { text: captionCell("Cardholder name") }, value: { text: agreement.payment_instrument.card_details.cardholder_name } },
         { key : { text: captionCell("Card") }, value: { text: agreement.payment_instrument.card_details.first_digits_card_number + " •••• " + agreement.payment_instrument.card_details.last_digits_card_number } },
-        { key : { text: captionCell("Date created") }, value: { text: agreement.payment_instrument.created_date | formatDate } } 
+        { key : { text: captionCell("Date created") }, value: { text: agreement.payment_instrument.created_date | formatDate } }
       ]
     }) }}
 
@@ -60,13 +60,13 @@
   {% endfor %}
   {% endset %}
   {% set serviceLink %}
-  <a class="govuk-link govuk-link--no-visited-state" href="/services/{{ service.external_id }}">{{ service.name }}</a> 
+  <a class="govuk-link govuk-link--no-visited-state" href="/services/{{ service.external_id }}">{{ service.name }}</a>
   {% endset %}
 
   {{ govukSummaryList({
     rows: [
       { key : { html: captionCell("Gateway account") }, value: { html: accountLink } },
-      { key : { text: captionCell("Service") }, value: { html: serviceLink } } 
+      { key : { text: captionCell("Service") }, value: { html: serviceLink } }
     ]
   }) }}
 


### PR DESCRIPTION
Fixes 0e94e99dcf559699453d4a0daeb4b603b4a69d85
As we don't return the account ID on the agreement - only the service_id whether it is live or test, we need to get the gateway account using the service ID. We were incorrectly providing the query parameter for searching by service id.