### PR TITLE
BAU Fix incorrect service live flag on go lives

### DIFF
--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -160,7 +160,7 @@ async function writeAccount(req: Request, res: Response): Promise<void> {
       service_went_live_date: moment.utc().format(),
       service_created_date: moment.utc(service.created_date).format(),
       service_using_provider: account.provider,
-      service_is_internal_service: service.internal
+      service_is_internal_service: account.internalFlag
     })
   }
 


### PR DESCRIPTION
After updating the service on the backend, we're logging values from a service object fetched before the update.

Change this to log the value that we just updated the service with.

This will allow reports/ log searches to appropriately filter out services that have been made live for internal purposes.