### PR TITLE
PP-11212 Improve go-live and test account journeys

### DIFF
--- a/src/lib/liveStatus.ts
+++ b/src/lib/liveStatus.ts
@@ -1,0 +1,4 @@
+export const liveStatus = {
+    live: 'live',
+    notLive: 'not-live'
+}

--- a/src/lib/pay-request/services/admin_users/types.ts
+++ b/src/lib/pay-request/services/admin_users/types.ts
@@ -4,6 +4,7 @@ export enum GoLiveStage {
   EnteredOrganisationAddress = 'ENTERED_ORGANISATION_ADDRESS',
   ChosenPSPStripe = 'CHOSEN_PSP_STRIPE',
   TermsAgreedStripe = 'TERMS_AGREED_STRIPE',
+  TermsAgreedWorldpay = 'TERMS_AGREED_GOV_BANKING_WORLDPAY',
   Denied = 'DENIED',
   Live = 'LIVE'
 }

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,7 @@
+export const providers = {
+    sandbox: 'sandbox',
+    worldpay: 'worldpay',
+    smartpay: 'smartpay',
+    epdq: 'epdq',
+    stripe: 'stripe'
+}

--- a/src/web/modules/gateway_accounts/create.njk
+++ b/src/web/modules/gateway_accounts/create.njk
@@ -7,49 +7,20 @@
 {% extends "layout/layout.njk" %}
 
 {% block main %}
-  <h1 class="govuk-heading-m">Create new gateway account</h1>
+  {% set liveOrTest %}{% if live === 'live' %}live{% else%}test{% endif%}{% endset %}
+
+  {% if live === 'live' %}
+    <span class="govuk-caption-m">Go live</span>
+  {% else %}
+    <span class="govuk-caption-m">Add test account</span>
+  {% endif %}
+  <h1 class="govuk-heading-m">Create {{ liveOrTest }} {{ provider | capitalize }} gateway account</h1>
 
   {% if errors %}
     {{ errorSummary({ errors: errors }) }}
   {% endif %}
 
   <form method="post" action="/gateway_accounts/create/confirm">
-    <!-- @TODO(sfount) consider using standard markup vs. macros -->
-    <!-- @TODO(sfount) repopulating values in this method is very manual -->
-    {{ govukRadios({
-      classes: "govuk-radios--inline",
-      idPrefix: "live",
-      name: "live",
-      fieldset: {
-        legend: {
-          text: "Live status",
-          isPageHeading: false
-        }
-      },
-      items: [
-        { value: "live", text: "Live", checked: recovered.live and recovered.live === "live" or true },
-        { value: "not-live", text: "Not live", checked: recovered.live === "not-live" }
-      ]
-    })
-    }}
-
-    {{ govukRadios({
-      classes: "govuk-radios--inline",
-      idPrefix: "provider",
-      name: "provider",
-      fieldset: {
-        legend: {
-          text: "Card provider",
-          isPageHeading: false
-        }
-      },
-      items: [
-        { value: "card-sandbox", text: "Sandbox", checked: recovered.provider and recovered.provider === "card-sandbox" or true },
-        { value: "worldpay", text: "Worldpay", checked: recovered.provider === "worldpay" },
-        { value: "stripe", text: "Stripe", checked: recovered.provider === "stripe" }
-      ]
-    })
-    }}
 
     {% if service %}
       <div class="govuk-form-group">
@@ -77,7 +48,7 @@
       hint: { html: '<p>GOV.UK Pay standard: "${Department} ${Service} ${Provider} ${IsLive}"</p><p>Blue Badge standard: "${Service} Blue Badge admin Stripe LIVE"</p>' },
       id: "description",
       name: "description",
-      value: recovered.description,
+      value: description or recovered.description,
       errorMessage: errorMap.description and { text: errorMap.description },
       autocomplete: "off"
     }) }}
@@ -85,16 +56,12 @@
     {% if linkedCredentials %}
     <div class="govuk-form-group">
       <label class="govuk-label">Stripe credentials</label>
