### PR TITLE
PP-11634- Add temporary Notify service ID checker utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "moment": "^2.29.4",
         "morgan": "^1.10.0",
         "multer": "1.4.5-lts.1",
+        "notifications-node-client": "^7.0.6",
         "nunjucks": "3.2.4",
         "passport": "~0.5.3",
         "passport-github": "1.1.0",
@@ -7044,6 +7045,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -8228,6 +8234,14 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -11050,6 +11064,27 @@
         "node >= 0.2.0"
       ]
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -11070,6 +11105,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keygrip": {
       "version": "1.0.3",
@@ -11235,6 +11289,11 @@
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
       "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -11250,10 +11309,30 @@
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
     "node_modules/lodash.isnil": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
       "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.isundefined": {
       "version": "3.0.1",
@@ -11265,6 +11344,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
@@ -12916,6 +13000,29 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notifications-node-client": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.6.tgz",
+      "integrity": "sha512-qo6eZMGdyaQnj/bkOnPb/d0a0sHIjiBzXlmICLPXYSD4pB3LYa537OhuZGuaFcSnkrM4NzbQhbQHAYX1NnbQgw==",
+      "dependencies": {
+        "axios": "^1.6.1",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.3",
+        "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/notifications-node-client/node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -14855,7 +14962,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14870,7 +14976,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14881,8 +14986,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "moment": "^2.29.4",
     "morgan": "^1.10.0",
     "multer": "1.4.5-lts.1",
+    "notifications-node-client": "^7.0.6",
     "nunjucks": "3.2.4",
     "passport": "~0.5.3",
     "passport-github": "1.1.0",

--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -48,7 +48,7 @@ export interface GatewayAccount {
   send_reference_to_gateway: boolean;
   email_collection_mode?: EmailCollectionMode,
   email_notifications: EmailNotifications,
-  notify_settings: NotifySettings
+  notifySettings: NotifySettings
   disabled: boolean;
   disabled_reason: string;
   allow_authorisation_api: boolean;

--- a/src/web/modules/gateway_accounts/check_notify_service_id.http.ts
+++ b/src/web/modules/gateway_accounts/check_notify_service_id.http.ts
@@ -1,0 +1,44 @@
+import {NextFunction, Request, Response} from 'express'
+import {Connector} from "../../../lib/pay-request/client";
+import crypto from "crypto";
+
+const NotifyClient = require('notifications-node-client').NotifyClient
+
+export async function tempCheckNotifyServiceId(req: Request, res: Response, next: NextFunction) {
+    try {
+        const {accountId} = req.params
+        const account = await Connector.accounts.retrieve(accountId)
+        if (!account.notifySettings) {
+            res.send("No email custom branding configured for gateway account")
+        }
+
+        const templateId = account.notifySettings.template_id
+        const serviceId = account.notifySettings.service_id
+        const apiKey = account.notifySettings.api_token
+
+        const notifyClient = new NotifyClient(apiKey)
+        const response = await notifyClient
+            .sendEmail(templateId, 'simulate-delivered@notifications.service.gov.uk', {
+                personalisation: {
+                    'serviceReference': 'TEST',
+                    'date': 'TEST',
+                    'amount': 'TEST',
+                    'description': 'TEST',
+                    'customParagraph': 'TEST',
+                    'serviceName': 'TEST',
+                    'corporateCardSurcharge': 'TEST'
+                },
+                reference: crypto.randomUUID()
+            })
+        const templateUri = response.data.template.uri
+        const regex = /services\/(\S+)\/templates/g
+        const serviceIdFromTemplate = regex.exec(templateUri)[1]
+        if (serviceId === serviceIdFromTemplate) {
+            res.send('Service ID correct')
+        } else {
+            res.send('Service ID does not match - should be ' + serviceIdFromTemplate)
+        }
+    } catch (err) {
+        next(err)
+    }
+}

--- a/src/web/modules/gateway_accounts/csv_data.ts
+++ b/src/web/modules/gateway_accounts/csv_data.ts
@@ -28,7 +28,7 @@ export async function createCsvData(filters: Filters): Promise<any> {
         payment_email_enabled: account.email_notifications['PAYMENT_CONFIRMED'] && account.email_notifications['PAYMENT_CONFIRMED'].enabled || false,
         refund_email_emailed: account.email_notifications['REFUND_ISSUED'] && account.email_notifications['REFUND_ISSUED'].enabled || false,
         custom_branding: service.custom_branding !== undefined,
-        email_branding: account.notify_settings !== undefined,
+        email_branding: account.notifySettings !== undefined,
         corporate_surcharge: account.corporate_prepaid_debit_card_surcharge_amount
           + account.corporate_credit_card_surcharge_amount
           + account.corporate_debit_card_surcharge_amount !== 0
@@ -65,7 +65,7 @@ export async function createCsvWithAdminEmailsData(filters: Filters): Promise<an
         payment_email_enabled: account.email_notifications['PAYMENT_CONFIRMED'] && account.email_notifications['PAYMENT_CONFIRMED'].enabled || false,
         refund_email_emailed: account.email_notifications['REFUND_ISSUED'] && account.email_notifications['REFUND_ISSUED'].enabled || false,
         custom_branding: service.custom_branding !== undefined,
-        email_branding: account.notify_settings !== undefined,
+        email_branding: account.notifySettings !== undefined,
         corporate_surcharge: account.corporate_prepaid_debit_card_surcharge_amount
           + account.corporate_credit_card_surcharge_amount
           + account.corporate_debit_card_surcharge_amount !== 0

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -25,6 +25,7 @@ const paymentLinks = require('./modules/payment_links/payment_links.http')
 const ledgerPayouts = require('./modules/ledger_payouts/payout.http')
 const performance = require('./modules/statistics/performance.http')
 const events = require('./modules/events')
+const {tempCheckNotifyServiceId} = require('./modules/gateway_accounts/check_notify_service_id.http')
 
 // @TODO(sfount) remove `default`s on update to import export syntax
 const users = require('./modules/users/users.http').default
@@ -181,6 +182,8 @@ router.get('/events-by-date', auth.secured(PermissionLevel.USER_SUPPORT), events
 router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), events.emitByDate)
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
+
+router.get('/temp-check-notify-service-id/:accountId', auth.secured(PermissionLevel.ADMIN), tempCheckNotifyServiceId)
 
 router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 


### PR DESCRIPTION
For PP-11634 some of the Notify service IDs were backfilled incorrectly due to a copy-paste error.

Add a temporary utility route that will check the stored service ID by making a request to the Notify API to send an email using the API key set for the custom branding for a gateway account. Although use the magic notify email address that won't actually send an email. Check the service ID returned in the `template_uri` field in the response matches the service ID we had stored in connector.

This route will be removed after it has served its purpose.