### PR TITLE
PP-11152 Read merchant code from new credentials structure

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -109,7 +109,15 @@
         <dd class="govuk-summary-list__actions"></dd>
       </div>
       {% endif %}
-      {% if currentCredential and currentCredential.credentials.merchant_id %}
+      {% if currentCredential
+        and currentCredential.credentials.one_off_customer_initiated|length
+        and currentCredential.credentials.one_off_customer_initiated.merchant_code %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Worldpay merchant code</span></dt>
+          <dd class="govuk-summary-list__value">{{ currentCredential.credentials.one_off_customer_initiated.merchant_code }}</dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        </div>
+      {% elif currentCredential and currentCredential.credentials.merchant_id %}
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><span class="govuk-caption-m">PSP merchant ID</span></dt>
         <dd class="govuk-summary-list__value">{{ currentCredential.credentials.merchant_id }}</dd>


### PR DESCRIPTION
Worldpay credentials in the response from connector now include a "one_off_customer_initiated" field that is always populated with the one off credentials if they are set. The "merchant_id" and "username" at the root of the credentials object will no longer be present for Worldpay accounts that set/update credentials in the future.

Use the `one_off_customer_initated.merchant_code` field to display the Worldpay merchant code.