### PR TITLE
PP-12696: Use primitive types

### DIFF
--- a/src/web/modules/payment_links/payment_links.http.ts
+++ b/src/web/modules/payment_links/payment_links.http.ts
@@ -98,7 +98,7 @@ export async function toggleRequireCaptcha(req: Request, res: Response, next: Ne
   }
 }
 
-async function fetchUsageContext(sortKey: string, filterLiveAccounts: Boolean, accountId?: string) {
+async function fetchUsageContext(sortKey: string, filterLiveAccounts: boolean, accountId?: string) {
   let serviceRequest, liveAccountsRequest
   if (accountId) {
     serviceRequest = AdminUsers.services.retrieve({gatewayAccountId: accountId})

--- a/src/web/modules/services/getFilteredServices.ts
+++ b/src/web/modules/services/getFilteredServices.ts
@@ -8,7 +8,7 @@ export interface ServiceFilters {
   archived: BooleanFilterOption;
 }
 
-function serviceAttributeMatchesFilter(filterValue: BooleanFilterOption, serviceValue: Boolean) {
+function serviceAttributeMatchesFilter(filterValue: BooleanFilterOption, serviceValue: boolean) {
   return filterValue === BooleanFilterOption.True && serviceValue ||
     filterValue === BooleanFilterOption.False && !serviceValue ||
     filterValue === BooleanFilterOption.All


### PR DESCRIPTION
According to the ITHC, we should use primitive types unless there's a good reason not to. Fair enough!