### PR TITLE
PP-11212 Refactor services controller

### DIFF
--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -1,27 +1,44 @@
-import http from './services.http'
 import * as exceptions from './services.exceptions'
+import {
+  branding,
+  detail,
+  linkAccounts,
+  listCsv,
+  overview,
+  performancePlatformCsv,
+  search,
+  searchRequest,
+  toggleAgentInitiatedMotoEnabledFlag,
+  toggleArchiveService,
+  toggleExperimentalFeaturesEnabledFlag,
+  toggleTerminalStateRedirectFlag,
+  updateBranding,
+  updateLinkAccounts,
+  updateOrganisation,
+  updateOrganisationForm
+} from './services.http'
 
 export default {
-  overview: http.overview,
-  listCsv: http.listCsv,
-  performancePlatformCsv: http.performancePlatformCsv,
+  overview: overview,
+  listCsv: listCsv,
+  performancePlatformCsv: performancePlatformCsv,
   detail: {
-    http: http.detail,
+    http: detail,
     exceptions: exceptions.detail
   },
-  branding: http.branding,
-  updateBranding: http.updateBranding,
-  linkAccounts: http.linkAccounts,
+  branding: branding,
+  updateBranding: updateBranding,
+  linkAccounts: linkAccounts,
   updateLinkAccounts: {
-    http: http.updateLinkAccounts,
+    http: updateLinkAccounts,
     exceptions: exceptions.updateLinkAccounts
   },
-  search: http.search,
-  searchRequest: http.searchRequest,
-  toggleTerminalStateRedirectFlag: http.toggleTerminalStateRedirectFlag,
-  toggleExperimentalFeaturesEnabled: http.toggleExperimentalFeaturesEnabledFlag,
-  toggleAgentInitiatedMotoEnabled: http.toggleAgentInitiatedMotoEnabled,
-  updateOrganisationForm: http.updateOrganisationForm,
-  updateOrganisation: http.updateOrganisation,
-  toggleArchiveService: http.toggleArchiveService
+  search: search,
+  searchRequest: searchRequest,
+  toggleTerminalStateRedirectFlag: toggleTerminalStateRedirectFlag,
+  toggleExperimentalFeaturesEnabled: toggleExperimentalFeaturesEnabledFlag,
+  toggleAgentInitiatedMotoEnabled: toggleAgentInitiatedMotoEnabledFlag,
+  updateOrganisationForm: updateOrganisationForm,
+  updateOrganisation: updateOrganisation,
+  toggleArchiveService: toggleArchiveService
 }

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -1,10 +1,9 @@
-import {Request, Response} from 'express'
+import {NextFunction, Request, Response} from 'express'
 import {ParsedQs, stringify} from 'qs'
 
 import logger from '../../../lib/logger'
 import {AdminUsers, Connector, PublicAuth} from '../../../lib/pay-request/client'
-import type {Service, User} from '../../../lib/pay-request/services/admin_users/types'
-import {wrapAsyncErrorHandler} from '../../../lib/routes'
+import type {Service} from '../../../lib/pay-request/services/admin_users/types'
 import {sanitiseCustomBrandingURL} from './branding'
 import GatewayAccountRequest from './gatewayAccountRequest.model'
 import {formatPerformancePlatformCsv} from './performancePlatformCsv'
@@ -23,32 +22,44 @@ function extractFiltersFromQuery(query: ParsedQs): ServiceFilters {
   }
 }
 
-const overview = async function overview(req: Request, res: Response): Promise<void> {
-  const filters = extractFiltersFromQuery(req.query)
-  const services = await fetchAndFilterServices(filters)
-  res.render('services/overview', {
-    services,
-    filters,
-    total: services.length.toLocaleString(),
-    csvUrl: `/services/csv?${stringify(filters)}`
-  })
+export async function overview(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const filters = extractFiltersFromQuery(req.query)
+    const services = await fetchAndFilterServices(filters)
+    res.render('services/overview', {
+      services,
+      filters,
+      total: services.length.toLocaleString(),
+      csvUrl: `/services/csv?${stringify(filters)}`
+    })
+  } catch(error) {
+    next(error)
+  }
 }
 
