### PR TITLE
PP-10634 Update status tag colours

### DIFF
--- a/src/web/modules/ledger_payouts/list.njk
+++ b/src/web/modules/ledger_payouts/list.njk
@@ -3,8 +3,8 @@
 {% macro payout_status(status) %}
   <strong class="govuk-tag
         {% if (status=='paidout') %} govuk-tag--green {% endif %}
-        {% if (status=='failed') %} govuk-tag--red {% endif %}
-        {% if (status=='intransit') %} govuk-tag--orange {% endif %}
+        {% if (status=='failed') %} govuk-tag--orange {% endif %}
+        {% if (status=='intransit') %} govuk-tag--grey {% endif %}
       ">
     <span>{{ status | capitalize }}</span>
   </strong>

--- a/src/web/modules/transactions/status.macro.njk
+++ b/src/web/modules/transactions/status.macro.njk
@@ -5,8 +5,8 @@
 
 <strong class="govuk-tag
     {% if final and success.includes(state) %} govuk-tag--green {% endif %}
-    {% if final and failed.includes(state) %} govuk-tag--red {% endif %}
-    {% if not final %} govuk-tag--orange {% endif %}
+    {% if final and failed.includes(state) %} govuk-tag--orange {% endif %}
+    {% if not final %} govuk-tag--grey {% endif %}
   ">
 
   {# 0p payments are supported and will be flagged as 'full' even though they are not refunded #}


### PR DESCRIPTION
- Make the status tag colours match up to what they were before:
  - 'in-transit' - grey tag
  - 'failed' - orange tag