### PR TITLE
PP-12211 CodeQL: restrict files to scan and enable on push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ jobs:
       # required for CodeQL to raise security issues on the repo
       security-events: write
 
+    paths:
+      - 'src/**'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
     paths:
       - 'src/**'
+  push:
+    branches: [ "master" ]
   schedule:
     # Weekly schedule
     - cron: '43 7 * * 1'


### PR DESCRIPTION
Changes the CodeQL config file to:

- enable scans on push to `master` branch (this was overlooked previously)
- only scan files in the `/src/**` folder. Note that this is separate to the trigger for the workflow ("only run the workflow if a file in `/src/**` is changed" versus "when the workflow is run,  scan stuff in `/src/**`")

If this works OK I'll adjust the config in the other app repositories.