-const listCsv = async function exportCsv(req: Request, res: Response): Promise<void> {
-  const filters = extractFiltersFromQuery(req.query)
-  const services = await fetchAndFilterServices(filters)
+export async function listCsv(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const filters = extractFiltersFromQuery(req.query)
+    const services = await fetchAndFilterServices(filters)
 
-  res.set('Content-Type', 'text/csv')
-  res.set('Content-Disposition', `attachment; filename="GOVUK_PAY_services_${stringify(filters)}.csv"`)
-  res.status(200).send(formatServiceExportCsv(services))
+    res.set('Content-Type', 'text/csv')
+    res.set('Content-Disposition', `attachment; filename="GOVUK_PAY_services_${stringify(filters)}.csv"`)
+    res.status(200).send(formatServiceExportCsv(services))
+  } catch (error) {
+    next(error)
+  }
 }
 
-const performancePlatformCsv = async function performancePlatformCsv(req: Request, res: Response): Promise<void> {
-  const liveActiveServices = await getLiveNotArchivedServices()
+export async function performancePlatformCsv(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const liveActiveServices = await getLiveNotArchivedServices()
 
-  res.set('Content-Type', 'text/csv')
-  res.set('Content-Disposition', `attachment; filename="GOVUK_Pay_live_services_for_performance_platform.csv"`)
-  res.status(200).send(formatPerformancePlatformCsv(liveActiveServices))
+    res.set('Content-Type', 'text/csv')
+    res.set('Content-Disposition', `attachment; filename="GOVUK_Pay_live_services_for_performance_platform.csv"`)
+    res.status(200).send(formatPerformancePlatformCsv(liveActiveServices))
+  } catch (error) {
+    next(error)
+  }
 }
 
 const getServiceGatewayAccounts = async (gateway_account_ids: Array<string>) => {
@@ -59,190 +70,230 @@ const getServiceGatewayAccounts = async (gateway_account_ids: Array<string>) => 
   return serviceGatewayAccounts
 }
 
