### PR TITLE
PP-11212 Re-order and rename links in side nav

### DIFF
--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -29,23 +29,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
 
-          <h4 class="govuk-heading-s app-subnav__header">Statistics</h4>
-          <ul class="govuk-list app-subnav__section">
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/services">Gateway accounts</a>
-            </li>
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/platform/dashboard/live">Dashboard</a>
-            </li>
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/performance-page">Performance page</a>
-            </li>
-          </ul>
-
           <h4 class="govuk-heading-s app-subnav__header">Transactions</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/transactions">Platform transactions</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/transactions">List transactions</a>
             </li>
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/transactions/search">Find a transaction</a>
@@ -58,26 +45,6 @@
             </li>
           </ul>
 
-          <h4 class="govuk-heading-s app-subnav__header">Agreements</h4>
-          <ul class="govuk-list app-subnav__section">
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/agreements">Platform agreements</a>
-            </li>
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/agreements/search">Find an agreement</a>
-            </li>
-          </ul>
-
-          <h4 class="govuk-heading-s app-subnav__header">Services</h4>
-          <ul class="govuk-list app-subnav__section">
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services">Platform services</a>
-            </li>
-            <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services/search">Find a service</a>
-            </li>
-          </ul>
-
           <h4 class="govuk-heading-s app-subnav__header">Users</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
@@ -85,10 +52,20 @@
             </li>
           </ul>
 
+          <h4 class="govuk-heading-s app-subnav__header">Services</h4>
+          <ul class="govuk-list app-subnav__section">
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services">List services</a>
+            </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/services/search">Find a service</a>
+            </li>
+          </ul>
+
           <h4 class="govuk-heading-s app-subnav__header">Gateway accounts</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts">Card</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts">List gateway accounts</a>
             </li>
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/gateway_accounts/search">Find a gateway account</a>
@@ -98,7 +75,7 @@
           <h4 class="govuk-heading-s app-subnav__header">Payment links</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payment_links">Platform payment links</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payment_links">List payment links</a>
             </li>
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payment_links/search">Find a payment link</a>
@@ -108,7 +85,17 @@
           <h4 class="govuk-heading-s app-subnav__header">Payouts</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payouts">Platform payouts</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/payouts">List payouts</a>
+            </li>
+          </ul>
+
+          <h4 class="govuk-heading-s app-subnav__header">Agreements</h4>
+          <ul class="govuk-list app-subnav__section">
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/agreements">List agreements</a>
+            </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/agreements/search">Find an agreement</a>
             </li>
           </ul>
 
@@ -116,6 +103,19 @@
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
               <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/webhooks/search">Find a webhook</a>
+            </li>
+          </ul>
+
+          <h4 class="govuk-heading-s app-subnav__header">Statistics</h4>
+          <ul class="govuk-list app-subnav__section">
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/services">Volume by service</a>
+            </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/platform/dashboard/live">Live dashboard</a>
+            </li>
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/statistics/performance-page">Performance stats</a>
             </li>
           </ul>
 


### PR DESCRIPTION
- Re-order the sections in the side navigation to be more in order of usage.
- Rename some links to make it clearer what they're for.
- Rename "Platform services" etc. to "List services" etc.