### PR TITLE
PP-13145: Accept BIND_HOST env var and default to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ If the above doesn't work, try the following:
 
 ## Key runtime environment variables
 
-| Variable                 | Description                               |
-| ------------------------ |:----------------------------------------- |
+| Variable                 | Description                                                          |
+| ------------------------ |:-------------------------------------------------------------------- |
+| `BIND_HOST`              | The IP address for the application to bind to. Defaults to 127.0.0.1
 | `NODE_ENV`               |
 | `STRIPE_ACCOUNT_API_KEY` |
 | `https_proxy`            |

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 
 const expectedServerEnvironmentValues = Joi.object({
+  BIND_HOST: Joi.string().ip().default("127.0.0.1"),
   PORT: Joi.number().integer().required(),
   COOKIE_SESSION_ENCRYPTION_SECRET: Joi.string().required(),
   HTTP_PROXY: Joi.string(),

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const app = require('./web/server')
 
 const logHTTPServerStarted = function logHTTPServerStarted() {
   const context = { node_version: process.version, port: server.PORT, excludeFromBreadcrumb: true }
-  logger.info(`Toolbox HTTP server listening on port ${server.PORT}`, context)
+  logger.info(`Toolbox HTTP server listening on ${server.BIND_HOST}:${server.PORT}`, context)
 }
 
-http.createServer(app).listen(server.PORT, logHTTPServerStarted)
+http.createServer(app).listen(server.PORT, server.BIND_HOST, logHTTPServerStarted)


### PR DESCRIPTION
Bind to 127.0.0.1 by default instead of 0.0.0.0 and allow override with BIND_HOST env var.

You can see this works, on master:

* On master run `npm run dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp46      0      0  *.3000                                        *.*                                           LISTEN.
    ```
* Switch to this branch, then `npm run dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  127.0.0.1.3000                                *.*                                           LISTEN
    ```
* Now `BIND_HOST=0.0.0.0 npm run dev`
* A final netstat to prove the override works
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  *.3000                                        *.*                                           LISTEN
    ```

Example of the updated logging:
```
info: Toolbox HTTP server listening on 0.0.0.0:3000 {"excludeFromBreadcrumb":true,"node_version":"v18.20.4","port":3000,"timestamp":"11:31:19"}
```