### PR TITLE
PP-13064 Allow toggling corporate exemptions in Worldpay accounts

### DIFF
--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -83,6 +83,8 @@ export interface Worldpay3dsFlexCredentials {
   issuer: string;
   organisational_unit_id: string;
   exemption_engine_enabled: boolean;
+  corporate_exemptions_enabled: boolean;
+
 }
 
 export interface NotifySettings {
@@ -98,6 +100,7 @@ export interface UpdateGatewayAccountRequest {
   block_prepaid_cards?: boolean;
   allow_moto?: boolean;
   worldpay_exemption_engine_enabled?: boolean;
+  worldpay_corporate_exemptions_enabled?: boolean;
   allow_telephone_payment_notifications?: boolean;
   send_payer_ip_address_to_gateway?: boolean;
   send_payer_email_to_gateway?: boolean;

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -24,7 +24,7 @@
   {% endif %}
 
 <span class="govuk-caption-m">{{ services.name }}</span>
-<h1 class="govuk-heading-m">Gateway account details <span><strong class="govuk-tag govuk-tag--grey">{{ account.payment_provider }} {{ account.type }}</strong></span></h1>
+<h1 class="govuk-heading-m">Gateway account details<span><strong class="govuk-tag govuk-tag--grey">{{ account.payment_provider }} {{ account.type }}</strong></span></h1>
 
 {% if services.external_id %}
   <div>
@@ -209,6 +209,15 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/worldpay_exemption_engine">Manage<span class="govuk-visually-hidden"> Worldpay Exemption Engine</span></a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><span class="govuk-caption-m">Corporate exemptions</span></dt>
+          <dd class="govuk-summary-list__value">
+            {{ 'Enabled' if account.worldpay_3ds_flex and account.worldpay_3ds_flex.corporate_exemptions_enabled else 'Disabled' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/worldpay_corporate_exemptions">Manage<span class="govuk-visually-hidden"> Worldpay Exemption Engine</span></a>
           </dd>
         </div>
       {% endif %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -441,6 +441,33 @@ async function updateWorldpayExemptionEngine(req: Request, res: Response): Promi
   res.redirect(`/gateway_accounts/${id}`)
 }
 
+async function worldpayCorporateExemptions(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const {id} = req.params
+  const account = await Connector.accounts.retrieve(id)
+
+  if (!account.worldpay_3ds_flex) {
+    throw new ValidationError('Worldpay 3DS Flex must be configured before you can enable the corporate exemptions.')
+  }
+
+  const enabled = account.worldpay_3ds_flex && account.worldpay_3ds_flex.corporate_exemptions_enabled
+  res.render('gateway_accounts/worldpay_corporate_exemptions', {
+    account,
+    enabled,
+    csrf: req.csrfToken()
+  })
+}
+
+async function updateWorldpayCorporateExemptions(req: Request, res: Response): Promise<void> {
+  const {id} = req.params
+  const enable = req.body.enabled === 'enabled'
+  await Connector.accounts.update(id, {worldpay_corporate_exemptions_enabled: enable})
+  req.flash('info', `Worldpay Corporate Exemptions ${enable ? 'enabled' : 'disabled'}`)
+  res.redirect(`/gateway_accounts/${id}`)
+}
+
 async function disableReasonPage(
   req: Request,
   res: Response
@@ -674,6 +701,8 @@ export default {
   searchRequest: wrapAsyncErrorHandler(searchRequest),
   worldpayExemptionEngine: wrapAsyncErrorHandler(worldpayExemptionEngine),
   updateWorldpayExemptionEngine: wrapAsyncErrorHandler(updateWorldpayExemptionEngine),
+  worldpayCorporateExemptions: wrapAsyncErrorHandler(worldpayCorporateExemptions),
+  updateWorldpayCorporateExemptions: wrapAsyncErrorHandler(updateWorldpayCorporateExemptions),
   recurringPayments: wrapAsyncErrorHandler(recurringPayments),
   updateRecurringPayments: wrapAsyncErrorHandler(updateRecurringPayments),
   worldpayPaymentData: wrapAsyncErrorHandler(worldpayPaymentData),

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -47,6 +47,8 @@ export default {
   searchRequest: http.searchRequest,
   worldpayExemptionEngine: http.worldpayExemptionEngine,
   updateWorldpayExemptionEngine: http.updateWorldpayExemptionEngine,
+  worldpayCorporateExemptions: http.worldpayCorporateExemptions,
+  updateWorldpayCorporateExemptions: http.updateWorldpayCorporateExemptions,
   recurringPayments: http.recurringPayments,
   updateRecurringPayments: http.updateRecurringPayments,
   worldpayPaymentData: http.worldpayPaymentData,

--- a/src/web/modules/gateway_accounts/worldpay_corporate_exemptions.njk
+++ b/src/web/modules/gateway_accounts/worldpay_corporate_exemptions.njk
@@ -1,0 +1,44 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "layout/layout.njk" %}
+
+{% set isTestData = account and not (account.type === "live") %}
+
+{% block main %}
+  <h1 class="govuk-heading-m">Worldpay 3DS Corporate Exemptions</h1>
+
+  <div>
+    <a href="/gateway_accounts/{{ account.gateway_account_id }}" class="govuk-back-link">Gateway account ({{ account.gateway_account_id }})</a>
+  </div>
+
+  <p class="govuk-body">With corporate exemptions, we can request that a payment be exempt from SCA (Strong Customer Authentication) because the cardholder is working in a secure corporate environment.</p>
+  <p class="govuk-body">When enabled, we will request a corporate exemption for any payments made using a corporate card (determined by the card number) when authorising.</p>
+  <p class="govuk-body">Unlike other exemptions, if our request for a corporate exemption is rejected by the bank and the payment is declined, we will not try again without requesting an exemption (soft declines are treated as hard declines).</p>
+  <p class="govuk-body">This feature will be requested by a service through support.</p>
+
+  <form method="POST" action="/gateway_accounts/{{ account.gateway_account_id }}/worldpay_corporate_exemptions">
+
+    {{ govukRadios({
+      name: "enabled",
+      items: [
+        {
+          value: "enabled",
+          text: "Turn on Corporate Exemptions",
+          checked: enabled
+        },
+        {
+          value: "disabled",
+          text: "Turn off Corporate Exemptions",
+          checked: not enabled
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save"
+    })
+    }}
+
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+  </form>
+{% endblock %}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -74,6 +74,8 @@ router.get('/gateway_accounts/:id/email_branding', auth.secured(PermissionLevel.
 router.post('/gateway_accounts/:id/email_branding', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.updateEmailBranding)
 router.get('/gateway_accounts/:id/worldpay_exemption_engine', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.worldpayExemptionEngine)
 router.post('/gateway_accounts/:id/worldpay_exemption_engine', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.updateWorldpayExemptionEngine)
+router.get('/gateway_accounts/:id/worldpay_corporate_exemptions', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.worldpayCorporateExemptions)
+router.post('/gateway_accounts/:id/worldpay_corporate_exemptions', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.updateWorldpayCorporateExemptions)
 router.get('/gateway_accounts/:id/disable', auth.secured(PermissionLevel.VIEW_ONLY), gatewayAccounts.disableReasonPage)
 router.post('/gateway_accounts/:id/disable', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.disable)
 router.post('/gateway_accounts/:id/enable', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.enable)


### PR DESCRIPTION
With recent work[1], we have introduced the ability to toggle corporate exemptions for Worldpay accounts in Connector via REST patch requests.

With this change, we are now introducing a new entry in the Worldpay account configuration, showing whether corporate exemptions are enabled or disabled, and including a link with the text 'Manage'.

Clicking on 'Manage', the user is then shown a page explaining how Worldpay 3DS Corporate Exemptions work, with radio buttons at the bottom of the page where the user can decide to 'Turn on or off Corporate Exemptions' and then 'Save' the change.

Further information and screenshots in Jira[2] and in this PR[3].

[1]
https://github.com/alphagov/pay-connector/pull/5513

[2]
https://payments-platform.atlassian.net/browse/PP-13064

[3]
https://github.com/alphagov/pay-toolbox/pull/1839

## Scenario 1  (New configuration entry)

![new configuration](https://github.com/user-attachments/assets/3506e8b5-fd94-44a9-9e85-356fc97d4aed)

## Corresponding setting in the DB

<img width="932" alt="corresponding to new field" src="https://github.com/user-attachments/assets/bcbff392-9b9b-4d84-bc2b-a194bf77f442">

## If Worldpay 3DS is not set, there is an error message

![error](https://github.com/user-attachments/assets/a71af3c9-dd2f-4742-8f88-4f3d45921e6c)

## Scenario 2 (Corporate exemptions are enabled)

![feature toggled](https://github.com/user-attachments/assets/a0913eb4-32fd-4a26-8691-b64dcc9da89d)

## Scenario 3 (New setting page)

![new setting page](https://github.com/user-attachments/assets/aaeda8c5-4a60-471b-ba57-9748e00af8cc)

## Scenario 4 (Turn on the setting)

![scenario 4](https://github.com/user-attachments/assets/ac712f92-eab7-45ad-9d71-912bb0f5ce81)

## Scenario 5 (Turn off the setting)

![scenario 5](https://github.com/user-attachments/assets/878b348b-d7fd-4c76-ab06-a81e1c8ad7d9)

## Scenario 6 (Patch request to turn exemptions on)

![patch to enable](https://github.com/user-attachments/assets/a482cb66-d322-4231-be62-f85881da8131)

## Scenario 7 (Patch request to turn exemptions off)

<img width="982" alt="patch to disable" src="https://github.com/user-attachments/assets/827e04ce-1e86-4a04-8200-dbfd38e91a78">

## Scenario 8 (successfully enabling Worldpay corporate exemptions shows a success message)

![success message](https://github.com/user-attachments/assets/bd4e74e6-7ad4-4c9c-90f1-6ec94e4f9200)

## Scenario 9 (successfully disabling Worldpay corporate exemptions shows a success message)

![scenario 9](https://github.com/user-attachments/assets/d6bf38c6-8571-4e92-850c-45441becd941)

## Scenario 10 (error when enabling or disabling Worldpay corporate exemptions shows an error message)

![if there is an error](https://github.com/user-attachments/assets/40458646-8e99-49f2-8375-a31a1f0e61b1)


