### PR TITLE
PP-12790 User journey duration for some failed payments

### DIFF
--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -154,10 +154,13 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     let userJourneyDurationFriendly: string = 'Not available'
     const paymentStartedEvent = events.find((event: any) => event.event_type === 'PAYMENT_STARTED')
     if (paymentStartedEvent) {
-      const userApprovedForCaptureEvent = events.find((event: any) => event.event_type === 'USER_APPROVED_FOR_CAPTURE' ||
-                                                                      event.event_type === 'USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL');
-      if (userApprovedForCaptureEvent) {
-        const userJourneyDurationMillis : number = Date.parse(userApprovedForCaptureEvent.timestamp) - Date.parse(paymentStartedEvent.timestamp)
+      const endOfUserJourneyEvent = events.find((event: any) => event.event_type === 'USER_APPROVED_FOR_CAPTURE' ||
+                                                                event.event_type === 'USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL' ||
+                                                                event.event_type === 'CANCELLED_BY_USER' ||
+                                                                event.event_type === 'AUTHORISATION_REJECTED' ||
+                                                                event.event_type === 'GATEWAY_ERROR_DURING_AUTHORISATION');
+      if (endOfUserJourneyEvent) {
+        const userJourneyDurationMillis : number = Date.parse(endOfUserJourneyEvent.timestamp) - Date.parse(paymentStartedEvent.timestamp)
         const userJourneyDurationSeconds : number = Math.floor(userJourneyDurationMillis / 1000)
 
         userJourneyDurationFriendly = ''


### PR DESCRIPTION
Add how long the paying user spent on the payment pages for some failed payments (such as when the authorisation was rejected, the user cancelled the payment or there was an error during authorisation). In most of these cases the user will be shown an error page and the duration will not include how long they spent reading this page but it still gives an idea.