### PR TITLE
Inital simplification of parity summary page.

### DIFF
--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -15,7 +15,7 @@ export async function validateLedgerTransaction(
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
     const connectorEntry = await Connector.charges.retrieveAPI(req.params.id, ledgerEntry.gateway_account_id)
 
-    const ledgerPreparedForDiff = _.omit(ledgerEntry, [
+    const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
       'gateway_account_id',
       'transaction_id',
       'disputed',
@@ -26,12 +26,12 @@ export async function validateLedgerTransaction(
       'service_id',
       'refund_summary.amount_refunded'
     ])
-    const connectorPreparedForDiff = _.omit(connectorEntry, [
+    const connectorResponseWithoutConnectorSpecificFields = _.omit(connectorEntry, [
         'links',
         'charge_id'
     ])
 
-    const parity = diff(connectorPreparedForDiff, ledgerPreparedForDiff).filter(obj => {
+    const parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
         if (obj.path[0] !== 'created_date' && obj.kind === EDIT) {
             return true
         }

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -1,6 +1,10 @@
 import { Request, Response, NextFunction } from 'express'
-import { diff } from 'deep-diff'
+import {diff, DiffEdit} from 'deep-diff'
 import { Ledger, Connector } from '../../../../lib/pay-request/client'
+import * as _ from 'lodash'
+import moment from 'moment'
+
+const EDIT = 'E'
 
 export async function validateLedgerTransaction(
   req: Request,
@@ -10,7 +14,35 @@ export async function validateLedgerTransaction(
   try {
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
     const connectorEntry = await Connector.charges.retrieveAPI(req.params.id, ledgerEntry.gateway_account_id)
-    const parity = diff(connectorEntry, ledgerEntry)
+
+    const ledgerPreparedForDiff = _.omit(ledgerEntry, [
+      'gateway_account_id',
+      'transaction_id',
+      'disputed',
+      'source',
+      'live',
+      'transaction_type',
+      'credential_external_id',
+      'service_id',
+      'refund_summary.amount_refunded'
+    ])
+    const connectorPreparedForDiff = _.omit(connectorEntry, [
+        'links',
+        'charge_id'
+    ])
+
+    const parity = diff(connectorPreparedForDiff, ledgerPreparedForDiff).filter(obj => {
+        if (obj.path[0] !== 'created_date' && obj.kind === EDIT) {
+            return true
+        }
+        const castedObj = obj as DiffEdit<string>
+        const lhsDate = moment(castedObj.lhs)
+        const rhsDate = moment(castedObj.rhs)
+        if (Math.abs(lhsDate.diff(rhsDate)) > 10) {
+            return true
+        }
+        return false
+    })
 
     res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parity })
   } catch (error) {

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -23,7 +23,7 @@
   {% if not parity.length %}
     {{ govukPanel({
       titleText: "Parity",
-      html: "No differences found between in-flight and Ledger payment record"
+      html: "No meaningful differences found between in-flight and Ledger payment record"
       })
     }}
   {% endif %}


### PR DESCRIPTION
This change removes the obviously unnecessary differences, that decision is based on a successful transaction on my local environment.  It allows 10 milliseconds time difference between Connector and Ledger's timings.

This was initially committed as work in progress but I've started to see it as a step in the right direction and worth merging while we continue to look at the rest of the page.

(Paired with @james-peacock-gds)