-const detail = async function detail(req: Request, res: Response): Promise<void> {
-  const serviceId = req.params.id
-  const messages = req.flash('info')
+export async function detail(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const serviceId = req.params.id
+    const messages = req.flash('info')
 
-  const [service, users] = await Promise.all([
-    AdminUsers.services.retrieve(serviceId),
-    AdminUsers.services.listUsers(serviceId)
-  ])
+    const [service, users] = await Promise.all([
+      AdminUsers.services.retrieve(serviceId),
+      AdminUsers.services.listUsers(serviceId)
+    ])
 
-  const userDetails = users.map(user => {
-    const currentServicesRole = user.service_roles
-      .find((serviceRole) => serviceRole.service && serviceRole.service.external_id === serviceId)
-    return {
-      external_id: user.external_id,
-      role: currentServicesRole.role.name,
-      email: user.email,
-      disabled: user.disabled
-    }
-  })
-
-  const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
-
-  const adminEmails = userDetails
-    .filter((userDetail) => userDetail.role.toLowerCase() == 'admin')
-    .map((userDetail) => userDetail.email)
-    .toString()
-
-  res.render('services/detail', {
-    service,
-    serviceGatewayAccounts,
-    users: userDetails,
-    serviceId,
-    messages,
-    adminEmails
-  })
-}
-
-const branding = async function branding(req: Request, res: Response): Promise<void> {
-  const serviceId: string = req.params.id
-  const service = await AdminUsers.services.retrieve(serviceId)
-
-  res.render('services/branding', {serviceId, service, csrf: req.csrfToken()})
-}
-
-const updateBranding = async function updateBranding(req: Request, res: Response): Promise<void> {
-  const {id} = req.params
-
-  await AdminUsers.services.update(id, {
-      custom_branding: {
-        image_url: sanitiseCustomBrandingURL(req.body.image_url),
-        css_url: sanitiseCustomBrandingURL(req.body.css_url)
+    const userDetails = users.map(user => {
+      const currentServicesRole = user.service_roles
+          .find((serviceRole) => serviceRole.service && serviceRole.service.external_id === serviceId)
+      return {
+        external_id: user.external_id,
+        role: currentServicesRole.role.name,
+        email: user.email,
+        disabled: user.disabled
       }
+    })
+
+    const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
+
+    const adminEmails = userDetails
+        .filter((userDetail) => userDetail.role.toLowerCase() == 'admin')
+        .map((userDetail) => userDetail.email)
+        .toString()
+
+    res.render('services/detail', {
+      service,
+      serviceGatewayAccounts,
+      users: userDetails,
+      serviceId,
+      messages,
+      adminEmails
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function branding(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const serviceId: string = req.params.id
+    const service = await AdminUsers.services.retrieve(serviceId)
+
+    res.render('services/branding', {serviceId, service, csrf: req.csrfToken()})
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function updateBranding(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const {id} = req.params
+
+    await AdminUsers.services.update(id, {
+          custom_branding: {
+            image_url: sanitiseCustomBrandingURL(req.body.image_url),
+            css_url: sanitiseCustomBrandingURL(req.body.css_url)
+          }
+        }
+    )
+
+    logger.info(`Updated service branding for ${id}`)
+    req.flash('info', `Service ${id} branding successfully replaced`)
+    res.redirect(`/services/${id}`)
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function linkAccounts(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const serviceId = req.params.id
+    const context: {
+      serviceId: string;
+      messages: object;
+      recovered?: object;
+      csrf: string;
+    } = {
+      serviceId,
+      messages: req.flash('error'),
+      csrf: req.csrfToken()
     }
-  )
 
-  logger.info(`Updated service branding for ${id}`)
-  req.flash('info', `Service ${id} branding successfully replaced`)
-  res.redirect(`/services/${id}`)
+    if (req.session.recovered) {
+      context.recovered = {...req.session.recovered}
+      delete req.session.recovered
+    }
+    res.render('services/link_accounts', context)
+  } catch (error) {
+    next(error)
+  }
 }
 
-const linkAccounts = async function linkAccounts(req: Request, res: Response): Promise<void> {
-  const serviceId = req.params.id
-  const context: {
-    serviceId: string;
-    messages: object;
-    recovered?: object;
-    csrf: string;
-  } = {
-    serviceId,
-    messages: req.flash('error'),
-    csrf: req.csrfToken()
-  }
-
-  if (req.session.recovered) {
-    context.recovered = {...req.session.recovered}
-    delete req.session.recovered
-  }
-  res.render('services/link_accounts', context)
-}
-
-const updateLinkAccounts = async function updateLinkAccounts(
+export async function updateLinkAccounts(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const serviceId = req.params.id
+  try {
+    const serviceId = req.params.id
 
-  const gatewayAccountRequest = new GatewayAccountRequest(req.body)
-  await AdminUsers.services.update(serviceId, {
-    gateway_account_ids: [gatewayAccountRequest.id.toString()]
-  })
+    const gatewayAccountRequest = new GatewayAccountRequest(req.body)
+    await AdminUsers.services.update(serviceId, {
+      gateway_account_ids: [gatewayAccountRequest.id.toString()]
+    })
 
-  logger.info(`Service ${serviceId} added gateway account ${gatewayAccountRequest.id}`)
-  req.flash('info', `Gateway Account ${gatewayAccountRequest.id} linked`)
-  res.redirect(`/services/${serviceId}`)
+    logger.info(`Service ${serviceId} added gateway account ${gatewayAccountRequest.id}`)
+    req.flash('info', `Gateway Account ${gatewayAccountRequest.id} linked`)
+    res.redirect(`/services/${serviceId}`)
+  }  catch (error) {
+    next(error)
+  }
 }
 
-const search = async function search(req: Request, res: Response): Promise<void> {
+export async function search(req: Request, res: Response): Promise<void> {
   res.render('services/search', {csrf: req.csrfToken()})
 }
 
-const searchRequest = async function searchRequest(req: Request, res: Response): Promise<void> {
-  const isAdminusersUuid = /^[0-9a-f]{8}[0-9a-f]{4}[1-5][0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/
-  const filtered = !!req.body.options
-  const term = req.body.term.trim()
-  if (term !== '') {
-    if (isAdminusersUuid.test(term)) {
-      res.redirect(`/services/${term}`)
+export async function searchRequest(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const isAdminusersUuid = /^[0-9a-f]{8}[0-9a-f]{4}[1-5][0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/
+    const filtered = !!req.body.options
+    const term = req.body.term.trim()
+    if (term !== '') {
+      if (isAdminusersUuid.test(term)) {
+        res.redirect(`/services/${term}`)
+      } else {
+        const data = await AdminUsers.services.search({
+          service_name: term,
+          service_merchant_name: term
+        })
+        const nameResults = data.name_results.map((serv: Service) => Object.assign(serv, {matched: 'name'}))
+        let merchantResults = data.merchant_results.map((serv: Service) => Object.assign(serv, {matched: 'merchant'}))
+
+        // remove results from merchantResults if we have already found the service in nameResults
+        const servIds = new Set(nameResults.map((serv: Service) => serv.id))
+        merchantResults = merchantResults.filter((serv: Service) => !servIds.has(serv.id))
+        const results = filtered
+            ? [...nameResults.filter((serv: Service) => serv.current_go_live_stage === 'LIVE'), ...merchantResults.filter((serv: Service) => serv.current_go_live_stage === 'LIVE')]
+            : [...nameResults, ...merchantResults]
+
+        res.render('services/search_results', {
+          term,
+          filtered,
+          results,
+          total: results.length.toLocaleString(),
+          csrf: req.csrfToken()
+        })
+      }
     } else {
-      const data = await AdminUsers.services.search({
-        service_name: term,
-        service_merchant_name: term
-      })
-      const nameResults = data.name_results.map((serv: Service) => Object.assign(serv, {matched: 'name'}))
-      let merchantResults = data.merchant_results.map((serv: Service) => Object.assign(serv, {matched: 'merchant'}))
-
-      // remove results from merchantResults if we have already found the service in nameResults
-      const servIds = new Set(nameResults.map((serv: Service) => serv.id))
-      merchantResults = merchantResults.filter((serv: Service) => !servIds.has(serv.id))
-      const results = filtered
-        ? [...nameResults.filter((serv: Service) => serv.current_go_live_stage === 'LIVE'), ...merchantResults.filter((serv: Service) => serv.current_go_live_stage === 'LIVE')]
-        : [...nameResults, ...merchantResults]
-
-      res.render('services/search_results', {
-        term,
-        filtered,
-        results,
-        total: results.length.toLocaleString(),
-        csrf: req.csrfToken()
-      })
+      res.render('services/search', {csrf: req.csrfToken(), error: 'Please enter a search term'})
     }
-  } else {
-    res.render('services/search', {csrf: req.csrfToken(), error: 'Please enter a search term'})
+  } catch (error) {
+    next(error)
   }
 }
 
-const toggleTerminalStateRedirectFlag = async function toggleTerminalStateRedirectFlag(
+export async function toggleTerminalStateRedirectFlag(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const serviceId = req.params.id
+  try {
+    const serviceId = req.params.id
 
-  const service = await AdminUsers.services.retrieve(serviceId);
-  const enable = !service.redirect_to_service_immediately_on_terminal_state;
-  await AdminUsers.services.update(serviceId, {
-    redirect_to_service_immediately_on_terminal_state: enable
-  })
-  logger.info(`Toggled redirect to service on terminal state flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
+    const service = await AdminUsers.services.retrieve(serviceId);
+    const enable = !service.redirect_to_service_immediately_on_terminal_state;
+    await AdminUsers.services.update(serviceId, {
+      redirect_to_service_immediately_on_terminal_state: enable
+    })
+    logger.info(`Toggled redirect to service on terminal state flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
 
-  req.flash('info', `Redirect to service on terminal state ${enable ? 'enabled' : 'disabled'}`)
-  res.redirect(`/services/${serviceId}`)
+    req.flash('info', `Redirect to service on terminal state ${enable ? 'enabled' : 'disabled'}`)
+    res.redirect(`/services/${serviceId}`)
+  } catch (error) {
+    next(error)
+  }
 }
 
-const toggleExperimentalFeaturesEnabledFlag = async function toggleExperimentalFeaturesEnabledFlag(
+export async function toggleExperimentalFeaturesEnabledFlag(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const serviceId = req.params.id
+  try {
+    const serviceId = req.params.id
 
-  const service = await AdminUsers.services.retrieve(serviceId);
-  const enable = !service.experimental_features_enabled
-  await AdminUsers.services.update(serviceId, {
-    experimental_features_enabled: enable
-  })
-  logger.info(`Toggled experimental features enabled flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
+    const service = await AdminUsers.services.retrieve(serviceId);
+    const enable = !service.experimental_features_enabled
+    await AdminUsers.services.update(serviceId, {
+      experimental_features_enabled: enable
+    })
+    logger.info(`Toggled experimental features enabled flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
 
-  req.flash('info', `Experimental features ${ enable? 'enabled' : 'disabled'}`)
-  res.redirect(`/services/${serviceId}`)
+    req.flash('info', `Experimental features ${enable ? 'enabled' : 'disabled'}`)
+    res.redirect(`/services/${serviceId}`)
+  } catch (error) {
+    next(error)
+  }
 }
 
-const toggleAgentInitiatedMotoEnabledFlag = async function toggleAgentInitiatedMotoEnabledFlag(
+export async function toggleAgentInitiatedMotoEnabledFlag(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const serviceId = req.params.id
+  try {
+    const serviceId = req.params.id
 
-  const service = await AdminUsers.services.retrieve(serviceId);
-  const enable = !service.agent_initiated_moto_enabled
-  await AdminUsers.services.update(serviceId, {
-    agent_initiated_moto_enabled: enable
-  })
-  logger.info(`Toggled agent-initiated MOTO enabled flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
+    const service = await AdminUsers.services.retrieve(serviceId);
+    const enable = !service.agent_initiated_moto_enabled
+    await AdminUsers.services.update(serviceId, {
+      agent_initiated_moto_enabled: enable
+    })
+    logger.info(`Toggled agent-initiated MOTO enabled flag to ${enable} for service ${serviceId}`, {externalId: serviceId})
 
-  req.flash('info', `Agent-initiated MOTO ${ enable? 'enabled' : 'disabled'}`)
-  res.redirect(`/services/${serviceId}`)
+    req.flash('info', `Agent-initiated MOTO ${enable ? 'enabled' : 'disabled'}`)
+    res.redirect(`/services/${serviceId}`)
+  } catch (error) {
+    next(error)
+  }
 }
 
 interface RecoverContext {
@@ -253,36 +304,42 @@ interface RecoverContext {
   errorMap?: object[];
 }
 
-const updateOrganisationForm = async function updateOrganisationForm(
+export async function updateOrganisationForm(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const service = await AdminUsers.services.retrieve(req.params.id)
-  const context: RecoverContext = {service, csrf: req.csrfToken()}
-  const {recovered} = req.session
+  try {
+    const service = await AdminUsers.services.retrieve(req.params.id)
+    const context: RecoverContext = {service, csrf: req.csrfToken()}
+    const {recovered} = req.session
 
-  if (recovered) {
-    context.formValues = recovered.formValues
+    if (recovered) {
+      context.formValues = recovered.formValues
 
-    if (recovered.errors) {
-      context.errors = recovered.errors
-      context.errorMap = recovered.errors.reduce((aggregate: {
-        [key: string]: string;
-      }, error: ClientFormError) => {
-        // eslint-disable-next-line no-param-reassign
-        aggregate[error.id] = error.message
-        return aggregate
-      }, {})
+      if (recovered.errors) {
+        context.errors = recovered.errors
+        context.errorMap = recovered.errors.reduce((aggregate: {
+          [key: string]: string;
+        }, error: ClientFormError) => {
+          // eslint-disable-next-line no-param-reassign
+          aggregate[error.id] = error.message
+          return aggregate
+        }, {})
+      }
+      delete req.session.recovered
     }
-    delete req.session.recovered
-  }
 
-  res.render('services/services.update_organisation.njk', context)
+    res.render('services/services.update_organisation.njk', context)
+  } catch (error) {
+    next(error)
+  }
 }
 
-const updateOrganisation = async function updateOrganisation(
+export async function updateOrganisation(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
   const {id} = req.params
 
@@ -302,56 +359,43 @@ const updateOrganisation = async function updateOrganisation(
       res.redirect(`/services/${id}/organisation`)
       return
     }
+    next(error)
   }
 }
 
-const toggleArchiveService = async function toggleArchiveService(
+export async function toggleArchiveService(
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> {
-  const serviceId = req.params.id
+  try {
+    const serviceId = req.params.id
 
-  const service = await AdminUsers.services.retrieve(serviceId);
-  const archive = !service.archived
+    const service = await AdminUsers.services.retrieve(serviceId);
+    const archive = !service.archived
 
-  if (archive) {
-    const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
+    if (archive) {
+      const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
 
-    serviceGatewayAccounts.map(async account => {
-      const tokensResponse = await PublicAuth.tokens.list({gateway_account_id: account.gateway_account_id})
+      serviceGatewayAccounts.map(async account => {
+        const tokensResponse = await PublicAuth.tokens.list({gateway_account_id: account.gateway_account_id})
 
-      tokensResponse.tokens.map(async token => {
-        await PublicAuth.tokens.delete({gateway_account_id: account.gateway_account_id, token_link: token.token_link})
-        logger.info(`Deleted API Token with token_link ${token.token_link} for Gateway Account ${account.gateway_account_id}`)
+        tokensResponse.tokens.map(async token => {
+          await PublicAuth.tokens.delete({gateway_account_id: account.gateway_account_id, token_link: token.token_link})
+          logger.info(`Deleted API Token with token_link ${token.token_link} for Gateway Account ${account.gateway_account_id}`)
+        })
       })
+    }
+
+    await AdminUsers.services.update(serviceId, {
+      archived: archive
     })
+    logger.info(`Toggled archive status to ${archive} for service ${serviceId}`, {externalId: serviceId})
+
+    req.flash('info', `Service ${archive ? 'archived' : 'un-archived'}`)
+    res.redirect(`/services/${serviceId}`)
+  } catch (error) {
+    next(error)
   }
-
-  await AdminUsers.services.update(serviceId, {
-    archived: archive
-  })
-  logger.info(`Toggled archive status to ${archive} for service ${serviceId}`, {externalId: serviceId})
-
-  req.flash('info', `Service ${archive ? 'archived' : 'un-archived'}`)
-  res.redirect(`/services/${serviceId}`)
-}
-
-export default {
-  overview: wrapAsyncErrorHandler(overview),
-  listCsv: wrapAsyncErrorHandler(listCsv),
-  performancePlatformCsv: wrapAsyncErrorHandler(performancePlatformCsv),
-  detail: wrapAsyncErrorHandler(detail),
-  branding: wrapAsyncErrorHandler(branding),
-  updateBranding: wrapAsyncErrorHandler(updateBranding),
-  linkAccounts: wrapAsyncErrorHandler(linkAccounts),
-  updateLinkAccounts: wrapAsyncErrorHandler(updateLinkAccounts),
-  search: wrapAsyncErrorHandler(search),
-  searchRequest: wrapAsyncErrorHandler(searchRequest),
-  toggleTerminalStateRedirectFlag: wrapAsyncErrorHandler(toggleTerminalStateRedirectFlag),
-  toggleExperimentalFeaturesEnabledFlag: wrapAsyncErrorHandler(toggleExperimentalFeaturesEnabledFlag),
-  toggleAgentInitiatedMotoEnabled: wrapAsyncErrorHandler(toggleAgentInitiatedMotoEnabledFlag),
-  updateOrganisationForm: wrapAsyncErrorHandler(updateOrganisationForm),
-  updateOrganisation: wrapAsyncErrorHandler(updateOrganisation),
-  toggleArchiveService: wrapAsyncErrorHandler(toggleArchiveService)
 }
 


### PR DESCRIPTION
- Try/catch in controller methods rather then using the wrapAsyncErrorHandlers method in the exports. This should make code navigation easier.
- Use the ES6 `export function` delcaration. This should mean fewer clicks in an IDE when navigating to/from usages.

## Review notes

Hiding whitespace changes will make this a lot easier to review.