### PR TITLE
PP-12790 Add user journey duration to payment page

### DIFF
--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -198,6 +198,10 @@
           <td class="govuk-table__cell payment__cell">{{ summary_3ds(transaction, events) }}</td>
         </tr>
         <tr class="govuk-table__row">
+          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">User journey duration</span></th>
+          <td class="govuk-table__cell payment__cell">{{ userJourneyDurationFriendly }}</td>
+        </tr>
+        <tr class="govuk-table__row">
           <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">MOTO</span></th>
           <td class="govuk-table__cell payment__cell">{{ transaction.moto | string | capitalize }}</td>
         </tr>


### PR DESCRIPTION
Add a fairly crude calculation of how long the paying user spent on the payment pages entering their card details etc.

Example: 1 hour, 5 minutes and 17 seconds