### PR TITLE
PP-10895 Add associated webhook messages to the payments page

### DIFF
--- a/src/lib/pay-request/services/webhooks/types.ts
+++ b/src/lib/pay-request/services/webhooks/types.ts
@@ -61,5 +61,6 @@ export interface ListWebhooksForServiceRequest extends ListWebhookRequest {
 
 export interface ListWebhookMessageRequest {
   page?: number,
-  status?: string
+  status?: string,
+  resource_id?: string
 }

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -1,5 +1,6 @@
 {% from "transactions/status.macro.njk" import status %}
 {% from "common/json.njk" import json %}
+{% from "./../webhooks/webhookMessageStatus.macro.njk" import webhookMessageStatusTag %}
 {% extends "layout/layout.njk" %}
 
 {% set isTestData = not transaction.live %}
@@ -176,6 +177,25 @@
       </table>
     {% else %}
       <div class="center bottom-spacer"><span class="govuk-caption-m">No metadata</span></div>
+    {% endif %}
+  </div>
+
+  <div>
+    <h1 class="govuk-heading-s payment__header">Webhook messages</h1>
+    {% if webhookMessages.length %}
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+      {% for message in webhookMessages %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><a class="govuk-link" href="/webhooks/{{ message.webhook_id }}/messages/{{ message.external_id }}">{{ humanReadableSubscriptions[message.event_type | upper] }}</a></td>
+          <td class="govuk-table__cell">{{ webhookMessageStatusTag(message.last_delivery_status or 'PENDING') }}</td>
+          <td class="govuk-table__cell">{{ message.created_date | formatDate }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+      <div class="center bottom-spacer"><span class="govuk-caption-m">No webhook messages associated with payment</span></div>
     {% endif %}
   </div>
 

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -161,16 +161,20 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     }
 
     const webhookMessages = []
-    const webhooks = await Webhooks.webhooks.list({
-      service_id: service.external_id,
-      live: account.type === AccountType.Live
-    })
-
-    for (const webhook of webhooks) {
-      const messages = await Webhooks.webhooks.listMessages(webhook.external_id, {
-        resource_id: transaction.transaction_id
+    try {
+      const webhooks = await Webhooks.webhooks.list({
+        service_id: service.external_id,
+        live: account.type === AccountType.Live
       })
-      webhookMessages.push(...messages.results.map((webhookMessage) => ({ ...webhookMessage, webhook_id: webhook.external_id })))
+
+      for (const webhook of webhooks) {
+        const messages = await Webhooks.webhooks.listMessages(webhook.external_id, {
+          resource_id: transaction.transaction_id
+        })
+        webhookMessages.push(...messages.results.map((webhookMessage) => ({ ...webhookMessage, webhook_id: webhook.external_id })))
+      }
+    } catch (webhooksError) {
+      logger.warn('Failed to fetch webhooks data for the payments page', webhooksError)
     }
 
     const renderKey = transaction.transaction_type.toLowerCase()

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -1,9 +1,9 @@
 import {NextFunction, Request, Response} from 'express'
 
-import {AdminUsers, Connector, Ledger} from '../../../lib/pay-request/client'
+import {AdminUsers, Connector, Ledger, Webhooks} from '../../../lib/pay-request/client'
 import {EntityNotFoundError} from '../../../lib/errors'
 import logger from '../../../lib/logger'
-import {TransactionType} from "../../../lib/pay-request/shared";
+import {AccountType, TransactionType} from '../../../lib/pay-request/shared'
 import {PaymentListFilterStatus, resolvePaymentStates, resolveRefundStates} from "./states";
 
 const process = require('process')
@@ -13,6 +13,7 @@ const moment = require('moment')
 const rfc822Validator = require('rfc822-validate')
 
 const {common, services} = require('./../../../config')
+const {constants} = require('@govuk-pay/pay-js-commons')
 
 if (common.development) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0
@@ -159,6 +160,19 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
       parentTransaction = await Ledger.transactions.retrieve(transaction.parent_transaction_id)
     }
 
+    const webhookMessages = []
+    const webhooks = await Webhooks.webhooks.list({
+      service_id: service.external_id,
+      live: account.type === AccountType.Live
+    })
+
+    for (const webhook of webhooks) {
+      const messages = await Webhooks.webhooks.listMessages(webhook.external_id, {
+        resource_id: transaction.transaction_id
+      })
+      webhookMessages.push(...messages.results.map((webhookMessage) => ({ ...webhookMessage, webhook_id: webhook.external_id })))
+    }
+
     const renderKey = transaction.transaction_type.toLowerCase()
 
     if (transaction.gateway_transaction_id && account.payment_provider === 'stripe') {
@@ -172,7 +186,9 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
       account,
       service,
       events,
-      stripeDashboardUri
+      stripeDashboardUri,
+      webhookMessages,
+      humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions
     })
   } catch (error) {
     next(error)

--- a/src/web/modules/webhooks/messages/detail.njk
+++ b/src/web/modules/webhooks/messages/detail.njk
@@ -34,7 +34,7 @@
 
   <div class="govuk-!-margin-top-8">
     <h2 class="govuk-heading-s">Delivery attempts</h2>
-    <table class="govuk-table">
+      <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Attempt date</th>


### PR DESCRIPTION
Make it easy to check if a service has webhooks subscribed to certain payments by putting associated webhook messages on the payments page.

Do this by:
- checking if there are any webhooks associated with the service
- checking for messages assoicated with those webhooks and this resource (this is because messages are a sub-resource of webhooks)

Use the precedent set by other components on the page for a centred no data found message.

![localhost_3200_transactions_ahttdf42rjp67at7u5gcqe2ghd](https://github.com/alphagov/pay-toolbox/assets/2844572/8f7478c0-a059-431a-9312-42575a58a4d4)


