### PR TITLE
PP-11812 Revoke API keys when a service is archived

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -246,7 +246,7 @@
         Toggle the archived status of this service.
       </p>
       <p class="govuk-body">
-        This will remove ALL users from service, redacts gateway account credentials and impacts internal Pay team reports
+        This will remove ALL users from the service, revoke API keys, and redact gateway account credentials. Also impacts internal Pay team reports
       </p>
       <p class="govuk-body">This should not be used if you need to suspend a service</p>
     {% endif %}


### PR DESCRIPTION
## WHAT
- When a service is archived, we currently remove users from the service and redact gateway account credentials
- We can also revoke API keys as users will not have access to service.
