### PR TITLE
PP-10784 Update compile assets script

### DIFF
--- a/scripts/compile-assets
+++ b/scripts/compile-assets
@@ -14,7 +14,7 @@ MANIFEST_TARGET="$BUILD_FOLDER/manifest.json"
 VERSION=$(npm run version --silent)
 
 TEMP_FILE="$BUILD_FOLDER/$BUILD_TARGET.tmp"
-sass --style=compressed --load-path=node_modules $APPLICATION_SASS > $TEMP_FILE
+sass --style=compressed --load-path=node_modules --quietDeps $APPLICATION_SASS > $TEMP_FILE
 
 # Version file based on file hash
 HASH=$(sha1sum $TEMP_FILE | awk '{ print $1 }')


### PR DESCRIPTION
- Add the `--quietDeps` flag to the SASS compilation step to hide warnings from design system SASS files.  Design system will be updating these in the future but have to leave them in for now to ensure backward compatibility.
- Warnings will still be shown from any of our SASS files