### PR TITLE
PP-12433: Clarify that the Find A User search is for service users

### DIFF
--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -45,7 +45,7 @@
           <h4 class="govuk-heading-s app-subnav__header">Users</h4>
           <ul class="govuk-list app-subnav__section">
             <li class="app-subnav__section-item">
-              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/users/search">Find a user</a>
+              <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="/users/search">Find a service user</a>
             </li>
           </ul>
 

--- a/src/web/modules/users/search.njk
+++ b/src/web/modules/users/search.njk
@@ -4,7 +4,7 @@
 
 {% block main %}
   <span class="govuk-caption-m">GOV.UK Pay platform</span>
-  <h1 class="govuk-heading-m">Find a user</h1>
+  <h1 class="govuk-heading-m">Find a service user</h1>
 
   <form method="POST" action="/users/search">
     {{ govukInput({
@@ -22,3 +22,5 @@
     <input type="hidden" name="_csrf" value="{{ csrf }}">
   </form>
 {% endblock %}
+
+<p class="govuk-body">To search for a paying user, use <a class="govuk-link" href="/transactions/search">Find a transaction</a>.</p>


### PR DESCRIPTION
This has caught me out several times over the years. The [Find A User](https://toolbox.payments.service.gov.uk/users/search) search page is looking for service users only, in the Adminusers database. This PR renames the page and the sidebar to make that clear.

I've also linked to the [Find A Transaction](https://toolbox.payments.service.gov.uk/transactions/search) search, to help developers who need to look up paying users.