### PR TITLE
BAU: Fix Docker Dependabot ignore version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
   ignore:
   - dependency-name: node
     versions:
-    - ">= 18"
+    - ">= 19"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
We want updates for Node 18.x but not 19.x.