### PR TITLE
PP-11212 Replace most of buttons on gateway account page

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -72,8 +72,32 @@
           {% endif %}
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><span class="govuk-caption-m">API</span></dt>
+        <dd class="govuk-summary-list__value">
+          {{ tokensCount }} API keys
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage<span class="govuk-visually-hidden"> API keys</span></a>
+        </dd>
+      </div>
     </dl>
   </div>
+</div>
+
+<div class="govuk-!-margin-bottom-8">
+  <ul class="govuk-list">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ gatewayAccountId }}">View account payments</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ gatewayAccountId }}&type=REFUND">View account refunds</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ gatewayAccountId }}/payment_links">View account payment links</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/agreements?account={{ gatewayAccountId }}">View account agreements</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/webhooks?account={{ gatewayAccountId }}">View account webhooks</a></li>
+    {% if account.payment_provider === 'stripe' %}
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/payouts?account={{ gatewayAccountId }}">View account payouts</a></li>
+    {% endif %}
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions/csv?account={{ gatewayAccountId }}">Download transaction CSV reports</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions/statistics?account={{ gatewayAccountId }}">View payment statistics</a></li>
+  </ul>
 </div>
 
 <div class="govuk-summary-card">
@@ -126,6 +150,24 @@
             {% endif %}
           </dd>
         </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Payments statement descriptor</span></dt>
+          <dd class="govuk-summary-list__value">
+            {{ stripePaymentsStatementDescriptor or '(Unable to fetch from Stripe)' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/stripe_statement_descriptor">Manage<span class="govuk-visually-hidden"> Stripe payments statement descriptor</span></a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Payouts statement descriptor</span></dt>
+          <dd class="govuk-summary-list__value">
+            {{ stripePayoutsStatementDescriptor or '(Unable to fetch from Stripe)' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/stripe_payout_descriptor">Manage<span class="govuk-visually-hidden"> Stripe payouts statement descriptor</span></a>
+          </dd>
+        </div>
       {% elif account.payment_provider === 'worldpay' %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Payment details sent to Worldpay</span></dt>
@@ -167,6 +209,9 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Switching PSP</span></dt>
         <dd class="govuk-summary-list__value">{{ 'Enabled' if account.provider_switch_enabled else 'Disabled' }}</dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/switch_psp">Manage<span class="govuk-visually-hidden"> PSP switching</span></a>
+        </dd>
       </div>
     </dl>
   </div>
@@ -312,74 +357,6 @@
     </dl>
   </div>
 </div>
-
-  <div>
-    {{ govukButton({
-    text: "Manage API keys",
-    href: "/gateway_accounts/" + gatewayAccountId + "/api_keys"
-    })
-    }}
-
-    {# @TODO(sfount) use standard enum for provider type #}
-    {% if account.payment_provider == 'stripe' %}
-      {{ govukButton({
-        text: "View Payouts",
-        href: "/payouts?account=" + gatewayAccountId
-      })
-      }}
-      {{ govukButton({
-        text: "Update statement descriptor",
-        href: "/gateway_accounts/" + gatewayAccountId + "/stripe_statement_descriptor"
-      })
-      }}
-      {{ govukButton({
-        text: "Update payout descriptor",
-        href: "/gateway_accounts/" + gatewayAccountId + "/stripe_payout_descriptor"
-      })
-      }}
-    {% endif %}
-
-    {{ govukButton({
-      text: "View payments",
-      href: "/transactions?account=" + gatewayAccountId
-    })
-    }}
-    {{ govukButton({
-      text: "View refunds",
-      href: "/transactions?account=" + gatewayAccountId + "&type=REFUND"
-    })
-    }}
-    {{ govukButton({
-      text: "View payment links",
-      href: "/gateway_accounts/" + gatewayAccountId + "/payment_links"
-    })
-    }}
-    {{ govukButton({
-      text: "View agreements",
-      href: "/agreements?account=" + gatewayAccountId
-    })
-    }}
-    {{ govukButton({
-    text: "View webhooks",
-    href: "/webhooks?account=" + gatewayAccountId
-    })
-    }}
-    {{ govukButton({
-    text: "Download transaction CSV reports",
-    href: "/transactions/csv?account=" + gatewayAccountId
-    })
-    }}
-    {{ govukButton({
-      text: "View statistics",
-      href: "/transactions/statistics?account=" + gatewayAccountId
-    })
-    }}
-    {{ govukButton({
-      text: "Switch PSP",
-      href: "/gateway_accounts/" + gatewayAccountId + "/switch_psp"
-    })
-    }}
-  </div>
 
   {% if account.disabled === true %}
   <div>

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -11,6 +11,10 @@
   <span class="govuk-caption-m">{{ service.service_name and service.service_name.en }} ({{ account.payment_provider | capitalize }})
   <h1 class="govuk-heading-m">Set up provider switching</h1>
 
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Gateway account {{serviceName}} ({{ account.gateway_account_id }})</a>
+  </div>
+
   <p class="govuk-body">You can set an account up for switching payment service provider.</p>
 
   <p class="govuk-body">This will add a new credentials record to the account and enable the switching feature flag.</p>


### PR DESCRIPTION
Replace most of the remaining buttons on the gateway account details page.

- All the green buttons that were links to related pages have been replaced with a list of hyperlinks.
- The "Manage API Keys" button has been replaced by displaying the number of API keys in the "Account details" summary list and adding a "Manage" link.
- The "Switch PSP" button has been replaced with a "Manage" link in the PSP configuration summary list.
- The Stripe statement descriptor buttons have been replaced by fetching and displaying the statement descriptors in the "Stripe configuration" summary table and adding "Manage" links.

The changes are highlighted in red on the screenshot below:

![Screenshot 2024-01-12 at 15 43 19](https://github.com/alphagov/pay-toolbox/assets/5648592/2406a04c-41d5-4185-aa23-7a81172cc817)
