### PR TITLE
PP-12549 Fix bug where & in some links encoded as &amp;amp;

### DIFF
--- a/src/web/modules/agreements/list.njk
+++ b/src/web/modules/agreements/list.njk
@@ -4,7 +4,8 @@
 
 {% set isTestData = account and not (account.type === "live") %}
 
-{% set linkQueryParams %}{% if service %}&amp;account={{ accountId }}{% endif %}{% if filters.reference %}&amp;reference={{ filters.reference }}{% endif %}{% endset %}
+{# Autoescaping will convert & to &amp; when linkQueryParams variable is used in template #}
+{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if filters.reference %}&reference={{ filters.reference }}{% endif %}{% endset %}
 
 {% block main %}
   <span class="govuk-caption-m">

--- a/src/web/modules/transactions/list.njk
+++ b/src/web/modules/transactions/list.njk
@@ -5,7 +5,8 @@
 
 {% set isTestData = account and not (account.type === "live") %}
 
-{% set linkQueryParams %}{% if service %}&amp;account={{ accountId }}{% endif %}{% if transactionType %}&amp;type={{ transactionType }}{% endif %}{% if filters.reference %}&amp;reference={{ filters.reference }}{% endif %}{% if filters.email %}&amp;email={{ filters.email }}{% endif %}{% endset %}
+{# Autoescaping will convert & to &amp; when linkQueryParams variable is used in template #}
+{% set linkQueryParams %}{% if service %}&account={{ accountId }}{% endif %}{% if transactionType %}&type={{ transactionType }}{% endif %}{% if filters.reference %}&reference={{ filters.reference }}{% endif %}{% if filters.email %}&email={{ filters.email }}{% endif %}{% endset %}
 
 {% block main %}
   <span class="govuk-caption-m">


### PR DESCRIPTION
If the value of a Nunjucks variable is assigned with a set expression and that variable is later displayed in the template, autoescaping will convert any `&` characters to `&amp;` — so the variable value should just use `&` characters.

This regression was introduced by commit e96dc1c16b79e0baa3215cfd121d8994b15f2da6.