### PR TITLE
PP-11138 Dependabot security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
   labels:
   - dependencies
   - govuk-pay
-  - javascript
+  - docker
   ignore:
   - dependency-name: node
     versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,11 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
   - javascript
-  allow:
-  - dependency-type: "production"
-  ignore:
-  - dependency-name: "google-libphonenumber"
-    update-types: ["version-update:semver-patch"]
-  - dependency-name: "@sentry/node"
-    update-types: ["version-update:semver-patch"]
-  - dependency-name: "@aws-sdk/client-ecs"
-    update-types: ["version-update:semver-patch","version-update:semver-minor"]
-  - dependency-name: "@aws-sdk/client-s3"
-    update-types: ["version-update:semver-patch","version-update:semver-minor"]
-  - dependency-name: stripe
-    versions:
-    - "> 7.15.0"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
See RFC: https://github.com/alphagov/pay-architecture/discussions/97

We can simplify the existing configuration that ignores dev dependencies and AWS etc, by setting Dependabot to only generate security update PRs for the `npm` package ecosystem. 