### PR TITLE
PP-11860 default Apple Pay enabled for Worldpay

### DIFF
--- a/src/lib/zendesk/zendesk.client.ts
+++ b/src/lib/zendesk/zendesk.client.ts
@@ -104,6 +104,7 @@ Click this link to go to the live version of your service: ${worldpayGoLiveUrl}
 Once you’re in your account, you should confirm:
 
 * which card types you want to enable in 'Settings' (3D Secure is enabled by default)
+* Apple Pay is enabled by default. You can disable it in ‘Settings’
 * if you want to collect billing or email address, or send payment and refund confirmation emails
 * customise the payment confirmation email, including adding your service support contact details should your users need to query a payment
 * your team’s account permissions

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -79,8 +79,11 @@ class GatewayAccount extends Validated {
       payload.requires_3ds = false
     }
 
-    if (this.provider === 'stripe') {
+    if (this.provider === 'worldpay' || this.provider === 'stripe') {
       payload.allow_apple_pay = true
+    }
+
+    if (this.provider === 'stripe') {
       payload.allow_google_pay = true
       if (this.credentials) {
         payload.credentials = {

--- a/src/web/modules/gateway_accounts/gateway_accounts.spec.js
+++ b/src/web/modules/gateway_accounts/gateway_accounts.spec.js
@@ -112,6 +112,21 @@ describe('Gateway Accounts', () => {
       account.serviceId = 'service-id'
       const payload = account.formatPayload()
       expect(payload.requires_3ds).to.eql(true)
+      expect(payload.allow_apple_pay).to.eql(true)
+      expect(payload.allow_google_pay).to.not.exist
+    });
+
+    it('successfully creates model when provider is stripe and test account', function () {
+      const details = _.cloneDeep(validGatewayAccountDetails)
+      details.live = 'not-live'
+
+      const account = new GatewayAccount(details)
+      expect(account).to.be.an('object')
+      account.serviceId = 'service-id'
+      const payload = account.formatPayload()
+      expect(payload.requires_3ds).to.eql(true)
+      expect(payload.allow_apple_pay).to.eql(true)
+      expect(payload.allow_google_pay).to.eql(true)
     });
   })
 })


### PR DESCRIPTION
- Enable Apple Pay by default when creating Wordlpay accounts (both test and live).
- Update Zendesk micro to reflect the change