### PR TITLE
PP-10537 Quality of life improvements for webhooks

### DIFF
--- a/src/web/modules/webhooks/detail.njk
+++ b/src/web/modules/webhooks/detail.njk
@@ -10,11 +10,14 @@
 {% endmacro %}
 
 {% block main %}
+  <div>
+    <a href="/services/{{ webhook.service_id }}" class="govuk-back-link">Associated service ({{ webhook.service_id }})</a>
+  </div>
   <h1 class="govuk-heading-m">Webhook</h1>
 
   {% set subscriptions_list %}
     <ul class="govuk-list">
-      {% for subscription_key in webhook.subscriptions %}
+      {% for subscription_key in webhook.subscriptions | sort %}
         <li>{{human_readable_subscriptions[subscription_key | upper]}}</li>
       {% endfor %}
     </ul>
@@ -31,11 +34,15 @@
   ]
   }) }}
 
-  <ul class="govuk-list">
-    <li>
-      <a href="/webhooks/{{ webhook.external_id }}/messages" class="govuk-link">View messages</a>
-    </li>
-  </ul><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <h2 class="govuk-heading-s">Actions</h2>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "View messages",
+      href: "/webhooks/" + webhook.external_id + "/messages",
+      classes: "govuk-button--secondary"
+    }) }}
+  </div>
 
   {{ json("Webhook source", webhook) }}
 {% endblock %}

--- a/src/web/modules/webhooks/messages/detail.njk
+++ b/src/web/modules/webhooks/messages/detail.njk
@@ -30,8 +30,6 @@
   ]
   }) }}
 
-  {{ json(eventType + " event body", message.resource) }}
-
   <div class="govuk-!-margin-top-8">
     <h2 class="govuk-heading-s">Delivery attempts</h2>
     <table class="govuk-table">
@@ -64,6 +62,7 @@
       </table>
   </div>
 
+  {{ json(eventType + " event body", message.resource) }}
   {{ json("Webhook source", webhook) }}
   {{ json("Webhook message source", message) }}
 {% endblock %}

--- a/src/web/modules/webhooks/messages/overview.njk
+++ b/src/web/modules/webhooks/messages/overview.njk
@@ -39,7 +39,6 @@
       <th class="govuk-table__header" scope="col">Event type</th>
       <th class="govuk-table__header" scope="col">Status</th>
       <th class="govuk-table__header" scope="col">Created</th>
-      <th class="govuk-table__header" scope="col">Latest attempt</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -49,13 +48,10 @@
         <a class="govuk-link" href="/webhooks/{{ webhook.external_id }}/messages/{{ message.external_id }}">{{ human_readable_subscriptions[message.event_type | upper] }}</a>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-caption-m">{{ webhookMessageStatusTag(message.last_delivery_status) }}</span>
+        <span class="govuk-caption-m">{{ webhookMessageStatusTag(message.last_delivery_status or 'PENDING') }}</span>
       </td>
       <td class="govuk-table__cell">
         <span class="govuk-caption-m">{{ message.created_date | formatDate }}</span>
-      </td>
-      <td class="govuk-table__cell">
-        <span class="govuk-caption-m">{{ message.latest_attempt and message.latest_attempt.created_date | formatDate }}</span>
       </td>
     </tr>
     {% else %}

--- a/src/web/modules/webhooks/overview.njk
+++ b/src/web/modules/webhooks/overview.njk
@@ -3,6 +3,10 @@
 {% from "./webhookStatus.macro.njk" import webhookStatusTag %}
 
 {% block main %}
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Associated account ({{ account.external_id }})</a>
+  </div>
+
   <span class="govuk-caption-m">
     {% if service %}
       <span>{{ service.name }}</span>
@@ -27,7 +31,7 @@
         {% for webhook in webhooks %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              {{ webhook.domain }}
+              <a class="govuk-link" href="/webhooks/{{ webhook.external_id }}">{{ webhook.domain }}</a>
             </td>
             <td class="govuk-table__cell">
               {{ webhookStatusTag(
@@ -35,7 +39,7 @@
               ) }}
             </td>
             <td class="govuk-table__cell">
-              <a class="govuk-link" href="/webhooks/{{ webhook.external_id }}">{{ webhook.created_date | formatToSimpleDate }}</a>
+              {{ webhook.created_date | formatToSimpleDate }}
             </td>
           </tr>
         {% else %}


### PR DESCRIPTION
A few tweaks to make navigating around webhooks in Toolbox better:
- include links to associated services/ accounts from pages to support digging down into detail and back up
- add subheadings to separate content and actions
- order subscriptions alphabetically to stop them moving in-place
- address visual issue when no`last_delivery_status` existing when a message hasn't been attempted yet