### PR TITLE
PP-10537 Add delivery attempts to webhook message detail

### DIFF
--- a/src/lib/pay-request/services/webhooks/client.ts
+++ b/src/lib/pay-request/services/webhooks/client.ts
@@ -9,6 +9,7 @@ import type {
 } from './types'
 import { App, SearchResponse } from '../../shared'
 import { handleEntityNotFound } from '../../utils/error';
+import { DeliveryAttempt } from './types';
 
 export default class Webhooks extends Client {
   constructor() {
@@ -51,6 +52,16 @@ export default class Webhooks extends Client {
       return client._axios
         .get(`/v1/webhook/${webhookId}/message/${messageId}`)
         .then(response => client._unpackResponseData<WebhookMessage>(response))
+        .catch(handleEntityNotFound('Webhook message', messageId))
+    },
+
+    listMessageAttempts(
+      webhookId: string,
+      messageId: string
+    ): Promise<DeliveryAttempt[] | undefined> {
+      return client._axios
+        .get(`/v1/webhook/${webhookId}/message/${messageId}/attempt`)
+        .then(response => client._unpackResponseData<DeliveryAttempt[]>(response))
         .catch(handleEntityNotFound('Webhook message', messageId))
     }
   }))(this)

--- a/src/web/modules/webhooks/messages/detail.njk
+++ b/src/web/modules/webhooks/messages/detail.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
-{% from "../webhookStatus.macro.njk" import webhookStatusTag %}
+{% from "../webhookMessageStatus.macro.njk" import webhookMessageStatusTag %}
 
 {% set isTestData = webhook and not webhook.live %}
 
@@ -32,7 +32,37 @@
 
   {{ json(eventType + " event body", message.resource) }}
 
-  </ul><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <div class="govuk-!-margin-top-8">
+    <h2 class="govuk-heading-s">Delivery attempts</h2>
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Attempt date</th>
+            <th class="govuk-table__header" scope="col">Status</th>
+            <th class="govuk-table__header" scope="col">Status code</th>
+            <th class="govuk-table__header" scope="col">Result</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+        {% for attempt in attempts %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">{{ attempt.send_at | formatDate }}</td>
+            <td class="govuk-table__cell">{{ webhookMessageStatusTag(attempt.status) }}</td>
+            <td class="govuk-table__cell">{{ attempt.status_code or '-' }}</td>
+            <td class="govuk-table__cell">{{ attempt.result }}</td>
+          </tr>
+
+        {% else %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" colspan="4">
+              <i>No delivery attempts found for event</i>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+  </div>
 
   {{ json("Webhook source", webhook) }}
   {{ json("Webhook message source", message) }}

--- a/src/web/modules/webhooks/webhooks.http.ts
+++ b/src/web/modules/webhooks/webhooks.http.ts
@@ -117,9 +117,11 @@ export async function messageDetail(req: Request, res: Response, next: NextFunct
   try {
     const webhook = await Webhooks.webhooks.retrieve(req.params.webhookId, { override_account_or_service_id_restriction: true })
     const message = await Webhooks.webhooks.retrieveMessage(req.params.webhookId, req.params.messageId)
+    const attempts = await Webhooks.webhooks.listMessageAttempts(req.params.webhookId, req.params.messageId)
     res.render('webhooks/messages/detail', {
       webhook,
       message,
+      attempts,
       human_readable_subscriptions: constants.webhooks.humanReadableSubscriptions
     })
   } catch (error) {


### PR DESCRIPTION
Include the history of delivery attempts for a given webhook message, this can be used to support services that are struggling to integrate their service.

<img width="569" alt="Screenshot 2023-05-15 at 10 44 33" src="https://github.com/alphagov/pay-toolbox/assets/2844572/56b7d93d-14c6-45e6-8cb4-8810eb50b920">

