### PR TITLE
PP-11212 Remove payment method selection for creating gateway account

### DIFF
--- a/src/web/modules/gateway_accounts/confirm.njk
+++ b/src/web/modules/gateway_accounts/confirm.njk
@@ -9,7 +9,6 @@
   {{ govukTable({
     firstCellIsHeader: true,
     rows: [
-    [ { text: 'Payment method' }, { text: request.paymentMethod | capitalize } ],
     [ { text: 'Account type' }, { text: request.provider | capitalize } ],
     [ { text: 'Service name' }, { text: request.serviceName } ],
     [ { text: 'Description' }, { text: request.description } ],
@@ -22,7 +21,6 @@
   }}
 
   <form method="post" action="/gateway_accounts/create">
-    <input type="hidden" name="paymentMethod" value="{{ request.paymentMethod }}">
     <input type="hidden" name="provider" value="{{ request.provider }}">
     <input type="hidden" name="serviceName" value="{{ request.serviceName }}">
     <input type="hidden" name="description" value="{{ request.description }}">

--- a/src/web/modules/gateway_accounts/create.njk
+++ b/src/web/modules/gateway_accounts/create.njk
@@ -35,22 +35,6 @@
 
     {{ govukRadios({
       classes: "govuk-radios--inline",
-      idPrefix: "paymentMethod",
-      name: "paymentMethod",
-      fieldset: {
-        legend: {
-          text: "Payment method",
-          isPageHeading: false
-        }
-      },
-      items: [
-        { value: "card", text: "Card", checked: recovered.paymentMethod and recovered.paymentMethod === "card" or true }
-      ]
-    })
-    }}
-
-    {{ govukRadios({
-      classes: "govuk-radios--inline",
       idPrefix: "provider",
       name: "provider",
       fieldset: {

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -26,19 +26,10 @@ const cardProviders = {
   stripe: 'stripe'
 }
 
-const paymentMethod = {
-  card: 'card'
-}
-
 class GatewayAccount extends Validated {
   @IsIn(Object.values(liveStatus))
   @IsNotEmpty()
   public live: string;
-
-  @IsIn(Object.values(paymentMethod))
-  @IsString()
-  @IsNotEmpty()
-  public paymentMethod: string;
 
   @IsString()
   @IsNotEmpty({message: 'Please enter a description'})
@@ -66,11 +57,6 @@ class GatewayAccount extends Validated {
   public validate(): void {
     super.validate()
 
-    if (this.paymentMethod === paymentMethod.card
-      && !Object.values(cardProviders).includes(this.provider)) {
-      throw new ValidationError(`For Card accounts, provider must be one of ${Object.values(cardProviders)}`)
-    }
-
     if (this.live === liveStatus.live && Object.values(sandbox).includes(this.provider)) {
       throw new ValidationError('Live accounts cannot have Sandbox provider')
     }
@@ -83,7 +69,6 @@ class GatewayAccount extends Validated {
   public constructor(formValues: { [key: string]: string }) {
     super()
     this.live = formValues.live
-    this.paymentMethod = formValues.paymentMethod
     this.description = formValues.description
     this.serviceName = formValues.serviceName
     this.provider = formValues.provider

--- a/src/web/modules/gateway_accounts/gateway_accounts.spec.js
+++ b/src/web/modules/gateway_accounts/gateway_accounts.spec.js
@@ -6,7 +6,6 @@ const { ValidationError, IOValidationError } = require('./../../../lib/errors')
 
 const validGatewayAccountDetails = {
   live: 'live',
-  paymentMethod: 'card',
   description: 'Valid gateway account details',
   serviceName: 'Valid gateway account service',
   provider: 'stripe',
@@ -36,26 +35,6 @@ describe('Gateway Accounts', () => {
       expect(() => {
         const details = _.cloneDeep(validGatewayAccountDetails)
         details.live = 'not-valid'
-
-        // eslint-disable-next-line no-new
-        new GatewayAccount(details)
-      }).to.throw(IOValidationError)
-    })
-
-    it('rejects when payment method is empty', () => {
-      expect(() => {
-        const details = _.cloneDeep(validGatewayAccountDetails)
-        details.paymentMethod = ''
-
-        // eslint-disable-next-line no-new
-        new GatewayAccount(details)
-      }).to.throw(IOValidationError)
-    })
-
-    it('rejects when payment method is not allowed value', () => {
-      expect(() => {
-        const details = _.cloneDeep(validGatewayAccountDetails)
-        details.paymentMethod = 'not-allowed'
 
         // eslint-disable-next-line no-new
         new GatewayAccount(details)
@@ -92,21 +71,10 @@ describe('Gateway Accounts', () => {
       }).to.throw(Error)
     })
 
-    it('rejects when paymentMethod is direct-debit ', () => {
-      expect(() => {
-        const details = _.cloneDeep(validGatewayAccountDetails)
-        details.paymentMethod = 'direct-debit'
-
-        // eslint-disable-next-line no-new
-        new GatewayAccount(details)
-      }).to.throw(Error)
-    })
-
     it('rejects when account is live and provider is card sandbox', () => {
       expect(() => {
         const details = _.cloneDeep(validGatewayAccountDetails)
         details.live = 'live'
-        details.paymentMethod = 'card'
         details.provider = 'card-sandbox'
 
         // eslint-disable-next-line no-new

--- a/src/web/modules/stripe/test-account.http.ts
+++ b/src/web/modules/stripe/test-account.http.ts
@@ -80,7 +80,6 @@ const createTestAccountConfirm = async function createTestAccountConfirm(req: Re
 async function createTestGatewayAccount(serviceId: string, serviceName: string, stripeConnectId: string): Promise<CreateGatewayAccountResponse> {
     const account = new GatewayAccountFormModel({
         live: 'not-live',
-        paymentMethod: 'card',
         description: `Stripe test account for service ${serviceName}`,
         sector: 'Other',
         serviceName: serviceName,


### PR DESCRIPTION
This was added when we supported Direct Debit, which has now been retired. If we add another new payment method we might configure accounts in a different way - so remove radio buttons on the create gateway account page which only had one option - "Card".