### PR TITLE
PP-12247 Bump govuk-frontend and update header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express": "4.18.1",
         "fast-csv": "^4.3.6",
         "google-libphonenumber": "~3.2.21",
-        "govuk-frontend": "^4.7.0",
+        "govuk-frontend": "^4.8.0",
         "helmet": "^7.0.0",
         "http-errors": "^2.0.0",
         "https-proxy-agent": "5.0.1",
@@ -9623,9 +9623,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": "4.18.1",
     "fast-csv": "^4.3.6",
     "google-libphonenumber": "~3.2.21",
-    "govuk-frontend": "^4.7.0",
+    "govuk-frontend": "^4.8.0",
     "helmet": "^7.0.0",
     "http-errors": "^2.0.0",
     "https-proxy-agent": "5.0.1",

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
 <head>
@@ -11,16 +13,11 @@
 </html>
 
 <body class="govuk-template__body js-enabled">
-
-  <header class="govuk-header " role="banner" data-module="header">
-    <div class="govuk-header__container govuk-width-container">
-      <div class="govuk-header__content toolbox_header__offset">
-        <a href="/" class="govuk-header__link govuk-header__link--service-name">
-          GOV.UK Pay Toolbox
-        </a>
-      </div>
-    </div>
-  </header>
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: "Toolbox",
+    useTudorCrown: true
+  }) }}
 
   <div class="govuk-width-container">
     {% include "layout/user_banner.njk" %}


### PR DESCRIPTION
- Bump govuk-frontend so we can use the new crown.
- Update the header to use the Nunjuks macro from govuk-frontend
  - Enable the option to show the new crown