### PR TITLE
PP-10731 set 3ds required to true for Worldpay test accounts

### DIFF
--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -111,7 +111,7 @@ class GatewayAccount extends Validated {
       service_id: this.serviceId
     }
 
-    if (this.isLive() || this.provider === 'stripe' ) {
+    if (this.isLive() || this.provider === 'stripe' || this.provider === 'worldpay' ) {
       payload.requires_3ds = true
     } else {
       payload.requires_3ds = false

--- a/src/web/modules/gateway_accounts/gateway_accounts.spec.js
+++ b/src/web/modules/gateway_accounts/gateway_accounts.spec.js
@@ -12,7 +12,8 @@ const validGatewayAccountDetails = {
   provider: 'stripe',
   analyticsId: 'fs-valid-id',
   credentials: 'valid-credentials',
-  sector: 'valid-sector'
+  sector: 'valid-sector',
+  serviceId: 'service-id'
 }
 
 describe('Gateway Accounts', () => {
@@ -143,6 +144,18 @@ describe('Gateway Accounts', () => {
         new GatewayAccount(details)
       }).to.throw(ValidationError)
     })
+
+    it('successfully creates model when provider is worldpay and test account', function () {
+      const details = _.cloneDeep(validGatewayAccountDetails)
+      details.provider = 'worldpay'
+      details.live = 'not-live'
+
+      const account = new GatewayAccount(details)
+      expect(account).to.be.an('object')
+      account.serviceId = 'service-id'
+      const payload = account.formatPayload()
+      expect(payload.requires_3ds).to.eql(true)
+    });
   })
 })
 


### PR DESCRIPTION
- set the flag `requires_3ds` to true when creating a Worldpay test account

with @alan-gds