-      <div class="govuk-hint">
-        This is only required for Stripe accounts
-      </div>
       <input readonly class="govuk-input" id="credentials" name="credentials" type="text" value="{{ linkedCredentials }}" autocomplete="off">
       <input hidden id="systemLinkedCredentials" name="systemLinkedCredentials" value="{{ linkedCredentials }}">
     </div>
-    {% else %}
+    {% elif provider === "stripe" %}
       {{govukInput({
         label: { text: "Stripe credentials" },
-        hint: { text: "This is only required for Stripe accounts" },
         id: "credentials",
         name: "credentials",
         value: recovered.credentials,
@@ -171,6 +138,8 @@
       })
       }}
 
+    <input type="hidden" name="live" value="{{ live or recovered.live }}">
+    <input type="hidden" name="provider" value="{{ provider or recovered.provider }}">
     <input type="hidden" name="_csrf" value="{{ csrf }}">
   </form>
 {% endblock %}

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -66,12 +66,6 @@
         </dd>
       </div>
       <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Payment method</span></dt>
-          <dd class="govuk-summary-list__value">
-              {% if account.payment_method %} {{ account.payment_method }}  {% else %} CARD {% endif %}
-          </dd>
-      </div>
-      <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Service</span></dt>
         <dd class="govuk-summary-list__value">{{ account.service_name }}</dd>
       </div>

