### PR TITLE
PP-10537 Add new webhook message detail page

### DIFF
--- a/src/lib/pay-request/services/webhooks/client.ts
+++ b/src/lib/pay-request/services/webhooks/client.ts
@@ -42,6 +42,16 @@ export default class Webhooks extends Client {
       return client._axios
         .get(`/v1/webhook/${webhookId}/message`, {params})
         .then(response => client._unpackResponseData<SearchResponse<WebhookMessage> | undefined >(response));
+    },
+
+    retrieveMessage(
+      webhookId: string,
+      messageId: string
+    ): Promise<WebhookMessage | undefined> {
+      return client._axios
+        .get(`/v1/webhook/${webhookId}/message/${messageId}`)
+        .then(response => client._unpackResponseData<WebhookMessage>(response))
+        .catch(handleEntityNotFound('Webhook message', messageId))
     }
   }))(this)
 }

--- a/src/web/modules/webhooks/messages/detail.njk
+++ b/src/web/modules/webhooks/messages/detail.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "common/json.njk" import json %}
+{% extends "layout/layout.njk" %}
+{% from "../webhookStatus.macro.njk" import webhookStatusTag %}
+
+{% set isTestData = webhook and not webhook.live %}
+
+{% macro captionCell(content) %}
+<span class="govuk-caption-m">{{ content }}</span>
+{% endmacro %}
+
+{% block main %}
+  <div>
+    <a href="/webhooks/{{ webhook.external_id }}/messages" class="govuk-back-link">Back to webhook messages</a>
+  </div>
+
+  {% set eventType = human_readable_subscriptions[message.event_type | upper] %}
+
+  <h1 class="govuk-heading-m">{{ eventType }}</h1>
+
+  {% set resourceLink %}
+    <a class="govuk-link" href="/transactions/{{ message.resource_id }}">{{ message.resource_id }}</a>
+  {% endset %}
+  {{ govukSummaryList({
+  rows: [
+    { key : { text: captionCell("ID") }, value: { text: webhook.external_id } },
+    { key : { text: captionCell("Resource") }, value: { html: resourceLink } },
+    { key : { text: captionCell("Event date") }, value: { text: message.event_date | formatDate } },
+    { key : { text: captionCell("Status code") }, value: { text: message.latest_attempt and message.latest_attempt.status_code or "-" } }
+  ]
+  }) }}
+
+  {{ json(eventType + " event body", message.resource) }}
+
+  </ul><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  {{ json("Webhook source", webhook) }}
+  {{ json("Webhook message source", message) }}
+{% endblock %}

--- a/src/web/modules/webhooks/messages/overview.njk
+++ b/src/web/modules/webhooks/messages/overview.njk
@@ -1,7 +1,7 @@
 {% from "transactions/status.macro.njk" import status %}
 
 {% extends "layout/layout.njk" %}
-{% from "./webhookMessageStatus.macro.njk" import webhookMessageStatusTag %}
+{% from "./../webhookMessageStatus.macro.njk" import webhookMessageStatusTag %}
 
 {% set isTestData = webhook and not webhook.live %}
 
@@ -46,7 +46,7 @@
     {% for message in webhookMessages.results %}
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <span class="govuk-caption-m">{{ human_readable_subscriptions[message.event_type | upper] }}</span>
+        <a class="govuk-link" href="/webhooks/{{ webhook.external_id }}/messages/{{ message.external_id }}">{{ human_readable_subscriptions[message.event_type | upper] }}</a>
       </td>
       <td class="govuk-table__cell">
         <span class="govuk-caption-m">{{ webhookMessageStatusTag(message.last_delivery_status) }}</span>

--- a/src/web/modules/webhooks/webhooks.http.ts
+++ b/src/web/modules/webhooks/webhooks.http.ts
@@ -100,13 +100,27 @@ export async function listMessages(req: Request, res: Response, next: NextFuncti
       }
     )
 
-    res.render('webhooks/messages', {
+    res.render('webhooks/messages/overview', {
       webhook,
       webhookMessages,
       webhookMessagePageSize,
       page,
       selectedStatus: status,
       human_readable_subscriptions: constants.webhooks.humanReadableSubscriptions,
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function messageDetail(req: Request, res: Response, next: NextFunction) {
+  try {
+    const webhook = await Webhooks.webhooks.retrieve(req.params.webhookId, { override_account_or_service_id_restriction: true })
+    const message = await Webhooks.webhooks.retrieveMessage(req.params.webhookId, req.params.messageId)
+    res.render('webhooks/messages/detail', {
+      webhook,
+      message,
+      human_readable_subscriptions: constants.webhooks.humanReadableSubscriptions
     })
   } catch (error) {
     next(error)

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -165,6 +165,7 @@ router.post('/webhooks/search', auth.secured(PermissionLevel.VIEW_ONLY), webhook
 router.get('/webhooks/:id', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.detail)
 router.get('/webhooks', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.list)
 router.get('/webhooks/:id/messages', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.listMessages)
+router.get('/webhooks/:webhookId/messages/:messageId', auth.secured(PermissionLevel.VIEW_ONLY), webhooks.messageDetail)
 
 router.get('/platform/dashboard', auth.secured(PermissionLevel.VIEW_ONLY), platform.dashboard)
 router.get('/platform/dashboard/live', platform.live)


### PR DESCRIPTION
Adds a new page to show the details of a webhook message, this will be linked from all source in a follow up commit. Including:
- helper client wrapper to access message detail backend endpoint
- controller, template and router to link them together

<img width="762" alt="Screenshot 2023-05-15 at 10 00 13" src="https://github.com/alphagov/pay-toolbox/assets/2844572/5b48e02b-6af2-40dd-9b16-e3aafe48ebf2">

<img width="752" alt="Screenshot 2023-05-15 at 10 00 20" src="https://github.com/alphagov/pay-toolbox/assets/2844572/a65d965c-84df-41d7-bffd-702614c38fe7">



