### PR TITLE
PP-12509 More at-a-glance payment info: follow-up fixes

### DIFF
--- a/src/web/modules/agreements/list.njk
+++ b/src/web/modules/agreements/list.njk
@@ -4,7 +4,7 @@
 
 {% set isTestData = account and not (account.type === "live") %}
 
-{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if filters.reference %}&reference={{ filters.reference }}{% endif %}{% endset %}
+{% set linkQueryParams %}{% if service %}&amp;account={{ accountId }}{% endif %}{% if filters.reference %}&amp;reference={{ filters.reference }}{% endif %}{% endset %}
 
 {% block main %}
   <span class="govuk-caption-m">
@@ -91,7 +91,7 @@
       {% if set.page <= 1 %}
         disabled
       {% else %}
-        href="/agreements?page={{ set.page - 1 }}&status={{ selectedStatus }}{{ linkQueryParams }}"
+        href="/agreements?page={{ set.page - 1 }}&amp;status={{ selectedStatus }}{{ linkQueryParams }}"
       {% endif %}
 
       class="govuk-button govuk-button--secondary">
@@ -101,7 +101,7 @@
       {% if not(set._links.next_page) %}
         disabled
       {% else %}
-        href="/agreements?page={{ set.page + 1 }}&status={{ selectedStatus }}{{ linkQueryParams }}"
+        href="/agreements?page={{ set.page + 1 }}&amp;status={{ selectedStatus }}{{ linkQueryParams }}"
       {% endif %}
 
       class="govuk-button govuk-button--secondary">

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -94,7 +94,7 @@
 <div class="govuk-!-margin-bottom-8">
   <ul class="govuk-list">
     <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ gatewayAccountId }}">View account payments</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ gatewayAccountId }}&type=REFUND">View account refunds</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="/transactions?account={{ gatewayAccountId }}&amp;type=REFUND">View account refunds</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{ gatewayAccountId }}/payment_links">View account payment links</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="/agreements?account={{ gatewayAccountId }}">View account agreements</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="/webhooks?account={{ gatewayAccountId }}">View account webhooks</a></li>

--- a/src/web/modules/ledger_payouts/list.njk
+++ b/src/web/modules/ledger_payouts/list.njk
@@ -4,7 +4,7 @@
   <strong class="govuk-tag
         {% if (status=='paidout') %} govuk-tag--green {% endif %}
         {% if (status=='failed') %} govuk-tag--orange {% endif %}
-        {% if (status=='intransit') %} govuk-tag--light-blue {% endif %}
+        {% if (status=='intransit') %} govuk-tag--blue {% endif %}
       ">
     <span>{{ status | capitalize }}</span>
   </strong>
@@ -34,7 +34,7 @@
     {% for status in["intransit", "paidout", "failed", "all"] %}
       <a
         class="list-page-filter__item {% if selectedStatus === status %}selected{% endif %} no-decoration"
-        href="/payouts?status={{ status }}{% if service %}&account={{ accountId }}{% endif %}">
+        href="/payouts?status={{ status }}{% if service %}&amp;account={{ accountId }}{% endif %}">
         <span>{{ status | capitalize }}</span>
       </a>
     {% endfor %}
@@ -98,12 +98,12 @@
 
   <div class="toolbox-right">
     <a  {% if set.page <= 1 %} disabled
-        {% else %} href="/payouts?page={{ set.page - 1 }}&status={{ selectedStatus }}{% if service %}&account={{ accountId }}{% endif %}"
+        {% else %} href="/payouts?page={{ set.page - 1 }}&amp;status={{ selectedStatus }}{% if service %}&amp;account={{ accountId }}{% endif %}"
         {% endif %} class="govuk-button govuk-button--secondary">
       Previous
     </a>
     <a  {% if not(set._links.next_page) %} disabled
-        {% else %} href="/payouts?page={{ set.page + 1 }}&status={{ selectedStatus }}{% if service %}&account={{ accountId }}{% endif %}"
+        {% else %} href="/payouts?page={{ set.page + 1 }}&amp;status={{ selectedStatus }}{% if service %}&amp;account={{ accountId }}{% endif %}"
       {% endif %} class="govuk-button govuk-button--secondary">
       Next
     </a>

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -5,7 +5,7 @@
 
 {% set isTestData = account and not (account.type === "live") %}
 
-{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if transactionType %}&type={{ transactionType }}{% endif %}{% if filters.reference %}&reference={{ filters.reference }}{% endif %}{% if filters.email %}&email={{ filters.email }}{% endif %}{% endset %}
+{% set linkQueryParams %}{% if service %}&amp;account={{ accountId }}{% endif %}{% if transactionType %}&amp;type={{ transactionType }}{% endif %}{% if filters.reference %}&amp;reference={{ filters.reference }}{% endif %}{% if filters.email %}&amp;email={{ filters.email }}{% endif %}{% endset %}
 
 {% block main %}
   <span class="govuk-caption-m">

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -44,7 +44,9 @@
         {{ card_payment_method(transaction) }}
         </div>
         <div class="govuk-grid-column-one-half text-right">
+        {% if transaction.card_details.first_digits_card_number or transaction.card_details.last_digits_card_number %}
         {{ transaction.card_details.first_digits_card_number }}••••{{ transaction.card_details.last_digits_card_number }}
+        {% endif %}
         </div>
       </div>
     </div>

--- a/src/web/modules/webhooks/messages/overview.njk
+++ b/src/web/modules/webhooks/messages/overview.njk
@@ -72,7 +72,7 @@
     {% if webhookMessages.page <= 1 %}
       disabled
     {% else %}
-      href="/webhooks/{{webhook.external_id}}/messages?page={{ webhookMessages.page - 1 }}&status={{ selectedStatus }}"
+      href="/webhooks/{{webhook.external_id}}/messages?page={{ webhookMessages.page - 1 }}&amp;status={{ selectedStatus }}"
     {% endif %}
 
     class="govuk-button govuk-button--secondary">
@@ -82,7 +82,7 @@
     {% if webhookMessages.count < webhookMessagePageSize %}
       disabled
     {% else %}
-      href="/webhooks/{{webhook.external_id}}/messages?page={{ webhookMessages.page + 1 }}&status={{ selectedStatus }}"
+      href="/webhooks/{{webhook.external_id}}/messages?page={{ webhookMessages.page + 1 }}&amp;status={{ selectedStatus }}"
     {% endif %}
 
     class="govuk-button govuk-button--secondary">


### PR DESCRIPTION
- Do not show •••• when we have no digits at all from the card number to show but do have some card details available (this can happen if a service prefills the cardholder name but the user has not yet entered their card number)
- Consistently using blue tags (one was accidentally light blue, which is not even a colour in GOV.UK Frontend 4)
- Consistently use entities for ampersands in link URLs