### PR TITLE
PP-12790 Add 3D Secure information to payment page

### DIFF
--- a/src/web/modules/transactions/features.macro.njk
+++ b/src/web/modules/transactions/features.macro.njk
@@ -20,4 +20,8 @@
 <span class="govuk-tag govuk-tag--grey">MOTO</span>
 {% endif %}
 
+{% if transaction.authorisation_summary and transaction.authorisation_summary.three_d_secure and transaction.authorisation_summary.three_d_secure.required %}
+<span class="govuk-tag govuk-tag--grey">3DS</span>
+{% endif %}
+
 {% endmacro %}

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -1,6 +1,7 @@
 {% from "transactions/status.macro.njk" import status %}
 {% from "transactions/features.macro.njk" import features %}
 {% from "transactions/card_payment_method.macro.njk" import card_payment_method %}
+{% from "transactions/summary_3ds.macro.njk" import summary_3ds %}
 {% from "common/json.njk" import json %}
 {% from "./../webhooks/webhookMessageStatus.macro.njk" import webhookMessageStatusTag %}
 {% extends "layout/layout.njk" %}
@@ -191,6 +192,10 @@
           Payment created before we recorded source
           {% endif %}
           </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">3D Secure</span></th>
+          <td class="govuk-table__cell payment__cell">{{ summary_3ds(transaction, events) }}</td>
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">MOTO</span></th>

--- a/src/web/modules/transactions/summary_3ds.macro.njk
+++ b/src/web/modules/transactions/summary_3ds.macro.njk
@@ -1,0 +1,23 @@
+{% macro summary_3ds(transaction, events) %}
+
+{% if transaction.authorisation_summary and transaction.authorisation_summary.three_d_secure and transaction.authorisation_summary.three_d_secure.required %}
+Required {% if transaction.authorisation_summary.three_d_secure.version %} — version {{ transaction.authorisation_summary.three_d_secure.version }}{% endif %}
+{% else %}
+Not required
+{% endif %}
+
+{% for event in events %}
+  {% if event.event_type == 'GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED' and event.data %}
+    {% if event.data.exemption3ds == 'EXEMPTION_NOT_REQUESTED' %}
+    (exemption not requested)
+    {% elif event.data.exemption3ds == 'EXEMPTION_HONOURED' %}
+    (exemption requested and honoured)
+    {% elif event.data.exemption3ds == 'EXEMPTION_REJECTION' %}
+    (exemption requested but rejected)
+    {% elif event.data.exemption3ds == 'EXEMPTION_OUT_OF_SCOPE' %}
+    (exemption requested but payment out of scope)
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
If a payment required 3D Secure, add a ‘3DS’ tag to its page.

Add a new 3D Secure row to the processing details table, stating whether the payment required 3D Secure, the 3D Secure version (if known) and any information about whether an exemption was requested and whether or not it was honoured (if available).