### PR TITLE
PP-11287 add auth mode and agreement id to transaction detail page

### DIFF
--- a/src/tests/fixtures/payment.ts
+++ b/src/tests/fixtures/payment.ts
@@ -45,7 +45,8 @@ const transaction: Transaction = {
   },
   transaction_id: 'rs7l0c6ka8b0hr2ho7omkpo6ot',
   transaction_type: 'PAYMENT',
-  live: true
+  live: true,
+  authorisation_mode: "web"
 }
 
 export default transaction

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -155,6 +155,18 @@
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">MOTO</span></th>
           <td class="govuk-table__cell payment__cell">{{ transaction.moto | string | capitalize }}</td>
         </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Recurring</span></th>
+          <td class="govuk-table__cell payment__cell">{{ "True" if transaction.authorisation_mode == "agreement" else "False" | string }}</td>
+        </tr>
+        {% if transaction.agreement_id %}
+          <tr class="govuk-table__row">
+            <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Agreement</span></th>
+            <td class="govuk-table__cell payment__cell">
+            <a class="govuk-link govuk-link--no-visited-state" href="/agreements/{{transaction.agreement_id}}">{{ transaction.agreement_id }}
+            </td>
+          </tr>
+        (% endif %}
       </tbody>
     </table>
   </div>

--- a/src/web/modules/transactions/types/ledger.ts
+++ b/src/web/modules/transactions/types/ledger.ts
@@ -61,6 +61,8 @@ export interface Transaction {
   parent_transaction_id?: string;
   parent?: Transaction;
   live: boolean;
+  authorisation_mode: string,
+  agreement_id?: string
 }
 
 export interface Event {


### PR DESCRIPTION
The payment page in Toolbox includes information on the payment, how it was processed and its event timeline. Add rows to include information about recurring payments in the “Processing details” section of the page.

- Recurring: True if authorisation mode == agreement else False
- Agreement: (agreement_id) (links to agreement detail page) if transaction has agreement_id