### PR TITLE
PP-11327 remove username from User class

### DIFF
--- a/src/lib/pay-request/services/admin_users/types.ts
+++ b/src/lib/pay-request/services/admin_users/types.ts
@@ -62,7 +62,6 @@ export interface ServiceRole {
 
 export interface User {
   external_id: string;
-  username: string;
   email: string;
   telephone_number: string;
   service_roles: ServiceRole[];


### PR DESCRIPTION
We no longer have username as such stored in adminusers and we are not going to include it in any responses that contain user info.

- remove username from User.class