### PR TITLE
PP-12433: Move user search guidance text inside main block

### DIFF
--- a/src/web/modules/users/search.njk
+++ b/src/web/modules/users/search.njk
@@ -21,6 +21,6 @@
 
     <input type="hidden" name="_csrf" value="{{ csrf }}">
   </form>
-{% endblock %}
 
-<p class="govuk-body">To search for a paying user, use <a class="govuk-link" href="/transactions/search">Find a transaction</a>.</p>
+  <p class="govuk-body">To search for a paying user, use <a class="govuk-link" href="/transactions/search">Find a transaction</a>.</p>
+{% endblock %}


### PR DESCRIPTION
I mistakenly put the paragraph outside the `{% main %}` block 🤦‍♀️ 

That will serve me right for moving things around at the last minute to be 'neater' and not doing a subsequent check locally.