### PR TITLE
PP-10977 remove expired status from agreements

### DIFF
--- a/src/lib/pay-request/shared.ts
+++ b/src/lib/pay-request/shared.ts
@@ -57,7 +57,7 @@ export enum ExternalAgreementState {
   Created = 'created',
   Active = 'active',
   Cancelled = 'cancelled',
-  Expired = 'expired'
+  Inactive = 'inactive'
 }
 
 export enum PaymentInstrumentType {

--- a/src/web/modules/agreements/list.njk
+++ b/src/web/modules/agreements/list.njk
@@ -18,7 +18,7 @@
   <h1 class="govuk-heading-m">Agreements</h1>
 
   <div class="list-page-filter__container govuk-body">
-    {% for status in ["created", "active", "cancelled", "all"] %}
+    {% for status in ["created", "active", "cancelled", "inactive", "all"] %}
       <a
         class="list-page-filter__item {% if selectedStatus === status %}selected{% endif %} no-decoration"
         href="/agreements?status={{ status }}{{ linkQueryParams }}">

--- a/src/web/modules/agreements/states.ts
+++ b/src/web/modules/agreements/states.ts
@@ -1,14 +1,15 @@
 import {ExternalAgreementState, ExternalTransactionState} from "../../../lib/pay-request/shared";
 
 export enum AgreementListFilterStatus {
-  Created = 'created', Active = 'active', Cancelled = 'cancelled', All = 'all'
+  Created = 'created', Active = 'active', Cancelled = 'cancelled', Inactive = 'inactive', All = 'all'
 }
 
 const agreementFilterStatusMap: { [key in AgreementListFilterStatus]: ExternalAgreementState } = {
   all: null,
   created: ExternalAgreementState.Created,
   active: ExternalAgreementState.Active,
-  cancelled: ExternalAgreementState.Cancelled
+  cancelled: ExternalAgreementState.Cancelled,
+  inactive: ExternalAgreementState.Inactive
 }
 
 export function resolveAgreementStates(statusFilter: AgreementListFilterStatus) {

--- a/src/web/modules/agreements/status.macro.njk
+++ b/src/web/modules/agreements/status.macro.njk
@@ -1,14 +1,14 @@
 {% set statusStyleMap = {
   "CREATED": "govuk-tag--grey",
   "ACTIVE": "govuk-tag--green",
-  "EXPIRED": "govuk-tag--yellow",
+  "INACTIVE": "govuk-tag--yellow",
   "CANCELLED": "govuk-tag--yellow"
 } %}
 {% set statusTextMap = {
   "CREATED": "created",
   "ACTIVE": "active",
+  "INACTIVE": "inactive"
   "CANCELLED": "cancelled",
-  "EXPIRED": "expired"
 } %}
 
 {% macro agreementStatusTag(status) %}


### PR DESCRIPTION
We don’t have any process/code that sets the payment_instrument/agreement status to expired. Also don’t have any plans to set payment instruments to expired status.

- replace expired with inactive status