### PR TITLE
PP-11634 Collect Notify service ID

### DIFF
--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -86,9 +86,11 @@ export interface Worldpay3dsFlexCredentials {
 }
 
 export interface NotifySettings {
+  service_id: string,
   api_token: string;
   template_id: string;
   refund_issued_template_id: string;
+  email_reply_to_id?: string;
 }
 
 export interface UpdateGatewayAccountRequest {

--- a/src/web/modules/gateway_accounts/email_branding.njk
+++ b/src/web/modules/gateway_accounts/email_branding.njk
@@ -14,6 +14,15 @@
 
   <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/email_branding">
     {{ govukInput({
+      id: "service_id",
+      name: "service_id",
+      label: { text: "Notify Service ID" },
+      hint: { html: "Get this from the page URL when you've navigated into the service in Notify" },
+      autocomplete: "off",
+      value: account.notifySettings.service_id
+    })
+    }}
+    {{ govukInput({
       id: "api_token",
       name: "api_token",
       label: { text: "Notify API key" },
@@ -24,14 +33,16 @@
       id: "template_id",
       name: "template_id",
       label: { text: "Payment confirmation template ID" },
-      autocomplete: "off"
+      autocomplete: "off",
+      value: account.notifySettings.template_id
     })
     }}
     {{ govukInput({
       id: "refund_issued_template_id",
       name: "refund_issued_template_id",
       label: { text: "Refund template ID" },
-      autocomplete: "off"
+      autocomplete: "off",
+      value: account.notifySettings.refund_issued_template_id
     })
     }}
     {{ govukInput({
@@ -39,7 +50,8 @@
       name: "email_reply_to_id",
       label: { text: "Reply-to email address ID (optional)" },
       hint: { html: "Enter an existing ID, not an email address" },
-      autocomplete: "off"
+      autocomplete: "off",
+      value: account.notifySettings.email_reply_to_id
     })
     }}
 


### PR DESCRIPTION
For configuring email custom branding for a gateway account, add a required field to set the Notify Service ID.

No changes in connector are required for this, as connector accepts and stores any JSON for the `notify_settings` property for a gateway account.

Add simple validation for the form to configure email branding using the Joi library.