--- a/src/web/modules/gateway_accounts/gateway_accounts.exceptions.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.exceptions.ts
@@ -13,7 +13,9 @@ import { formatErrorsForTemplate } from '../common/validationErrorFormat'
 const buildPreservedQuery = function buildPreservedQuery(body: { [key: string]: string }): string {
   const supported: { [key: string]: string } = {
     systemLinkedService: 'service',
-    systemLinkedCredentials: 'credentials'
+    systemLinkedCredentials: 'credentials',
+    provider: 'provider',
+    live: 'live'
   }
 
   const queryElements: string[] = []

--- a/src/web/modules/gateway_accounts/gateway_accounts.spec.js
+++ b/src/web/modules/gateway_accounts/gateway_accounts.spec.js
@@ -75,7 +75,7 @@ describe('Gateway Accounts', () => {
       expect(() => {
         const details = _.cloneDeep(validGatewayAccountDetails)
         details.live = 'live'
-        details.provider = 'card-sandbox'
+        details.provider = 'sandbox'
 
         // eslint-disable-next-line no-new
         new GatewayAccount(details)

--- a/src/web/modules/services/AddTestAccountForm.ts
+++ b/src/web/modules/services/AddTestAccountForm.ts
@@ -1,0 +1,15 @@
+import {IsBoolean, IsEmail, IsNotEmpty, IsString} from 'class-validator'
+
+import Validated from '../common/validated'
+
+export default class AddTestAccountFormRequest extends Validated {
+  @IsNotEmpty()
+  @IsString()
+  public provider: string;
+
+  public constructor(formValues: {[key: string]: string}) {
+    super()
+    this.provider = formValues.provider
+    this.validate()
+  }
+}

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -108,46 +108,29 @@
   </div>
 
   <div>
-    <h1 class="govuk-heading-m">Stripe payment provider</h1>
-
-    <h2 class="govuk-heading-s">Going live</h2>
-    <p class="govuk-body">This will guide you through:</p>
-    <ul class="govuk-list govuk-list--number">
-      <li>Creating new Stripe account through the Stripe API</li>
-      <li>Creating a GOV.UK Pay gateway account, with the correct Stripe credentials</li>
-    </ul>
+    <h2 class="govuk-heading-m">Going live</h2>
+    <p class="govuk-body">Make this service live in response to receiving a go-live request Zendesk ticket.</p>
 
     {{ govukButton({
-      text: "Setup live Stripe account",
-      href: "/stripe/create?service=" + service.external_id
+      text: "Go live",
+      href: "/services/" + serviceId + "/go_live"
       })
     }}
-    <h2 class="govuk-heading-s">Test account</h2>
+  </div>
+
+  <div>
+    <h2 class="govuk-heading-m">Test account</h2>
+    <p class="govuk-body">Add a test account to this service.</p>
+
     {{ govukButton({
-      text: "Setup test Stripe account",
+      text: "Add test account",
       classes: "govuk-button--secondary",
-      href: "/stripe/create-test-account?service=" + service.external_id
+      href: "/services/" + serviceId + "/test_account"
       })
     }}
 
-  </div>
-
   <div>
-    <h1 class="govuk-heading-m">Going live - existing payment provider</h1>
-    <p class="govuk-body">This will guide you through:</p>
-    <ul class="govuk-list govuk-list--number">
-      <li>Creating a GOV.UK Pay gateway account</li>
-    </ul>
-
-  {{ govukButton({
-      text: "Setup gateway account",
-      href: "/gateway_accounts/create?service=" + service.external_id
-      })
-      }}
-  </div>
-
-  <div>
-    <h1 class="govuk-heading-m">Service actions</h1>
+    <h2 class="govuk-heading-m">Service actions</h2>
     {{ govukButton({
       text: "Edit custom branding",
       href: "/services/" + serviceId + "/branding"
@@ -162,7 +145,7 @@
 
   {% if service.redirect_to_service_immediately_on_terminal_state %}
   <div>
-    <h1 class="govuk-heading-s">Redirect to service on terminal state is enabled</h1>
+    <h2 class="govuk-heading-s">Redirect to service on terminal state is enabled</h2>
     <p class="govuk-body">Reference the <a <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/use_your_own_error_pages/#use-your-own-payment-failure-pages">use your own error pages</a> documentation for more details.</p>
     {{ govukButton({
       text: "Disable redirect to service on terminal state",
@@ -173,7 +156,7 @@
   </div>
   {% else %}
   <div>
-    <h1 class="govuk-heading-s">Enable redirect to service on terminal state</h1>
+    <h2 class="govuk-heading-s">Enable redirect to service on terminal state</h2>
     <p class="govuk-body">Enabling this flag for a service will change the payment flow across all gateway accounts, this should never be done without consulting the service.</p>
     <p class="govuk-body">Reference the <a <a class="govuk-link" href="https://docs.payments.service.gov.uk/optional_features/use_your_own_error_pages/#use-your-own-payment-failure-pages">use your own error pages</a> documentation for more details.</p>
     {{ govukButton({
@@ -187,7 +170,7 @@
 
   {% if service.agent_initiated_moto_enabled%}
   <div>
-    <h1 class="govuk-heading-s">Agent-initiated MOTO payments are enabled</h1>
+    <h2 class="govuk-heading-s">Agent-initiated MOTO payments are enabled</h2>
     <p class="govuk-body">Enabling this flag for a service shows a ‘Take a telephone payment’ link on the admin tool dashboard if there is at least one agent-initiated MOTO product for the linked gateway account.</p>
     <p class="govuk-body">It also allows administrators to assign users to the ‘View and take telephone payments’ and ‘View, refund and take telephone payments’ roles.</p>
     <p class="govuk-body">Linked gateway accounts must have MOTO payments enabled or payment creation will fail.</p>
@@ -199,7 +182,7 @@
   </div>
   {% else %}
   <div>
-    <h1 class="govuk-heading-s">Enable agent-initiated MOTO payments</h1>
+    <h2 class="govuk-heading-s">Enable agent-initiated MOTO payments</h2>
     <p class="govuk-body">Enabling this flag for a service shows a ‘Take a telephone payment’ link on the admin tool dashboard if there is at least one agent-initiated MOTO product for the linked gateway account.</p>
     <p class="govuk-body">It also allows administrators to assign users to the ‘View and take telephone payments’ and ‘View, refund and take telephone payments’ roles.</p>
     <p class="govuk-body">Linked gateway accounts must have MOTO payments enabled or payment creation will fail.</p>
@@ -213,7 +196,7 @@
 
   {% if service.experimental_features_enabled %}
   <div>
-    <h1 class="govuk-heading-s">Experimental features are enabled</h1>
+    <h2 class="govuk-heading-s">Experimental features are enabled</h2>
     <p class="govuk-body">Enabling this flag for a service will opt the service into any features checking for this flag to be set on the service.</p>
     {{ govukButton({
       text: "Disable experimental features",
@@ -223,7 +206,7 @@
   </div>
   {% else %}
   <div>
-    <h1 class="govuk-heading-s">Enable experimental features</h1>
+    <h2 class="govuk-heading-s">Enable experimental features</h2>
     <p class="govuk-body">Enabling this flag for a service will opt the service into any features checking for this flag to be set on the service.</p>
     <p class="govuk-body">This flag should only be enabled while the service is testing functionality that will not be made available to all users/ services initially.</p>
     {{ govukButton({
@@ -237,7 +220,7 @@
   <div>
     {% set serviceActionName = "Un-archive this service" if service.archived else "Archive this service" %}
 
-    <h1 class="govuk-heading-s">{{ serviceActionName }}</h1>
+    <h2 class="govuk-heading-s">{{ serviceActionName }}</h2>
 
     {% if service.archived %}
       <p class="govuk-body">Unarchiving service impacts internal team reports only</p>

--- a/src/web/modules/services/go_live.njk
+++ b/src/web/modules/services/go_live.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+    <div class="govuk-body">
+        <a href="/services/{{ serviceId }}" class="govuk-back-link">Back to service ({{ serviceId }})</a>
+    </div>
+
+    <span class="govuk-caption-m">Go live</span>
+    <h1 class="govuk-heading-m">Confirm provider</h1>
+
+    <p class="govuk-body">Check that the correct payment service provider has been chosen for the organisation before continuing.</p>
+
+    {{ govukTable({
+        firstCellIsHeader: true,
+        rows: [
+            [ { text: 'Organisation' }, { text: organisation } ],
+            [ { text: 'Service name' }, { text: serviceName } ],
+            [ { text: 'Chosen PSP' }, { text: provider | capitalize } ]
+        ]
+    })
+    }}
+
+    <div class="govuk-button-group">
+        {% if provider === 'stripe' %}
+            {{ govukButton({
+                text: "Continue",
+                href: "/stripe/create?service=" + serviceId
+            }) }}
+        {% else %}
+            {{ govukButton({
+                text: "Continue",
+                href: "/gateway_accounts/create?service=" + serviceId + "&live=live&provider=worldpay"
+            }) }}
+        {% endif %}
+        <a class="govuk-link" href="/services/{{ serviceId }}">Cancel</a>
+    </div>
+{% endblock %}

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -8,6 +8,8 @@ import {
   performancePlatformCsv,
   search,
   searchRequest,
+  addTestAccount,
+  submitTestAccountProvider,
   toggleAgentInitiatedMotoEnabledFlag,
   toggleArchiveService,
   toggleExperimentalFeaturesEnabledFlag,
@@ -15,7 +17,8 @@ import {
   updateBranding,
   updateLinkAccounts,
   updateOrganisation,
-  updateOrganisationForm
+  updateOrganisationForm,
+  goLive
 } from './services.http'
 
 export default {
@@ -40,5 +43,8 @@ export default {
   toggleAgentInitiatedMotoEnabled: toggleAgentInitiatedMotoEnabledFlag,
   updateOrganisationForm: updateOrganisationForm,
   updateOrganisation: updateOrganisation,
-  toggleArchiveService: toggleArchiveService
+  toggleArchiveService: toggleArchiveService,
+  goLive: goLive,
+  addTestAccount: addTestAccount,
+  submitTestAccountProvider: submitTestAccountProvider
 }

--- a/src/web/modules/services/test_account.njk
+++ b/src/web/modules/services/test_account.njk
@@ -1,0 +1,44 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/errorSummary.njk" import errorSummary %}
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+    <div class="govuk-body">
+        <a href="/services/{{ serviceId }}" class="govuk-back-link">Back to service ({{ serviceId }})</a>
+    </div>
+
+    <span class="govuk-caption-m">Add test account</span>
+    <h1 class="govuk-heading-m">Which type of test account do you want to add?</h1>
+
+    {% if errors %}
+        {{ errorSummary({ errors: errors }) }}
+    {% endif %}
+
+    <form method="post" action="/services/{{ serviceId }}/test_account">
+        {{ govukRadios({
+            name: "provider",
+            items: [
+                {
+                    value: "stripe",
+                    text: "Stripe"
+                },
+                {
+                    value: "worldpay",
+                    text: "Worldpay"
+                },
+                {
+                    value: "sandbox",
+                    text: "Sandbox"
+                }
+            ]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+        <input type="hidden" name="_csrf" value="{{ csrf }}">
+    </form>
+{% endblock %}

--- a/src/web/modules/stripe/confirm-create-test-account.njk
+++ b/src/web/modules/stripe/confirm-create-test-account.njk
@@ -8,7 +8,8 @@
     <a href="/services/{{ systemLinkService }}" class="govuk-back-link">Back to service ({{ systemLinkService }})</a>
   </div>
 
-  <h1 class="govuk-heading-m">Create test stripe account</h1>
+  <span class="govuk-caption-m">Add test account</span>
+  <h1 class="govuk-heading-m">Create test Stripe account</h1>
 
   {{ govukTable({
     firstCellIsHeader: true,
@@ -23,7 +24,7 @@
 
   {% if not stripeTestAccountRequested %}
     {{ govukWarningText({
-      text: "This service has not requested a Stripe test account using the self service tool",
+      text: "This service has not requested a Stripe test account using the admin tool",
       iconFallbackTest: "Warning"
     }) }}
   {% endif %}
@@ -31,14 +32,14 @@
   <form method="POST" action="/stripe/create-test-account">
     <p class="govuk-body">You are about to create a Stripe account for the service. This will create:</p>
     <ul class="govuk-list govuk-list--number">
-      <li>Stripe test connect account through the Stripe API</li>
+      <li>Stripe test Connect account through the Stripe API</li>
       <li>GOV.UK Pay test gateway account setting the provider to Stripe. This will be available for service immediately on the admin tool "My services" page</li>
     </ul>
 
     <input hidden="hidden" name="systemLinkService" id="systemLinkService" value="{{ systemLinkService }}">
     <div class="govuk-form-group">
       {{ govukButton({
-		    text: "Create test stripe account"
+		    text: "Create test Stripe account"
         })
       }}
     </div>

--- a/src/web/modules/stripe/live-account.njk
+++ b/src/web/modules/stripe/live-account.njk
@@ -5,6 +5,11 @@
 {% from "common/errorSummary.njk" import errorSummary %}
 
 {% block main %}
+  <div class="govuk-body">
+    <a href="/services/{{ systemLinkService }}" class="govuk-back-link">Back to service ({{ systemLinkService }})</a>
+  </div>
+
+  <span class="govuk-caption-m">Go live</span>
   <h1 class="govuk-heading-m">Create Stripe account for service</h1>
 
   {% if errors %}

--- a/src/web/modules/stripe/stripe-account.http.ts
+++ b/src/web/modules/stripe/stripe-account.http.ts
@@ -10,6 +10,8 @@ import AccountDetails from './accountDetails.model'
 import {setupProductionStripeAccount} from './account'
 
 import Stripe from "stripe";
+import {liveStatus} from "../../../lib/liveStatus";
+import {providers} from "../../../lib/providers";
 const {StripeError} = Stripe.errors
 
 const createAccountForm = async function createAccountForm(
@@ -94,7 +96,7 @@ const submitAccountCreate = async function submitAccountCreate(
       formValues: req.body,
       errors
     }
-    res.redirect(`/stripe/create?service=${systemLinkService}`)
+    res.redirect(`/stripe/create?service=${systemLinkService}&live=${liveStatus.live}&provider=${providers.stripe}`)
   }
 }
 

--- a/src/web/modules/stripe/success.njk
+++ b/src/web/modules/stripe/success.njk
@@ -29,7 +29,7 @@
 
  {{ govukButton({
     text: "Create Pay Live Gateway Account for " + service.merchant_details.name + "(" + service.name + ")",
-    href: "/gateway_accounts/create?service=" + systemLinkService + "&credentials=" + response.id
+    href: "/gateway_accounts/create?service=" + systemLinkService + "&live=live&provider=stripe" +  "&credentials=" + response.id
     })
     }}
   <br>

--- a/src/web/modules/stripe/test-account.http.ts
+++ b/src/web/modules/stripe/test-account.http.ts
@@ -12,6 +12,8 @@ import GatewayAccountFormModel from "../gateway_accounts/gatewayAccount.model";
 import {stripeTestAccountDetails} from './model/account.model'
 import {stripeTestResponsiblePersonDetails} from './model/person.model'
 import {CreateGatewayAccountResponse} from "../../../lib/pay-request/services/connector/types";
+import {liveStatus} from "../../../lib/liveStatus";
+import {providers} from "../../../lib/providers";
 
 const { StripeError } = Stripe.errors
 
@@ -70,7 +72,7 @@ const createTestAccountConfirm = async function createTestAccountConfirm(req: Re
         if (error instanceof StripeError) {
             logger.error(`Stripe Error - ${error.message}`)
             req.flash('error', `Stripe Error: ${error.message}`)
-            res.redirect(`/stripe/create-test-account?service=${systemLinkService}`)
+            res.redirect(`/stripe/create-test-account?service=${systemLinkService}&live=${liveStatus.notLive}&provider=${providers.stripe}`)
         } else {
             next(error)
         }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -107,6 +107,9 @@ router.get('/services/:id/toggle_agent_initiated_moto_enabled', auth.secured(Per
 router.get('/services/:id/toggle_archived_status', auth.secured(PermissionLevel.USER_SUPPORT), services.toggleArchiveService)
 router.get('/services/:id/organisation', auth.secured(PermissionLevel.USER_SUPPORT), services.updateOrganisationForm)
 router.post('/services/:id/organisation', auth.secured(PermissionLevel.USER_SUPPORT), services.updateOrganisation)
+router.get('/services/:id/go_live', auth.secured(PermissionLevel.USER_SUPPORT), services.goLive)
+router.get('/services/:id/test_account', auth.secured(PermissionLevel.USER_SUPPORT), services.addTestAccount)
+router.post('/services/:id/test_account', auth.secured(PermissionLevel.USER_SUPPORT), services.submitTestAccountProvider)
 
 router.get('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.search)
 router.post('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.getDiscrepancyReport)


### PR DESCRIPTION
Replace the 3 buttons on the services page to create live and test gateway accounts for Stripe/Non-Stripe with just 2 buttons:
- Go live
- Add test account

> <img width="699" alt="image" src="https://github.com/alphagov/pay-toolbox/assets/5648592/73ff8640-3172-499b-a175-9e8a0e3c45b4">

When "Go live" is clicked, determine the PSP from the go-live stage for the service. 

> <img width="757" alt="image (1)" src="https://github.com/alphagov/pay-toolbox/assets/5648592/89a9334f-80c3-4c22-9542-1668e5cb1e56">

If the service hasn't completed a go-live request, show an error.

> <img width="745" alt="Screenshot 2024-01-10 at 14 19 08" src="https://github.com/alphagov/pay-toolbox/assets/5648592/305f67a2-5a33-4876-a87a-207f73dc7fcc">

When "Add a test account" is clicked, show a new page with radio buttons to select the PSP for the test account (Stripe/Worldpay/Sandbox)

> <img width="641" alt="image (2)" src="https://github.com/alphagov/pay-toolbox/assets/5648592/f55d061c-0677-4bda-9fea-23a6175da3f3">

On the page that asks for details about the service/gateway account before creating the gateway account in Pay:

- remove the radio button for Live/Not live, as we already know the answer now
- remove the radio buttons for selecting the PSP, as we already know the answer now
- prefill the description input, but still allow this to be edited
- hide the "Stripe credentials" section if we are not adding a Stripe account.

> <img width="766" alt="image (3)" src="https://github.com/alphagov/pay-toolbox/assets/5648592/0fa40c4b-479a-4f68-8687-851665d08870">
