### PR TITLE
PP-12039 Bump axios to 1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@govuk-pay/pay-js-commons": "4.0.2",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "^6.12.0",
-        "axios": "1.6.0",
+        "axios": "^1.6.4",
         "class-validator": "0.14.0",
         "client-sessions": "^0.8.0",
         "cls-hooked": "4.2.2",
@@ -6687,11 +6687,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -9245,9 +9245,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@govuk-pay/pay-js-commons": "4.0.2",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "^6.12.0",
-    "axios": "1.6.0",
+    "axios": "^1.6.4",
     "class-validator": "0.14.0",
     "client-sessions": "^0.8.0",
     "cls-hooked": "4.2.2",


### PR DESCRIPTION
##WHAT
- Bump axios to the latest version which includes updates to vulnerable indirect dependencies (follow_redirects, formToJSON) https://github.com/axios/axios/releases/tag/v1.6.4