### PR TITLE
create button to fix failed Stripe refund

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -2,20 +2,21 @@ import _ from 'lodash'
 import Client from '../../base'
 import {mapRequestParamsToOperation} from '../../utils/request'
 import {
-  Charge,
-  GatewayAccount,
-  StripeCredentials,
-  ListCardTypesResponse,
-  ListGatewayAccountsRequest,
-  ListGatewayAccountsResponse,
-  CreateGatewayAccountRequest,
-  CreateGatewayAccountResponse,
-  GatewayStatusComparison,
-  StripeSetup,
-  UpdateGatewayAccountRequest,
-  UpdateStripeSetupRequest,
-  GatewayAccountCredentials,
-  AddGatewayAccountCredentialsRequest
+    Charge,
+    GatewayAccount,
+    StripeCredentials,
+    ListCardTypesResponse,
+    ListGatewayAccountsRequest,
+    ListGatewayAccountsResponse,
+    CreateGatewayAccountRequest,
+    CreateGatewayAccountResponse,
+    GatewayStatusComparison,
+    StripeSetup,
+    UpdateGatewayAccountRequest,
+    UpdateStripeSetupRequest,
+    GatewayAccountCredentials,
+    AddGatewayAccountCredentialsRequest,
+    AddGitHubAndZendeskCredential
 } from './types'
 import {App} from '../../shared'
 import {handleEntityNotFound} from "../../utils/error";
