### PR TITLE
PP-11212 Rename Stripe files and routes

### DIFF
--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -1,10 +1,10 @@
 import {NextFunction, Request, Response} from 'express'
 import {AdminUsers, Connector} from '../../../../lib/pay-request/client'
-import AccountDetails from '../../stripe/basic/basicAccountDetails.model'
-import {setupProductionStripeAccount} from '../../stripe/basic/account'
+import AccountDetails from '../../stripe/accountDetails.model'
+import {setupProductionStripeAccount} from '../../stripe/account'
 import logger from "../../../../lib/logger";
 
-import stripeTestAccount from '../../stripe/basic/test-account.http'
+import stripeTestAccount from '../../stripe/test-account.http'
 
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
   const account = await Connector.accounts.retrieve(req.params.id)

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -119,14 +119,14 @@
 
     {{ govukButton({
       text: "Setup live Stripe account",
-      href: "/stripe/basic/create?service=" + service.external_id
+      href: "/stripe/create?service=" + service.external_id
       })
     }}
     <h2 class="govuk-heading-s">Test account</h2>
     {{ govukButton({
       text: "Setup test Stripe account",
       classes: "govuk-button--secondary",
-      href: "/stripe/basic/create-test-account?service=" + service.external_id
+      href: "/stripe/create-test-account?service=" + service.external_id
       })
     }}
 

--- a/src/web/modules/stripe/account.ts
+++ b/src/web/modules/stripe/account.ts
@@ -1,10 +1,10 @@
 import Stripe from "stripe";
-import {AdminUsers} from '../../../../lib/pay-request/client'
-import AccountDetails from './basicAccountDetails.model'
-import {Service, StripeAgreement} from '../../../../lib/pay-request/services/admin_users/types'
-import {ValidationError as CustomValidationError} from '../../../../lib/errors'
-import logger from '../../../../lib/logger'
-import * as stripeClient from '../../../../lib/stripe/stripe.client'
+import {AdminUsers} from '../../../lib/pay-request/client'
+import AccountDetails from './accountDetails.model'
+import {Service, StripeAgreement} from '../../../lib/pay-request/services/admin_users/types'
+import {ValidationError as CustomValidationError} from '../../../lib/errors'
+import logger from '../../../lib/logger'
+import * as stripeClient from '../../../lib/stripe/stripe.client'
 
 const STRIPE_ACCOUNT_API_KEY: string = process.env.STRIPE_ACCOUNT_API_KEY || ''
 

--- a/src/web/modules/stripe/accountDetails.model.ts
+++ b/src/web/modules/stripe/accountDetails.model.ts
@@ -5,7 +5,7 @@ import {
   Matches
 } from 'class-validator'
 
-import Validated from '../../common/validated'
+import Validated from '../common/validated'
 
 class AccountDetails extends Validated {
   @Matches(/^[^<>'"\\]+$/, { message: 'Statement descriptor cannot contain the following < > \\ \' "' })

--- a/src/web/modules/stripe/confirm-create-test-account.njk
+++ b/src/web/modules/stripe/confirm-create-test-account.njk
@@ -28,7 +28,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" action="/stripe/basic/create-test-account">
+  <form method="POST" action="/stripe/create-test-account">
     <p class="govuk-body">You are about to create a Stripe account for the service. This will create:</p>
     <ul class="govuk-list govuk-list--number">
       <li>Stripe test connect account through the Stripe API</li>

--- a/src/web/modules/stripe/index.js
+++ b/src/web/modules/stripe/index.js
@@ -1,6 +1,6 @@
 // @TODO(sfount) improve TS export -> JS import
-const httpBasic = require('./basic/basic.http').default
-const httpBasicTest = require('./basic/test-account.http').default
+const httpBasic = require('./stripe-account.http').default
+const httpBasicTest = require('./test-account.http').default
 
 module.exports = {
   basic: httpBasic.createAccountForm,

--- a/src/web/modules/stripe/live-account.njk
+++ b/src/web/modules/stripe/live-account.njk
@@ -34,7 +34,7 @@
   })
   }}
 
