### PR TITLE
PP-10701: List agreement events on details page

### DIFF
--- a/src/lib/pay-request/services/ledger/client.ts
+++ b/src/lib/pay-request/services/ledger/client.ts
@@ -15,6 +15,8 @@ import type {
   ListTransactionRequestWithAccountOverrideRequest,
   ListAgreementForAccountRequest,
   ListAgreementRequestWithAccountOverrideRequest,
+  ListAgreementEventsRequest,
+  ListAgreementEventsResponse,
   ListPaymentRefundsRequest,
   ListTransactionEventsRequest,
   ListEventTickerRequest,
@@ -28,9 +30,9 @@ import type {
   ListPayoutWithAccountOverrideRequest,
   TransactionsByHourRequest,
   ListPaymentRefundsResponse,
-  ListTransactionEventsResponse, 
-  Transaction, 
-  RelatedTransactionsRequest, 
+  ListTransactionEventsResponse,
+  Transaction,
+  RelatedTransactionsRequest,
   TransactionsForTransactionResponse,
   Agreement,
   RetrieveAgreementForAccountRequest,
@@ -186,6 +188,18 @@ export default class Ledger extends Client {
       return client._axios
         .get('/v1/agreement', {params: filters})
         .then(response => client._unpackResponseData<SearchResponse<Agreement>>(response));
+    },
+
+    /**
+     * @param id - GOV.UK Pay agreement external ID
+     * @param params - optionally specify service ID
+     * @returns - List of events for this transaction and transaction with this
+     *            transaction set as their parent transaction
+     */
+    listEvents(id: string, params: ListAgreementEventsRequest): Promise<ListAgreementEventsResponse | undefined> {
+      return client._axios
+        .get(`/v1/agreement/${id}/event`, {params})
+        .then(response => client._unpackResponseData<ListAgreementEventsResponse>(response));
     },
   }))(this)
 

--- a/src/lib/pay-request/services/ledger/types.ts
+++ b/src/lib/pay-request/services/ledger/types.ts
@@ -328,6 +328,21 @@ export interface ListAgreementRequestWithAccountOverrideRequest extends ListAgre
   account_id?: number | number[];
 }
 
+export interface ListAgreementEventsRequest {
+  service_id: string;
+  /**
+   * Do not filter events. By default (false) events are filtered for the self
+   * service view, only showing certain events for backward compatability. Including
+   * all events will return everything that made up the transaction in Ledger.
+   */
+  include_all_events: boolean;
+}
+
+export interface ListAgreementEventsResponse {
+  agreement_id: string;
+  events: Event[];
+}
+
 
 
 export interface ListPaymentRefundsRequest {

--- a/src/web/modules/agreements/agreements.http.ts
+++ b/src/web/modules/agreements/agreements.http.ts
@@ -22,7 +22,18 @@ export async function detail(req: Request, res: Response, next: NextFunction) {
     })
     const service = await AdminUsers.services.retrieve(agreement.service_id)
 
-    res.render('agreements/detail', { agreement, service, accounts })
+    const agreementEvents = await Ledger.agreements.listEvents(agreement.external_id, {
+      service_id: agreement.service_id,
+      include_all_events: true
+    })
+
+    const events = agreementEvents.events
+      .map((event: any) => {
+        event.data = Object.keys(event.data).length ? event.data : null
+        return event
+      })
+
+    res.render('agreements/detail', { agreement, service, accounts, events })
   } catch (error) {
     next(error)
   }

--- a/src/web/modules/agreements/detail.njk
+++ b/src/web/modules/agreements/detail.njk
@@ -76,5 +76,41 @@
     ]
   }) }}
 
+  <div>
+    <h1 class="govuk-heading-s payment__header">Ledger events</h1>
+
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+      {% for event in events %}
+
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ event.event_type }}</td>
+        <td class="govuk-table__cell">{{ event.timestamp | formatDate}}</td>
+      </tr>
+
+      {% if event.data %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell" colspan="2">
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Event details
+                  </span>
+            </summary>
+            <div class="govuk-details__text">
+              <pre><code>{{ event.data | dump('\t') }}</code></pre>
+            </div>
+          </details>
+        </td>
+      </tr>
+      {% endif %}
+      {% else %}
+      <!-- @TODO(sfount) use a row here -->
+      <div class="center bottom-spacer"><span class="govuk-caption-m">No events</span></div>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
   {{ json("Agreement source", agreement) }}
 {% endblock %}


### PR DESCRIPTION
The agreement detail page now displays a list of the agreement's events, fetched from Ledger, similarly to the transaction detail page.