### PR TITLE
PP-11327 switch using email to find a user

### DIFF
--- a/src/lib/pay-request/services/admin_users/client.ts
+++ b/src/lib/pay-request/services/admin_users/client.ts
@@ -97,7 +97,7 @@ export default class AdminUsers extends Client {
 
     findByEmail(email: string) : Promise<User | undefined> {
       return client._axios
-        .post('/v1/api/users/find', { username: email })
+        .post('/v1/api/users/find', { username: email, email: email })
         .then(response => client._unpackResponseData<User>(response))
         .then(user => redactOTP(user))
         .catch(handleEntityNotFound('User', email));


### PR DESCRIPTION
Adminusers is searching by email. The method in Toolbox is called findByEmail. It makes sense to rename the payload's field to email instead of username.