-  <form method="POST" action="/stripe/basic/create">
+  <form method="POST" action="/stripe/create">
     {{ govukInput({
       label: { text: "Statement descriptor" },
       hint: { text: "Payment description to appear on user’s bank statement. Latin characters only. Contains between 5 and 22 characters, inclusive. Contains at least one letter. Does not contain any of the special characters < > \ ' \" *" },

--- a/src/web/modules/stripe/stripe-account.http.ts
+++ b/src/web/modules/stripe/stripe-account.http.ts
@@ -1,12 +1,12 @@
 import {Request, Response} from 'express'
 
-import logger from '../../../../lib/logger'
-import {AdminUsers} from '../../../../lib/pay-request/client'
-import {IOValidationError, ValidationError as CustomValidationError} from '../../../../lib/errors'
-import {wrapAsyncErrorHandler} from '../../../../lib/routes'
-import {ClientFormError, formatErrorsForTemplate} from '../../common/validationErrorFormat'
-import {Service} from '../../../../lib/pay-request/services/admin_users/types'
-import AccountDetails from './basicAccountDetails.model'
+import logger from '../../../lib/logger'
+import {AdminUsers} from '../../../lib/pay-request/client'
+import {IOValidationError, ValidationError as CustomValidationError} from '../../../lib/errors'
+import {wrapAsyncErrorHandler} from '../../../lib/routes'
+import {ClientFormError, formatErrorsForTemplate} from '../common/validationErrorFormat'
+import {Service} from '../../../lib/pay-request/services/admin_users/types'
+import AccountDetails from './accountDetails.model'
 import {setupProductionStripeAccount} from './account'
 
 import Stripe from "stripe";
@@ -66,7 +66,7 @@ const createAccountForm = async function createAccountForm(
       statementDescriptor: defaultStatementDescriptor
     }
   }
-  res.render('stripe/basic/basic', context)
+  res.render('stripe/live-account', context)
 }
 
 const submitAccountCreate = async function submitAccountCreate(
@@ -94,7 +94,7 @@ const submitAccountCreate = async function submitAccountCreate(
       formValues: req.body,
       errors
     }
-    res.redirect(`/stripe/basic/create?service=${systemLinkService}`)
+    res.redirect(`/stripe/create?service=${systemLinkService}`)
   }
 }
 

--- a/src/web/modules/stripe/test-account.http.ts
+++ b/src/web/modules/stripe/test-account.http.ts
@@ -2,16 +2,16 @@ import HTTPSProxyAgent from 'https-proxy-agent'
 import Stripe from "stripe";
 
 import {NextFunction, Request, Response} from 'express'
-import logger from '../../../../lib/logger'
-import * as config from '../../../../config'
-import {AdminUsers, Connector} from '../../../../lib/pay-request/client'
-import {ValidationError as CustomValidationError} from '../../../../lib/errors'
-import {wrapAsyncErrorHandler} from '../../../../lib/routes'
-import {PSPTestAccountStage, Service} from '../../../../lib/pay-request/services/admin_users/types'
-import GatewayAccountFormModel from "../../gateway_accounts/gatewayAccount.model";
-import {stripeTestAccountDetails} from '../model/account.model'
-import {stripeTestResponsiblePersonDetails} from '../model/person.model'
-import {CreateGatewayAccountResponse} from "../../../../lib/pay-request/services/connector/types";
+import logger from '../../../lib/logger'
+import * as config from '../../../config'
+import {AdminUsers, Connector} from '../../../lib/pay-request/client'
+import {ValidationError as CustomValidationError} from '../../../lib/errors'
+import {wrapAsyncErrorHandler} from '../../../lib/routes'
+import {PSPTestAccountStage, Service} from '../../../lib/pay-request/services/admin_users/types'
+import GatewayAccountFormModel from "../gateway_accounts/gatewayAccount.model";
+import {stripeTestAccountDetails} from './model/account.model'
+import {stripeTestResponsiblePersonDetails} from './model/person.model'
+import {CreateGatewayAccountResponse} from "../../../lib/pay-request/services/connector/types";
 
 const { StripeError } = Stripe.errors
 
@@ -43,7 +43,7 @@ const createTestAccount = async function createTestAccount(req: Request, res: Re
         stripeTestAccountRequested: service.current_psp_test_account_stage === 'REQUEST_SUBMITTED'
     }
 
-    return res.render('stripe/basic/confirm-create-test-account', context)
+    return res.render('stripe/confirm-create-test-account', context)
 }
 
 const createTestAccountConfirm = async function createTestAccountConfirm(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -70,7 +70,7 @@ const createTestAccountConfirm = async function createTestAccountConfirm(req: Re
         if (error instanceof StripeError) {
             logger.error(`Stripe Error - ${error.message}`)
             req.flash('error', `Stripe Error: ${error.message}`)
-            res.redirect(`/stripe/basic/create-test-account?service=${systemLinkService}`)
+            res.redirect(`/stripe/create-test-account?service=${systemLinkService}`)
         } else {
             next(error)
         }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -112,10 +112,10 @@ router.get('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), 
 router.post('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.getDiscrepancyReport)
 router.post('/discrepancies/resolve/:id', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.resolveDiscrepancy)
 
-router.get('/stripe/basic/create', auth.secured(PermissionLevel.VIEW_ONLY), stripe.basic)
-router.post('/stripe/basic/create', auth.secured(PermissionLevel.USER_SUPPORT), stripe.basicCreate)
-router.get('/stripe/basic/create-test-account', auth.secured(PermissionLevel.VIEW_ONLY), stripe.createTestAccount)
-router.post('/stripe/basic/create-test-account', auth.secured(PermissionLevel.USER_SUPPORT), stripe.createTestAccountConfirm)
+router.get('/stripe/create', auth.secured(PermissionLevel.VIEW_ONLY), stripe.basic)
+router.post('/stripe/create', auth.secured(PermissionLevel.USER_SUPPORT), stripe.basicCreate)
+router.get('/stripe/create-test-account', auth.secured(PermissionLevel.VIEW_ONLY), stripe.createTestAccount)
+router.post('/stripe/create-test-account', auth.secured(PermissionLevel.USER_SUPPORT), stripe.createTestAccountConfirm)
 
 // @TODO(sfount) simple to integrate into table action - should be reconsidered for POST or PATCH
 router.get('/users/search', auth.secured(PermissionLevel.VIEW_ONLY), users.searchPage)


### PR DESCRIPTION
We had the routes `/stripe/basic/` and files in a folder named "basic" for creating Stripe accounts.

This is because previously there was a "not basic" way of creating accounts where we needed to configure more account details. Since the old routes and files no longer exist, "basic" no longer makes any sense. So rename the files and routes accordingly.