@@ -26,156 +27,156 @@ import { EntityNotFoundError } from '../../../errors'
  * service.
  */
 export default class Connector extends Client {
-  constructor() {
-    super(App.Connector)
-  }
-
-  charges = ((client: Connector) => ({
-    /**
-     * Fetch an in-flight payment
-     * @param id - Charge external ID
-     * @returns In-flight payment object
-     */
-    retrieve(id: string): Promise<Charge | undefined> {
-      return client._axios
-        .get(`/v1/frontend/charges/${id}`)
-        .then(response => client._unpackResponseData<Charge>(response))
-        .catch(handleEntityNotFound("Charge", id))
-    },
-
-    retrieveAPI(externalChargeId: string, accountId: string): Promise<Charge | undefined> {
-      return client._axios
-        .get(`/v1/api/accounts/${accountId}/charges/${externalChargeId}`)
-        .then(response => client._unpackResponseData<Charge>(response))
-        .catch(handleEntityNotFound("Charge", externalChargeId))
-    },
-
-    /**
-     * Get the comparison between the status in Pay and the status with the Gateway for a list of
-     * charges
-     * @param ids - Charge external IDs
-     * @returns Array of gateway comparison objects
-     */
-    getGatewayComparisons(ids: string[]): Promise<GatewayStatusComparison[] | undefined> {
-      return client._axios
-        .post('/v1/api/discrepancies/report', ids)
-        .then(response => client._unpackResponseData<GatewayStatusComparison[]>(response))
-    },
-
-    /**
-     * Attempts to cancel an authorisation with the payment gateway
-     * @param id - Charge external ID
-     * @returns Array of gateway comparison objects
-     */
-    resolveDiscrepancy(id: string): Promise<GatewayStatusComparison[] | undefined> {
-      return client._axios
-        .post('/v1/api/discrepancies/resolve', [id])
-        .then(response => client._unpackResponseData<GatewayStatusComparison[]>(response))
+    constructor() {
+        super(App.Connector)
     }
-  }))(this)
 
-  accounts = ((client: Connector) => ({
-    /**
-     * Get gateway account by gateway account ID
-     * @param id - Gateway account ID
-     * @returns Gateway account object
-     */
-    retrieve(id: string): Promise<GatewayAccount | undefined> {
-      return client._axios
-        .get(`/v1/api/accounts/${id}`)
-        .then(response => client._unpackResponseData<GatewayAccount>(response))
-        .catch(handleEntityNotFound("Account by ID", id))
-    },
+    charges = ((client: Connector) => ({
+        /**
+         * Fetch an in-flight payment
+         * @param id - Charge external ID
+         * @returns In-flight payment object
+         */
+        retrieve(id: string): Promise<Charge | undefined> {
+            return client._axios
+                .get(`/v1/frontend/charges/${id}`)
+                .then(response => client._unpackResponseData<Charge>(response))
+                .catch(handleEntityNotFound("Charge", id))
+        },
 
-    /**
-     * Get gateway account by external ID
-     * @param externalId - Gateway account external ID
-     * @returns Gateway account object
-     */
-    retrieveByExternalId(externalId: string): Promise<GatewayAccount| undefined> {
-      return client._axios
-        .get(`/v1/frontend/accounts/external-id/${externalId}`)
-        .then(response => client._unpackResponseData<GatewayAccount>(response))
-        .catch(handleEntityNotFound("Account by external ID", externalId));
-    },
+        retrieveAPI(externalChargeId: string, accountId: string): Promise<Charge | undefined> {
+            return client._axios
+                .get(`/v1/api/accounts/${accountId}/charges/${externalChargeId}`)
+                .then(response => client._unpackResponseData<Charge>(response))
+                .catch(handleEntityNotFound("Charge", externalChargeId))
+        },
 
-    /**
-     * Fetch Stripe credentials map for a given gateway account. If the gateway
-     * account doesn't have Stripe credentials this route will return not found.
-     * @param id - Gateway account ID
-     * @returns Stripe credentials for a requested gateway account
-     */
-    retrieveStripeCredentials(id: string): Promise<StripeCredentials | undefined> {
-      return client._axios
-        .get(`/v1/api/accounts/${id}/stripe-account`)
-        .then(response => client._unpackResponseData<StripeCredentials>(response))
-    },
+        /**
+         * Get the comparison between the status in Pay and the status with the Gateway for a list of
+         * charges
+         * @param ids - Charge external IDs
+         * @returns Array of gateway comparison objects
+         */
+        getGatewayComparisons(ids: string[]): Promise<GatewayStatusComparison[] | undefined> {
+            return client._axios
+                .post('/v1/api/discrepancies/report', ids)
+                .then(response => client._unpackResponseData<GatewayStatusComparison[]>(response))
+        },
 
-    /**
-     * Retrieves which Stripe Connect account setup tasks have been completed for the gateway account
-     * @param id - Gateway account ID
-     * @returns Stripe account setup object
-     */
-    retrieveStripeSetup(id: string): Promise<StripeSetup | undefined> {
-      return client._axios
-        .get(`/v1/api/accounts/${id}/stripe-setup`)
-        .then(response => client._unpackResponseData<StripeSetup>(response))
-    },
+        /**
+         * Attempts to cancel an authorisation with the payment gateway
+         * @param id - Charge external ID
+         * @returns Array of gateway comparison objects
+         */
+        resolveDiscrepancy(id: string): Promise<GatewayStatusComparison[] | undefined> {
+            return client._axios
+                .post('/v1/api/discrepancies/resolve', [id])
+                .then(response => client._unpackResponseData<GatewayStatusComparison[]>(response))
+        }
+    }))(this)
 
-    /**
-     * List all supported account types currently enabled by the specified gateway
-     * account
-     * @param id - Gateway account ID
-     * @returns List of card types supported by this gateway account
-     */
-    listCardTypes(id: string): Promise<ListCardTypesResponse | undefined> {
-      return client._axios
-        .get(`/v1/frontend/accounts/${id}/card-types`)
-        .then(response => client._unpackResponseData<ListCardTypesResponse>(response))
-    },
+    accounts = ((client: Connector) => ({
+        /**
+         * Get gateway account by gateway account ID
+         * @param id - Gateway account ID
+         * @returns Gateway account object
+         */
+        retrieve(id: string): Promise<GatewayAccount | undefined> {
+            return client._axios
+                .get(`/v1/api/accounts/${id}`)
+                .then(response => client._unpackResponseData<GatewayAccount>(response))
+                .catch(handleEntityNotFound("Account by ID", id))
+        },
 
-    /*
-     * List gateway accounts (internal API view)
-     * @param filters - optional parameters to filter account list
-     * @returns List gateway account response
-     */
-    list(filters: ListGatewayAccountsRequest = {}): Promise<ListGatewayAccountsResponse | undefined> {
-      const params = _.omitBy(filters, _.isEmpty)
-      return client._axios
-        .get('/v1/api/accounts', {params})
-        .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
-    },
+        /**
+         * Get gateway account by external ID
+         * @param externalId - Gateway account external ID
+         * @returns Gateway account object
+         */
+        retrieveByExternalId(externalId: string): Promise<GatewayAccount | undefined> {
+            return client._axios
+                .get(`/v1/frontend/accounts/external-id/${externalId}`)
+                .then(response => client._unpackResponseData<GatewayAccount>(response))
+                .catch(handleEntityNotFound("Account by external ID", externalId));
+        },
 
-    /*
-     * Get one gateway account given service ID. This is a polyfill method until service ID and live/ test are the primary index for accounts on the backend.
-     */
-    async retrieveForService(filters: ListGatewayAccountsRequest = {}): Promise<GatewayAccount | undefined> {
-      const params = _.omitBy(filters, _.isEmpty)
-      const { accounts } = await client._axios
-        .get('/v1/api/accounts', {params})
-        .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
+        /**
+         * Fetch Stripe credentials map for a given gateway account. If the gateway
+         * account doesn't have Stripe credentials this route will return not found.
+         * @param id - Gateway account ID
+         * @returns Stripe credentials for a requested gateway account
+         */
+        retrieveStripeCredentials(id: string): Promise<StripeCredentials | undefined> {
+            return client._axios
+                .get(`/v1/api/accounts/${id}/stripe-account`)
+                .then(response => client._unpackResponseData<StripeCredentials>(response))
+        },
 
-      if (accounts.length > 1) {
-        throw new Error(`Multiple accounts for service ${filters.serviceIds} ${filters.type}, this is a legacy configuration`)
-      }
+        /**
+         * Retrieves which Stripe Connect account setup tasks have been completed for the gateway account
+         * @param id - Gateway account ID
+         * @returns Stripe account setup object
+         */
+        retrieveStripeSetup(id: string): Promise<StripeSetup | undefined> {
+            return client._axios
+                .get(`/v1/api/accounts/${id}/stripe-setup`)
+                .then(response => client._unpackResponseData<StripeSetup>(response))
+        },
 
-      if (!accounts.length) {
-        throw new EntityNotFoundError('Account for service', filters.serviceIds)
-      }
+        /**
+         * List all supported account types currently enabled by the specified gateway
+         * account
+         * @param id - Gateway account ID
+         * @returns List of card types supported by this gateway account
+         */
+        listCardTypes(id: string): Promise<ListCardTypesResponse | undefined> {
+            return client._axios
+                .get(`/v1/frontend/accounts/${id}/card-types`)
+                .then(response => client._unpackResponseData<ListCardTypesResponse>(response))
+        },
 
-      return accounts[0]
-    },
+        /*
+         * List gateway accounts (internal API view)
+         * @param filters - optional parameters to filter account list
+         * @returns List gateway account response
+         */
+        list(filters: ListGatewayAccountsRequest = {}): Promise<ListGatewayAccountsResponse | undefined> {
+            const params = _.omitBy(filters, _.isEmpty)
+            return client._axios
+                .get('/v1/api/accounts', {params})
+                .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
+        },
 
-    /**
-     * Create a new gateway account
-     * @param params - Gateway account details
-     * @returns The created gateway account object
-     */
-    create(params: CreateGatewayAccountRequest): Promise<CreateGatewayAccountResponse | undefined> {
-      return client._axios
-        .post('/v1/api/accounts', params)
-        .then(response => client._unpackResponseData<CreateGatewayAccountResponse>(response));
-    },
+        /*
+         * Get one gateway account given service ID. This is a polyfill method until service ID and live/ test are the primary index for accounts on the backend.
+         */
+        async retrieveForService(filters: ListGatewayAccountsRequest = {}): Promise<GatewayAccount | undefined> {
+            const params = _.omitBy(filters, _.isEmpty)
+            const {accounts} = await client._axios
+                .get('/v1/api/accounts', {params})
+                .then(response => client._unpackResponseData<ListGatewayAccountsResponse>(response))
+
+            if (accounts.length > 1) {
+                throw new Error(`Multiple accounts for service ${filters.serviceIds} ${filters.type}, this is a legacy configuration`)
+            }
+
+            if (!accounts.length) {
+                throw new EntityNotFoundError('Account for service', filters.serviceIds)
+            }
+
+            return accounts[0]
+        },
+
+        /**
+         * Create a new gateway account
+         * @param params - Gateway account details
+         * @returns The created gateway account object
+         */
+        create(params: CreateGatewayAccountRequest): Promise<CreateGatewayAccountResponse | undefined> {
+            return client._axios
+                .post('/v1/api/accounts', params)
+                .then(response => client._unpackResponseData<CreateGatewayAccountResponse>(response));
+        },
 
     /**
      * Update an existing gateway account. The patch endpoint for accounts only
@@ -193,92 +194,103 @@ export default class Connector extends Client {
       // Note that connector only supports single update per request, rather than an array of updates
       const payload = mapRequestParamsToOperation(params).pop()
 
-      return client._axios
-        .patch(`/v1/api/accounts/${id}`, payload)
-        .then(() => {
-          return
-        });
-      // @TODO(sfount) decide if this should return the updated account -- could determine through uses of it
-      // .then(() => this.retrieve(id))
-    },
+            return client._axios
+                .patch(`/v1/api/accounts/${id}`, payload)
+                .then(() => {
+                    return
+                });
+            // @TODO(sfount) decide if this should return the updated account -- could determine through uses of it
+            // .then(() => this.retrieve(id))
+        },
 
-    updateStripeSetup(id: string, params: UpdateStripeSetupRequest): Promise<void> {
-      const payload = mapRequestParamsToOperation(params);
-      return client._axios
-        .patch(`/v1/api/accounts/${id}/stripe-setup`, payload)
-    },
+        updateStripeSetup(id: string, params: UpdateStripeSetupRequest): Promise<void> {
+            const payload = mapRequestParamsToOperation(params);
+            return client._axios
+                .patch(`/v1/api/accounts/${id}/stripe-setup`, payload)
+        },
 
-    addGatewayAccountCredentials(id: string, params: AddGatewayAccountCredentialsRequest): Promise<GatewayAccountCredentials> {
-      return client._axios
-        .post(`/v1/api/accounts/${id}/credentials`, params)
-        .then(response => client._unpackResponseData<GatewayAccountCredentials>(response));
-    }
+        addGatewayAccountCredentials(id: string, params: AddGatewayAccountCredentialsRequest): Promise<GatewayAccountCredentials> {
+            return client._axios
+                .post(`/v1/api/accounts/${id}/credentials`, params)
+                .then(response => client._unpackResponseData<GatewayAccountCredentials>(response));
+        }
 
-  }))(this)
+    }))(this)
 
-  cardTypes = ((client: Connector) => ({
-    /**
-     * List all card types supported by the platform
-     * @returns List of card types
-     */
-    list(): Promise<ListCardTypesResponse | undefined> {
-      return client._axios
-        .get('/v1/api/card-types')
-        .then(response => client._unpackResponseData<ListCardTypesResponse>(response));
-    }
-  }))(this)
+    cardTypes = ((client: Connector) => ({
+        /**
+         * List all card types supported by the platform
+         * @returns List of card types
+         */
+        list(): Promise<ListCardTypesResponse | undefined> {
+            return client._axios
+                .get('/v1/api/card-types')
+                .then(response => client._unpackResponseData<ListCardTypesResponse>(response));
+        }
+    }))(this)
 
 
-  eventEmitter = ((client: Connector) => ({
-    emitByIdRange(startId: number, maxId: number, recordType: string, retryDelayInSeconds: number): Promise<void> {
-      const params = {
-        start_id: startId,
-        max_id: maxId,
-        record_type: recordType,
-        do_not_retry_emit_until: retryDelayInSeconds
-      }
-      return client._axios
-        .post('/v1/tasks/historical-event-emitter', null, {params})
-        .then(() => {
-          return
-        })
-    },
+    eventEmitter = ((client: Connector) => ({
+        emitByIdRange(startId: number, maxId: number, recordType: string, retryDelayInSeconds: number): Promise<void> {
+            const params = {
+                start_id: startId,
+                max_id: maxId,
+                record_type: recordType,
+                do_not_retry_emit_until: retryDelayInSeconds
+            }
+            return client._axios
+                .post('/v1/tasks/historical-event-emitter', null, {params})
+                .then(() => {
+                    return
+                })
+        },
 
-    emitByDate(startDate: string, endDate: string, retryDelayInSeconds: number): Promise<void> {
-      const params = {
-        start_date: startDate,
-        end_date: endDate,
-        do_not_retry_emit_until: retryDelayInSeconds
-      }
-      return client._axios
-        .post('/v1/tasks/historical-event-emitter-by-date', null, {params})
-        .then(() => {
-          return
-        })
-    }
-  }))(this)
+        emitByDate(startDate: string, endDate: string, retryDelayInSeconds: number): Promise<void> {
+            const params = {
+                start_date: startDate,
+                end_date: endDate,
+                do_not_retry_emit_until: retryDelayInSeconds
+            }
+            return client._axios
+                .post('/v1/tasks/historical-event-emitter-by-date', null, {params})
+                .then(() => {
+                    return
+                })
+        }
+    }))(this)
 
-  parityChecker = ((client: Connector) => ({
-    runParityCheck(
-      startId: number,
-      maxId: number,
-      doNotReprocessValidRecords: boolean,
-      parityCheckStatus: string,
-      retryDelayInSeconds: number,
-      recordType: string): Promise<void> {
-      const params = {
-        start_id: startId,
-        max_id: maxId,
-        do_not_reprocess_valid_records: doNotReprocessValidRecords,
-        parity_check_status: parityCheckStatus,
-        do_not_retry_emit_until: retryDelayInSeconds,
-        record_type: recordType
-      }
-      return client._axios
-        .post('/v1/tasks/parity-checker', null, {params})
-        .then(() => {
-          return
-        })
-    }
-  }))(this)
+    parityChecker = ((client: Connector) => ({
+        runParityCheck(
+            startId: number,
+            maxId: number,
+            doNotReprocessValidRecords: boolean,
+            parityCheckStatus: string,
+            retryDelayInSeconds: number,
+            recordType: string): Promise<void> {
+            const params = {
+                start_id: startId,
+                max_id: maxId,
+                do_not_reprocess_valid_records: doNotReprocessValidRecords,
+                parity_check_status: parityCheckStatus,
+                do_not_retry_emit_until: retryDelayInSeconds,
+                record_type: recordType
+            }
+            return client._axios
+                .post('/v1/tasks/parity-checker', null, {params})
+                .then(() => {
+                    return
+                })
+        }
+    }))(this)
+
+
+    fixAsyncFailedStripeRefund = ((client: Connector) => ({
+        fixStripeRefund(gatewayAccountId: string, chargeId: string, refundId: string, params: AddGitHubAndZendeskCredential): Promise<void> {
+            return client._axios
+                .post(`/v1/api/accounts/${gatewayAccountId}/charges/${chargeId}/refunds/${refundId}/reverse-failed`, params)
+                .then(() => {
+                    return
+                })
+        }
+    }))(this)
 }

--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -210,3 +210,8 @@ export interface AddGatewayAccountCredentialsRequest {
   payment_provider: string;
   credentials?: StripeCredentials;
 }
+
+export interface AddGitHubAndZendeskCredential {
+  zendesk_ticket_id: string;
+  github_user_id: string;
+}

--- a/src/web/modules/transactions/confirmFixAsyncFailedStripeRefund.njk
+++ b/src/web/modules/transactions/confirmFixAsyncFailedStripeRefund.njk
@@ -1,0 +1,55 @@
+{% from "common/json.njk" import json %}
+
+{% extends "layout/layout.njk" %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+
+{% set isTestData = not (parentTransaction and parentTransaction.live) %}
+
+{% block main %}
+  <h1 class="govuk-heading-m">Refund</h1>
+
+  <div class="govuk-body govuk-!-margin-bottom-4">
+    <a href="/transactions/{{ transaction.transaction_id }}" class="govuk-back-link">Refunds
+      payment {{ transaction.transaction_id }}</a>
+  </div>
+
+  <div class="status-inline-spacer">
+    <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
+  </div>
+
+  <div class="govuk-grid-row status-spacer payment-detail-row">
+    <div class="govuk-grid-column-one-quarter">
+      <span class="govuk-caption-m">Date</span>
+      <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
+    </div>
+  </div>
+
+  <h1 class="govuk-heading-m">Confirm refund</h1>
+
+  <form method="post" action="/confirm-fix-async-failed-stripe-refund/:id">
+
+    {{ govukInput({
+      label: { text: "Zendesk ticket number" },
+      id: "zendeskTicketNumber",
+      name: "zendeskTicketNumber",
+      autocomplete: "off"
+    }) }}
+
+    {{ govukWarningText({
+      text: "This feature is under development and you should NOT press the button yet.",
+      iconFallbackText: "Warning"
+    }) }}
+
+    {{ govukButton({
+      text: "Correct asynchronously failed Stripe refund "
+    }) }}
+
+  </form>
+{% endblock %}
+

--- a/src/web/modules/transactions/fix_async_failed_stripe_refund.ts
+++ b/src/web/modules/transactions/fix_async_failed_stripe_refund.ts
@@ -1,0 +1,36 @@
+import {NextFunction, Request, Response} from "express";
+import {Connector, Ledger} from "../../../lib/pay-request/client";
+
+export async function show(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const transaction = await Ledger.transactions.retrieve(req.params.id)
+
+        res.render(`transactions/confirmFixAsyncFailedStripeRefund`, {
+            transaction
+        })
+    } catch (error) {
+        next(error)
+    }
+}
+
+
+export async function fixAsyncFailedStripeRefund(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const transaction = await Ledger.transactions.retrieve(req.params.id)
+        const gatewayAccountId = transaction.gateway_account_id
+        const refundId = transaction.transaction_id
+        const chargeId = transaction.parent_transaction_id
+        const zendeskTicketId = req.body.zendesk_ticket_id
+        const githubUserId = req.user && req.user.username
+
+        await Connector.fixAsyncFailedStripeRefund.fixStripeRefund(gatewayAccountId, refundId, chargeId, {
+            zendesk_ticket_id: zendeskTicketId,
+            github_user_id: githubUserId
+        })
+        res.render(`transactions/confirmFixAsyncFailedStripeRefund`, {
+            transaction
+        })
+    } catch (error) {
+        next(error)
+    }
+}

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -5,85 +5,89 @@
 {% set isTestData = not (parentTransaction and parentTransaction.live) %}
 
 {% block main %}
-  <h1 class="govuk-heading-m">Refund</h1>
+<h1 class="govuk-heading-m">Refund</h1>
 
-  {% if transaction.parent_transaction_id %}
+{% if transaction.parent_transaction_id %}
   <div class="govuk-body govuk-!-margin-bottom-4">
-    <a href="/transactions/{{ transaction.parent_transaction_id }}" class="govuk-back-link">Refunds payment {{ transaction.parent_transaction_id }}</a>
+    <a href="/transactions/{{ transaction.parent_transaction_id }}" class="govuk-back-link">Refunds
+      payment {{ transaction.parent_transaction_id }}</a>
   </div>
-  {% endif %}
+{% endif %}
 
-  <div class="status-inline-spacer">
-    <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
+<div class="status-inline-spacer">
+  <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
+</div>
+
+<div class="govuk-grid-row status-spacer payment-detail-row">
+  <div class="govuk-grid-column-one-quarter">
+    <span class="govuk-caption-m">Date</span>
+    <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
   </div>
+</div>
 
-  <div class="govuk-grid-row status-spacer payment-detail-row">
-    <div class="govuk-grid-column-one-quarter">
-      <span class="govuk-caption-m">Date</span>
-      <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
-    </div>
-  </div>
+<div>
+  <h1 class="govuk-heading-s payment__header">Refund details</h1>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Status</span></th>
+      <td class="govuk-table__cell payment__cell">{{ transaction.state and transaction.state.status | capitalize }}</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date</span></th>
+      <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLong }}</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Amount</span></th>
+      <td class="govuk-table__cell payment__cell">
+        <span>{{ (transaction.total_amount or transaction.amount) | currency }} </span>
+      </td>
+    </tr>
+  </table>
+</div>
 
-  <div>
-    <h1 class="govuk-heading-s payment__header">Refund details</h1>
-    <table class="govuk-table">
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Status</span></th>
-          <td class="govuk-table__cell payment__cell">{{ transaction.state and transaction.state.status | capitalize }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Created date</span></th>
-          <td class="govuk-table__cell payment__cell">{{ transaction.created_date | formatDateLong }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Amount</span></th>
-          <td class="govuk-table__cell payment__cell">
-            <span>{{ (transaction.total_amount or transaction.amount) | currency }} </span>
-          </td>
-        </tr>
-    </table>
-  </div>
+<div>
+  <h1 class="govuk-heading-s payment__header">Processing details</h1>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Gateway account</span></th>
+      <td class="govuk-table__cell payment__cell">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="/gateway_accounts/{{ transaction.gateway_account_id }}">{{ transaction.gateway_account_id }}
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Service</span></th>
+      <td class="govuk-table__cell payment__cell">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="/services/{{ service.external_id }}">{{ service.external_id }}
+      </td>
+    </tr>
+    {% if transaction.gateway_transaction_id %}
+      <tr class="govuk-table__row">
+        <th class="govuk-table__cell payment__cell" scope="row"><span
+            class="govuk-caption-m">Provider transaction</span></th>
+        <td class="govuk-table__cell payment__cell">{{ transaction.gateway_transaction_id }}</td>
+      </tr>
+    {% endif %}
+    </tobdy>
+  </table>
+</div>
 
-  <div>
-    <h1 class="govuk-heading-s payment__header">Processing details</h1>
-    <table class="govuk-table">
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Gateway account</span></th>
-          <td class="govuk-table__cell payment__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="/gateway_accounts/{{transaction.gateway_account_id}}">{{ transaction.gateway_account_id }}
-          </td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Service</span></th>
-          <td class="govuk-table__cell payment__cell">
-          <a class="govuk-link govuk-link--no-visited-state" href="/services/{{service.external_id}}">{{ service.external_id }}
-          </td>
-        </tr>
-        {% if transaction.gateway_transaction_id %}
-        <tr class="govuk-table__row">
-          <th class="govuk-table__cell payment__cell" scope="row"><span class="govuk-caption-m">Provider transaction</span></th>
-          <td class="govuk-table__cell payment__cell">{{ transaction.gateway_transaction_id }}</td>
-        </tr>
-        {% endif %}
-      </tobdy>
-    </table>
-  </div>
+<div>
+  <h1 class="govuk-heading-s payment__header">Ledger events</h1>
 
-  <div>
-    <h1 class="govuk-heading-s payment__header">Ledger events</h1>
-
-    <table class="govuk-table">
-          <tbody class="govuk-table__body">
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
     {% for event in events %}
 
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ event.event_type }}</td>
-          <td class="govuk-table__cell">{{ event.timestamp | formatDate}}</td>
-        </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ event.event_type }}</td>
+        <td class="govuk-table__cell">{{ event.timestamp | formatDate }}</td>
+      </tr>
 
