### PR TITLE
PP-12083 Add noopener and noreferrer to external links

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -135,7 +135,7 @@
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Connected Stripe account</span></dt>
           <dd class="govuk-summary-list__value">
-            <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ stripeDashboardUri }}">
+            <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" href="{{ stripeDashboardUri }}">
               {{ currentCredential.credentials.stripe_account_id }}
             </a>
           </dd>

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -140,7 +140,7 @@
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Provider transaction</span></th>
           <td class="govuk-table__cell payment__cell">
             {% if stripeDashboardUri %}
-              <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ stripeDashboardUri }}">{{ transaction.gateway_transaction_id }}</a>
+              <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" href="{{ stripeDashboardUri }}">{{ transaction.gateway_transaction_id }}</a>
             {% else %}
               {{ transaction.gateway_transaction_id }}
             {% endif %}


### PR DESCRIPTION
Context: CodeQL warned us that 'External links without noopener/noreferrer are a potential security risk.'

Add noopener / noreferrer attributes to the two external links.