### PR TITLE
PP-11244 Use /api/ variant of GET account endpoint

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -3,8 +3,7 @@ import Client from '../../base'
 import {mapRequestParamsToOperation} from '../../utils/request'
 import {
   Charge,
-  GatewayAccountAPI,
-  GatewayAccountFrontend,
+  GatewayAccount,
   StripeCredentials,
   ListCardTypesResponse,
   ListGatewayAccountsRequest,
@@ -13,7 +12,10 @@ import {
   CreateGatewayAccountResponse,
   GatewayStatusComparison,
   StripeSetup,
-  UpdateGatewayAccountRequest, UpdateStripeSetupRequest, GatewayAccountCredentials, AddGatewayAccountCredentialsRequest, GatewayAccount
+  UpdateGatewayAccountRequest,
+  UpdateStripeSetupRequest,
+  GatewayAccountCredentials,
+  AddGatewayAccountCredentialsRequest
 } from './types'
 import {App} from '../../shared'
 import {handleEntityNotFound} from "../../utils/error";
@@ -74,38 +76,26 @@ export default class Connector extends Client {
 
   accounts = ((client: Connector) => ({
     /**
-     * Internal API view for gateway account
+     * Get gateway account by gateway account ID
      * @param id - Gateway account ID
      * @returns Gateway account object
      */
-    retrieveAPI(id: string): Promise<GatewayAccountAPI | undefined> {
+    retrieve(id: string): Promise<GatewayAccount | undefined> {
       return client._axios
         .get(`/v1/api/accounts/${id}`)
-        .then(response => client._unpackResponseData<GatewayAccountAPI>(response))
+        .then(response => client._unpackResponseData<GatewayAccount>(response))
         .catch(handleEntityNotFound("Account by ID", id))
     },
 
     /**
-     * Frontend view for gateway account
-     * @param id - Gateway account ID
-     * @returns Gateway account object
-     */
-    retrieveFrontend(id: string): Promise<GatewayAccountFrontend | undefined> {
-      return client._axios
-        .get(`/v1/frontend/accounts/${id}`)
-        .then(response => client._unpackResponseData<GatewayAccountFrontend>(response))
-        .catch(handleEntityNotFound("Account by ID", id))
-    },
-
-    /**
-     * Frontend view for gateway account, retrieved by the gateway account external ID`
+     * Get gateway account by external ID
      * @param externalId - Gateway account external ID
      * @returns Gateway account object
      */
-    retrieveFrontendByExternalId(externalId: string): Promise<GatewayAccountFrontend | undefined> {
+    retrieveByExternalId(externalId: string): Promise<GatewayAccount| undefined> {
       return client._axios
         .get(`/v1/frontend/accounts/external-id/${externalId}`)
-        .then(response => client._unpackResponseData<GatewayAccountFrontend>(response))
+        .then(response => client._unpackResponseData<GatewayAccount>(response))
         .catch(handleEntityNotFound("Account by external ID", externalId));
     },
 
@@ -209,7 +199,7 @@ export default class Connector extends Client {
           return
         });
       // @TODO(sfount) decide if this should return the updated account -- could determine through uses of it
-      // .then(() => this.retrieveAPI(id))
+      // .then(() => this.retrieve(id))
     },
 
     updateStripeSetup(id: string, params: UpdateStripeSetupRequest): Promise<void> {

--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -39,8 +39,6 @@ export interface GatewayAccount {
   allow_apple_pay: boolean;
   allow_google_pay: boolean;
   block_prepaid_cards: boolean;
-  /** Gateway account has 3ds enabled */
-  toggle_3ds: boolean;
   allow_zero_amount: boolean;
   integration_version_3ds: number;
   allow_moto: boolean;
@@ -57,6 +55,12 @@ export interface GatewayAccount {
   recurring_enabled: boolean;
   provider_switch_enabled: boolean;
   service_id: string;
+  worldpay_3ds_flex: Worldpay3dsFlexCredentials;
+  gateway_account_credentials: GatewayAccountCredential[];
+  live: boolean;
+  /** Gateway account has 3ds enabled */
+  requires3ds: boolean;
+  sendPayerIpAddressToGateway: boolean;
 }
 
 export interface GatewayAccountCredential {
@@ -73,26 +77,6 @@ export interface StripeCredentials {
 export interface Credentials {
   merchant_id?: string;
   username?: string;
-}
-
-export interface GatewayAccountFrontend extends GatewayAccount {
-  gateway_account_credentials: GatewayAccountCredential[];
-  live: boolean;
-  /** Gateway account has 3ds enabled */
-  requires3ds: boolean;
-  sendPayerIpAddressToGateway: boolean;
-  version: number;
-
-  // notificationCredentials
-  // notifySettings
-}
-
-export interface GatewayAccountAPI extends GatewayAccount {
-  /** Gateway account has 3ds enabled */
-  toggle_3ds: boolean;
-  worldpay_3ds_flex: Worldpay3dsFlexCredentials;
-
-  // _links: PayLinks
 }
 
 export interface Worldpay3dsFlexCredentials {

--- a/src/web/modules/agreements/agreements.http.ts
+++ b/src/web/modules/agreements/agreements.http.ts
@@ -66,7 +66,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
 
     if (req.query.account) {
       service = await AdminUsers.services.retrieve({gatewayAccountId: accountId as string})
-      account = await Connector.accounts.retrieveAPI(accountId as string)
+      account = await Connector.accounts.retrieve(accountId as string)
     }
 
     res.render('agreements/list', {

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -7,7 +7,7 @@ import logger from "../../../../lib/logger";
 import stripeTestAccount from '../../stripe/basic/test-account.http'
 
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
-  const account = await Connector.accounts.retrieveFrontend(req.params.id)
+  const account = await Connector.accounts.retrieve(req.params.id)
   const service = await AdminUsers.services.retrieve({gatewayAccountId: account.gateway_account_id})
   res.render('gateway_accounts/switch_psp/switch_psp', {account, service, flash: req.flash(), csrf: req.csrfToken()})
 }
@@ -17,7 +17,7 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
   let stripeCredentials: { stripe_account_id: string }
 
   try {
-    const account = await Connector.accounts.retrieveFrontend(req.params.id)
+    const account = await Connector.accounts.retrieve(req.params.id)
     const service = await AdminUsers.services.retrieve({gatewayAccountId: gatewayAccountId})
 
     if (!req.body.paymentProvider) {

--- a/src/web/modules/ledger_payouts/payout.http.ts
+++ b/src/web/modules/ledger_payouts/payout.http.ts
@@ -18,7 +18,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
 
     if (req.query.account) {
       service = await AdminUsers.services.retrieve({gatewayAccountId})
-      account = await Connector.accounts.retrieveAPI(gatewayAccountId)
+      account = await Connector.accounts.retrieve(gatewayAccountId)
     }
 
     res.render('ledger_payouts/list', {

--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -103,7 +103,7 @@ async function fetchUsageContext(sortKey: string, filterLiveAccounts: Boolean, a
   if (accountId) {
     serviceRequest = AdminUsers.services.retrieve({gatewayAccountId: accountId})
       .then((service) => [service])
-    liveAccountsRequest = Connector.accounts.retrieveAPI(accountId)
+    liveAccountsRequest = Connector.accounts.retrieve(accountId)
       .then((account) => [account])
   } else {
     serviceRequest = AdminUsers.services.list()

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -54,7 +54,7 @@ const performancePlatformCsv = async function performancePlatformCsv(req: Reques
 const getServiceGatewayAccounts = async (gateway_account_ids: Array<string>) => {
   const serviceGatewayAccounts = []
   for (const id of gateway_account_ids) {
-    serviceGatewayAccounts.push(await Connector.accounts.retrieveAPI(id))
+    serviceGatewayAccounts.push(await Connector.accounts.retrieve(id))
   }
   return serviceGatewayAccounts
 }

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -114,7 +114,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
 
     if (req.query.account) {
       service = await AdminUsers.services.retrieve({gatewayAccountId: accountId as string})
-      account = await Connector.accounts.retrieveAPI(accountId as string)
+      account = await Connector.accounts.retrieve(accountId as string)
     }
 
     res.render('transactions/list', {
@@ -135,7 +135,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
 export async function show(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const transaction = await Ledger.transactions.retrieve(req.params.id)
-    const account = await Connector.accounts.retrieveAPI(transaction.gateway_account_id)
+    const account = await Connector.accounts.retrieve(transaction.gateway_account_id)
     const service = await AdminUsers.services.retrieve({gatewayAccountId: transaction.gateway_account_id})
     const relatedTransactions = []
     let stripeDashboardUri = ''
@@ -225,7 +225,7 @@ export async function statistics(req: Request, res: Response, next: NextFunction
     const fromDate: string = moment().utc().startOf(momentKey).format()
     const toDate: string = moment().utc().endOf(momentKey).format()
 
-    const account = await Connector.accounts.retrieveAPI(accountId);
+    const account = await Connector.accounts.retrieve(accountId);
     const includeMotoStatistics = account.allow_moto;
 
     const paymentsByState = await Ledger.reports.retrievePaymentSummaryByState({
@@ -326,7 +326,7 @@ export async function streamCsv(req: Request, res: Response, next: NextFunction)
   try {
     if (accountId) {
       serviceDetails = await AdminUsers.services.retrieve({gatewayAccountId: accountId})
-      gatewayAccountDetails = await Connector.accounts.retrieveAPI(accountId)
+      gatewayAccountDetails = await Connector.accounts.retrieve(accountId)
     }
 
     const feeHeaders = gatewayAccountDetails && gatewayAccountDetails.payment_provider === 'stripe'

--- a/src/web/modules/webhooks/webhooks.http.ts
+++ b/src/web/modules/webhooks/webhooks.http.ts
@@ -41,7 +41,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
       throw new Error('Webhooks can currently only be shown for a single account')
     }
 
-    const account = await Connector.accounts.retrieveAPI(accountId as string)
+    const account = await Connector.accounts.retrieve(accountId as string)
     const service = await AdminUsers.services.retrieve(account.service_id)
 
     const webhooks = await Webhooks.webhooks.list({


### PR DESCRIPTION
There are 2 endpoints for getting an account by the internal ID: `/v1/api/accounts/{accountId}` and `/v1/frontend/accounts/{accountId}`

These both now return exactly the same response. We intend to remove the `/frontend/` variant, so use the `/api/` variant in all places.