-        {% if event.data %}
+      {% if event.data %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="2">
             <details class="govuk-details" data-module="govuk-details">
@@ -98,14 +102,25 @@
             </details>
           </td>
         </tr>
-        {% endif %}
+      {% endif %}
     {% else %}
       <!-- @TODO(sfount) use a row here -->
       <div class="center bottom-spacer"><span class="govuk-caption-m">No events</span></div>
     {% endfor %}
     </tbody>
-    </table>
-  </div>
+  </table>
+</div>
 
-  {{ json("Transaction source", transaction) }}
-{% endblock %}
+{{ json("Transaction source", transaction) }}
+
+<div>
+  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") %}
+    {{ govukButton({
+      text: "Correct asynchronously failed Stripe refund",
+      classes: "govuk-button--warning",
+      href: "/confirm-fix-async-failed-stripe-refund/" + transaction.transaction_id
+    }) }}
+  {% endif %}
+
+  {% endblock %}
+</div>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -25,11 +25,14 @@ const paymentLinks = require('./modules/payment_links/payment_links.http')
 const ledgerPayouts = require('./modules/ledger_payouts/payout.http')
 const performance = require('./modules/statistics/performance.http')
 const events = require('./modules/events')
+const fixRefunds = require('./modules/transactions/fix_async_failed_stripe_refund')
+
 
 // @TODO(sfount) remove `default`s on update to import export syntax
 const users = require('./modules/users/users.http').default
 
 const {PermissionLevel} = require('../lib/auth/types')
+const { fixAsyncFailedStripeRefund } = require("./modules/transactions/fix_async_failed_stripe_refund");
 
 const router = express.Router()
 
@@ -158,6 +161,8 @@ router.get('/agreements/search', auth.secured(PermissionLevel.VIEW_ONLY), agreem
 router.post('/agreements/search', auth.secured(PermissionLevel.VIEW_ONLY), agreements.search)
 router.get('/agreements/:id', auth.secured(PermissionLevel.VIEW_ONLY), agreements.detail)
 router.get('/agreements', auth.secured(PermissionLevel.VIEW_ONLY), agreements.list)
+router.get('/confirm-fix-async-failed-stripe-refund/:id', auth.secured(PermissionLevel.USER_SUPPORT), fixRefunds.show)
+router.post('/confirm-fix-async-failed-stripe-refund/:id', auth.secured(PermissionLevel.USER_SUPPORT), fixRefunds.fixAsyncFailedStripeRefund)
 
 router.get('/payment_links', auth.secured(PermissionLevel.VIEW_ONLY), paymentLinks.list)
 router.get('/payment_links/search', auth.secured(PermissionLevel.VIEW_ONLY), paymentLinks.search)


### PR DESCRIPTION
- Added routes for dealing with failed Stripe refunds
- Added refund button for failed Stripe refunds
- Added post requests to post to connector endpoint to reverse failed Stripe refund
- Added new confirmation page for failed Stripe refunds

Note: the `github_user_id` comes from the Github's API (https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user). There was no easy way to test this locally but looking through Splunk I am confident the `req.user && req.user.username` is the correct Github username.