### PR TITLE
PP-10537: Add webhooks detail page

### DIFF
--- a/src/lib/pay-request/services/webhooks/client.ts
+++ b/src/lib/pay-request/services/webhooks/client.ts
@@ -1,6 +1,7 @@
 import Client from '../../base'
-import type { ListWebhooksForServiceRequest, Webhook } from './types'
-import { SearchResponse, App } from '../../shared'
+import type { ListWebhooksForServiceRequest, RetrieveWebhookRequest, Webhook } from './types'
+import { App } from '../../shared'
+import { handleEntityNotFound } from "../../utils/error";
 
 export default class Webhooks extends Client {
   constructor() {
@@ -8,10 +9,20 @@ export default class Webhooks extends Client {
   }
 
   webhooks = ((client: Webhooks) => ({
+    retrieve(
+      id: string,
+      params: RetrieveWebhookRequest
+    ): Promise<Webhook | undefined> {
+      return client._axios
+        .get(`/v1/webhook/${id}`, {params})
+        .then(response => client._unpackResponseData<Webhook>(response))
+        .catch(handleEntityNotFound('Webhook', id))
+    },
+
     list(
       params: ListWebhooksForServiceRequest
     ): Promise<Webhook[] | undefined> {
-    
+
     return client._axios
       .get('/v1/webhook', {params})
       .then(response => client._unpackResponseData<Webhook[] | undefined >(response));

--- a/src/lib/pay-request/services/webhooks/types.ts
+++ b/src/lib/pay-request/services/webhooks/types.ts
@@ -9,6 +9,11 @@ export interface Webhook {
   subscriptions: string[];
 }
 
+export interface RetrieveWebhookRequest {
+  account_id?: string;
+  service_id?: string;
+}
+
 export interface ListWebhookRequest {
   live: boolean;
 }

--- a/src/web/modules/webhooks/detail.njk
+++ b/src/web/modules/webhooks/detail.njk
@@ -1,0 +1,33 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "common/json.njk" import json %}
+{% extends "layout/layout.njk" %}
+{% from "./status.macro.njk" import webhookStatusTag %}
+
+{% macro captionCell(content) %}
+<span class="govuk-caption-m">{{ content }}</span>
+{% endmacro %}
+
+{% block main %}
+  <h1 class="govuk-heading-m">Webhook</h1>
+
+  {% set subscriptions_list %}
+    <ul>
+      {% for subscription_key in webhook.subscriptions %}
+        <li>{{human_readable_subscriptions[subscription_key | upper]}}</li>
+      {% endfor %}
+    </ul>
+  {% endset %}
+
+  {{ govukSummaryList({
+  rows: [
+    { key : { text: captionCell("ID") }, value: { text: webhook.external_id } },
+    { key : { text: captionCell("URL") }, value: { text: webhook.callback_url } },
+    { key : { text: captionCell("Status") }, value: { html: webhookStatusTag(webhook.status) } },
+    { key : { text: captionCell("Description") }, value: { text: webhook.description } },
+    { key : { text: captionCell("Date created") }, value: { text: webhook.created_date | formatDate } },
+    { key : { text: captionCell("Event types") }, value: { html: subscriptions_list } }
+  ]
+  }) }}
+
+  {{ json("Webhook source", webhook) }}
+{% endblock %}

--- a/src/web/modules/webhooks/overview.njk
+++ b/src/web/modules/webhooks/overview.njk
@@ -27,7 +27,7 @@
         {% for webhook in webhooks %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              {{ webhook.external_id }}
+              <a class="govuk-link" href="/webhooks/{{ webhook.external_id }}?service_id={{ service.external_id }}">{{ webhook.external_id }}</a>
             </td>
             <td class="govuk-table__cell">
               {{ webhook.domain }}

--- a/src/web/modules/webhooks/status.macro.njk
+++ b/src/web/modules/webhooks/status.macro.njk
@@ -1,12 +1,12 @@
 {% set statusStyleMap = {
-  "CREATED": "govuk-tag--grey",
-  "ACTIVE": "govuk-tag--green",
-  "CANCELLED": "govuk-tag--yellow"
+  "ACTIVE": "govuk-tag--blue",
+  "INACTIVE": "govuk-tag--yellow",
+  "DISABLED": "govuk-tag--red"
 } %}
 {% set statusTextMap = {
-  "CREATED": "created",
-  "ACTIVE": "active",
-  "CANCELLED": "cancelled"
+  "ACTIVE": "Active",
+  "INACTIVE": "Inactive",
+  "DISABLED": "Disabled"
 } %}
 
 {% macro webhookStatusTag(status) %}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -160,6 +160,7 @@ router.post('/payment_links/:id/toggle_require_captcha', auth.secured(Permission
 
 router.get('/payouts', auth.secured(PermissionLevel.VIEW_ONLY), ledgerPayouts.list)
 
+router.get('/webhooks/:id', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.detail)
 router.get('/webhooks', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.list)
 
 router.get('/platform/dashboard', auth.secured(PermissionLevel.VIEW_ONLY), platform.dashboard)


### PR DESCRIPTION
* Endpoint for webhook details page is `/webhooks/{id}`
* Accessible via links in the webhooks overview page
* The macro which renders webhook statuses as badges contained the wrong values and mapped to the wrong colours, so this has been changed to bring it in line with the mappings used in the admin tool.  (https://github.com/alphagov/pay-selfservice/blob/master/app/views/webhooks/_webhook_status.njk)

<img width="754" alt="Screenshot 2023-04-25 at 15 43 46" src="https://user-images.githubusercontent.com/26431837/234314726-8e158b73-0c2f-439c-ab8f-c903e525637a.png">