### PR TITLE
PP-12854 Parity check - omit unnecessary fields and handle connector 404

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -45,11 +45,11 @@ export default class Connector extends Client {
                 .catch(handleEntityNotFound("Charge", id))
         },
 
-        retrieveAPI(externalChargeId: string, accountId: string): Promise<Charge | undefined> {
+        parityCheck(externalChargeId: string, accountId: string): Promise<Charge | String> {
             return client._axios
                 .get(`/v1/api/accounts/${accountId}/charges/${externalChargeId}`)
                 .then(response => client._unpackResponseData<Charge>(response))
-                .catch(handleChargeNotFoundForParityCheck("Charge", externalChargeId, true))
+                .catch(handleChargeNotFoundForParityCheck("Charge", externalChargeId))
         },
 
         /**

--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -19,7 +19,7 @@ import {
     UpdateStripeSetupRequest
 } from './types'
 import {App} from '../../shared'
-import {handleEntityNotFound} from "../../utils/error";
+import {handleEntityNotFound, handleChargeNotFoundForParityCheck} from "../../utils/error";
 import {EntityNotFoundError} from '../../../errors'
 import {Refund} from "../ledger/types";
 
@@ -49,7 +49,7 @@ export default class Connector extends Client {
             return client._axios
                 .get(`/v1/api/accounts/${accountId}/charges/${externalChargeId}`)
                 .then(response => client._unpackResponseData<Charge>(response))
-                .catch(handleEntityNotFound("Charge", externalChargeId))
+                .catch(handleChargeNotFoundForParityCheck("Charge", externalChargeId, true))
         },
 
         /**

--- a/src/lib/pay-request/utils/error.ts
+++ b/src/lib/pay-request/utils/error.ts
@@ -1,5 +1,4 @@
 import {EntityNotFoundError, RESTClientError} from "../../errors";
-import {Charge} from "../services/connector/types";
 
 export function handleEntityNotFound(entityName: string, entityId: string) {
   return (error: RESTClientError) => {
@@ -10,14 +9,10 @@ export function handleEntityNotFound(entityName: string, entityId: string) {
   }
 }
 
-export function handleChargeNotFoundForParityCheck(entityName: string, entityId: string, parityCheck = false) {
+export function handleChargeNotFoundForParityCheck(entityName: string, entityId: string) {
   return (error: RESTClientError) => {
     if (error.data.response && error.data.response.status === 404) {
-      if (parityCheck) {
-        const chargeNotFound: Charge = { charge_id: 'Not found', amount: undefined, total_amount: undefined, fee: undefined, net_amount: undefined, description: undefined, reference: undefined, payment_provider: undefined }
-        return chargeNotFound
-      }
-      throw new EntityNotFoundError(entityName, entityId)
+        return 'Charge not found in connector'
     }
     throw error
   }

--- a/src/lib/pay-request/utils/error.ts
+++ b/src/lib/pay-request/utils/error.ts
@@ -1,8 +1,22 @@
 import {EntityNotFoundError, RESTClientError} from "../../errors";
+import {Charge} from "../services/connector/types";
 
 export function handleEntityNotFound(entityName: string, entityId: string) {
   return (error: RESTClientError) => {
     if (error.data.response && error.data.response.status === 404) {
+      throw new EntityNotFoundError(entityName, entityId)
+    }
+    throw error
+  }
+}
+
+export function handleChargeNotFoundForParityCheck(entityName: string, entityId: string, parityCheck = false) {
+  return (error: RESTClientError) => {
+    if (error.data.response && error.data.response.status === 404) {
+      if (parityCheck) {
+        const chargeNotFound: Charge = { charge_id: 'Not found', amount: undefined, total_amount: undefined, fee: undefined, net_amount: undefined, description: undefined, reference: undefined, payment_provider: undefined }
+        return chargeNotFound
+      }
       throw new EntityNotFoundError(entityName, entityId)
     }
     throw error

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -16,19 +16,30 @@ export async function validateLedgerTransaction(
     const connectorEntry = await Connector.charges.retrieveAPI(req.params.id, ledgerEntry.gateway_account_id)
 
     const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
-      'gateway_account_id',
-      'transaction_id',
-      'disputed',
-      'source',
-      'live',
-      'transaction_type',
-      'credential_external_id',
-      'service_id',
-      'refund_summary.amount_refunded'
+        'gateway_account_id',
+        'transaction_id',
+        'disputed',
+        'source',
+        'live',
+        'transaction_type',
+        'credential_external_id',
+        'service_id',
+        'refund_summary.amount_refunded',
+        'evidence_due_date',
+        'gateway_payout_id',
+        'parent_transaction_id',
+        'payment_details',
+        'reason'
     ])
     const connectorResponseWithoutConnectorSpecificFields = _.omit(connectorEntry, [
         'links',
-        'charge_id'
+        'charge_id',
+        'auth_code',
+        'authorised_date',
+        'payment_outcome',
+        'processor_id',
+        'provider_id',
+        'telephone_number'
     ])
 
     const parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from 'express'
-import {diff, DiffEdit} from 'deep-diff'
+import {diff, DiffDeleted, DiffEdit, DiffNew} from 'deep-diff'
 import { Ledger, Connector } from '../../../../lib/pay-request/client'
 import * as _ from 'lodash'
 import moment from 'moment'
 
 const EDIT = 'E'
+const DELETED = 'D'
+const NEW = 'N'
 
 export async function validateLedgerTransaction(
   req: Request,
@@ -14,9 +16,9 @@ export async function validateLedgerTransaction(
   try {
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
     const connectorEntry = await Connector.charges.parityCheck(req.params.id, ledgerEntry.gateway_account_id)
-    let message
+    let warningMessage
     if (typeof connectorEntry === 'string') {
-        message = connectorEntry
+        warningMessage = connectorEntry
     }
 
     const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
@@ -47,18 +49,43 @@ export async function validateLedgerTransaction(
     ])
 
     const parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
-        if (obj.path[0] !== 'created_date' && obj.kind === EDIT) {
-            return true
+        switch (obj.kind) {
+            case EDIT: {
+                if (obj.path[0] !== 'created_date') {
+                    return true
+                } else {
+                    const castedDiffObj = obj as DiffEdit<string>
+                    const lhsDate = moment(castedDiffObj.lhs)
+                    const rhsDate = moment(castedDiffObj.rhs)
+                    return Math.abs(lhsDate.diff(rhsDate)) > 10;
+                }
+            }
+            case DELETED: {
+                const castedDeletedObj = obj as DiffDeleted<string>
+                return castedDeletedObj.lhs != null;
+            }
+            case NEW: {
+                const castedNewObj = obj as DiffNew<string>
+                return castedNewObj.rhs != null;
+            }
         }
-        const castedObj = obj as DiffEdit<string>
-        const lhsDate = moment(castedObj.lhs)
-        const rhsDate = moment(castedObj.rhs)
-        if (Math.abs(lhsDate.diff(rhsDate)) > 10) {
-            return true
-        }
-        return false
     })
-    res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parity, message})
+    let parityDisplay
+    if (parity.length > 0) {
+        const diffEdit = parity.filter((obj) => obj.kind === EDIT)
+        const diffNew = parity.filter((obj) => obj.kind === NEW)
+        const diffDelete = parity.filter((obj) => obj.kind === DELETED)
+        if (diffEdit.length > 0) {
+            parityDisplay = { 'Fields which have different values': diffEdit }
+        }
+        if (diffNew.length > 0) {
+            parityDisplay = { ...parityDisplay, 'Fields missing from Connector': diffNew }
+        }
+        if (diffDelete.length > 0) {
+            parityDisplay = { ...parityDisplay, 'Fields missing from Ledger': diffDelete }
+        }
+    }
+    res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parityDisplay, warningMessage})
   } catch (error) {
     next(error)
   }

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -15,7 +15,7 @@ export async function validateLedgerTransaction(
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
     const connectorEntry = await Connector.charges.retrieveAPI(req.params.id, ledgerEntry.gateway_account_id)
 
-    const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
+      const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
         'gateway_account_id',
         'transaction_id',
         'disputed',

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -13,33 +13,37 @@ export async function validateLedgerTransaction(
 ): Promise<void> {
   try {
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
-    const connectorEntry = await Connector.charges.retrieveAPI(req.params.id, ledgerEntry.gateway_account_id)
+    const connectorEntry = await Connector.charges.parityCheck(req.params.id, ledgerEntry.gateway_account_id)
+    let message
+    if (typeof connectorEntry === 'string') {
+        message = connectorEntry
+    }
 
-      const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
-        'gateway_account_id',
-        'transaction_id',
-        'disputed',
-        'source',
-        'live',
-        'transaction_type',
-        'credential_external_id',
-        'service_id',
-        'refund_summary.amount_refunded',
-        'evidence_due_date',
-        'gateway_payout_id',
-        'parent_transaction_id',
-        'payment_details',
-        'reason'
+    const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
+    'gateway_account_id',
+    'transaction_id',
+    'disputed',
+    'source',
+    'live',
+    'transaction_type',
+    'credential_external_id',
+    'service_id',
+    'refund_summary.amount_refunded',
+    'evidence_due_date',
+    'gateway_payout_id',
+    'parent_transaction_id',
+    'payment_details',
+    'reason'
     ])
     const connectorResponseWithoutConnectorSpecificFields = _.omit(connectorEntry, [
-        'links',
-        'charge_id',
-        'auth_code',
-        'authorised_date',
-        'payment_outcome',
-        'processor_id',
-        'provider_id',
-        'telephone_number'
+    'links',
+    'charge_id',
+    'auth_code',
+    'authorised_date',
+    'payment_outcome',
+    'processor_id',
+    'provider_id',
+    'telephone_number'
     ])
 
     const parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
@@ -54,9 +58,9 @@ export async function validateLedgerTransaction(
         }
         return false
     })
-
-    res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parity })
+    res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parity, message})
   } catch (error) {
     next(error)
   }
+
 }

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -11,9 +11,9 @@
   <div>
     <a href="/transactions/{{ ledgerEntry.transaction_id }}" class="govuk-back-link">Back to transaction ({{ ledgerEntry.transaction_id }})</a>
   </div>
-  {% if connectorEntry.charge_id === 'Not found' %}
+  {% if message %}
     {{ govukWarningText({
-      text: "Charge not found in connector",
+      text: message,
       iconFallbackText: "Warning"
       })
     }}
@@ -78,7 +78,7 @@
 
   {{ json("Ledger source", ledgerEntry) }}
 
-  {% if connectorEntry.charge_id !== 'Not found' %}
+  {% if message === undefined %}
     {{ json("Connector source", connectorEntry) }}
   {% endif %}
 

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -11,69 +11,70 @@
   <div>
     <a href="/transactions/{{ ledgerEntry.transaction_id }}" class="govuk-back-link">Back to transaction ({{ ledgerEntry.transaction_id }})</a>
   </div>
-  {% if message %}
+  {% if warningMessage %}
     {{ govukWarningText({
-      text: message,
+      text: warningMessage,
       iconFallbackText: "Warning"
       })
     }}
   {% else %}
-    {% if parity.length %}
+
+    {% if not parityDisplay %}
+      {{ govukPanel({
+        titleText: "Parity",
+        html: "No meaningful differences found between in-flight and Ledger payment record"
+      })
+      }}
+
+    {% else %}
       {{ govukWarningText({
         text: "Differences found between in-flight and Ledger payment records.",
         iconFallbackText: "Warning"
         })
       }}
-    {% endif %}
-
-    {% if not parity.length %}
-      {{ govukPanel({
-        titleText: "Parity",
-        html: "No meaningful differences found between in-flight and Ledger payment record"
-        })
-      }}
-    {% endif %}
-
-    {% for diff in parity %}
+      <br/>
       <div>
-        <span class="govuk-body-s">
-        {% if diff.kind === "E" %}Mismatched property value
-        {% elif diff.kind === "D" %}<span class="missing-text">Property missing</span>
-        {% elif diff.kind === "N" %}<span class="extra-text">Extra property</span>
-        {% elif diff.kind === "A" %}Mismatched array property values
-        {% endif %}
-        </span>
-        <h4 class="govuk-heading-s">
-          <code>{{ diff.path | join(' > ') }}</code>
-        </h4>
-
-        <table class="govuk-table">
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Connector</span></td>
-              <td class="govuk-table__cell">
-                {% if diff.lhs | isObject %}
-                  {{ diff.lhs | dump | truncate(60) }}
-                {% else %}
-                  {{ diff.lhs }}
-                {% endif %}
-              </td>
-
-            </tr>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Ledger</span></td>
-              <td class="govuk-table__cell">
-                {% if diff.rhs | isObject %}
-                  {{ diff.rhs | dump | truncate(60) }}
-                {% else %}
-                  {{ diff.rhs }}
-                {% endif %}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        {% for kind, diffList in parityDisplay %}
+        <div>
+          <span class="govuk-heading-s">
+          {{ kind }}
+          </span>
+          {% for diff in diffList %}
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code>{{ diff.path | join(' > ') }}</code>
+                  </td>
+                  <td class="govuk-table__cell"></td>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Connector</span></td>
+                  <td class="govuk-table__cell">
+                    {% if diff.lhs | isObject %}
+                      {{ diff.lhs | dump | truncate(60) }}
+                    {% else %}
+                      {{ diff.lhs }}
+                    {% endif %}
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Ledger</span></td>
+                  <td class="govuk-table__cell">
+                    {% if diff.rhs | isObject %}
+                      {{ diff.rhs | dump | truncate(60) }}
+                    {% else %}
+                      {{ diff.rhs }}
+                    {% endif %}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <br/>
+          {% endfor %}
+        </div>
+        {% endfor %}
       </div>
-    {% endfor %}
+      {% endif %}
   {% endif %}
 
   {{ json("Ledger source", ledgerEntry) }}

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "common/json.njk" import json %}
 
 {% extends "layout/layout.njk" %}
@@ -11,9 +12,9 @@
   <div>
     <a href="/transactions/{{ ledgerEntry.transaction_id }}" class="govuk-back-link">Back to transaction ({{ ledgerEntry.transaction_id }})</a>
   </div>
-  {% if warningMessage %}
-    {{ govukWarningText({
-      text: warningMessage,
+  {% if message %}
+    {{ govukInsetText({
+      text: message,
       iconFallbackText: "Warning"
       })
     }}

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -11,64 +11,75 @@
   <div>
     <a href="/transactions/{{ ledgerEntry.transaction_id }}" class="govuk-back-link">Back to transaction ({{ ledgerEntry.transaction_id }})</a>
   </div>
-
-  {% if parity.length %}
+  {% if connectorEntry.charge_id === 'Not found' %}
     {{ govukWarningText({
-      text: "Differences found between in-flight and Ledger payment records.",
+      text: "Charge not found in connector",
       iconFallbackText: "Warning"
       })
     }}
+  {% else %}
+    {% if parity.length %}
+      {{ govukWarningText({
+        text: "Differences found between in-flight and Ledger payment records.",
+        iconFallbackText: "Warning"
+        })
+      }}
+    {% endif %}
+
+    {% if not parity.length %}
+      {{ govukPanel({
+        titleText: "Parity",
+        html: "No meaningful differences found between in-flight and Ledger payment record"
+        })
+      }}
+    {% endif %}
+
+    {% for diff in parity %}
+      <div>
+        <span class="govuk-body-s">
+        {% if diff.kind === "E" %}Mismatched property value
+        {% elif diff.kind === "D" %}<span class="missing-text">Property missing</span>
+        {% elif diff.kind === "N" %}<span class="extra-text">Extra property</span>
+        {% elif diff.kind === "A" %}Mismatched array property values
+        {% endif %}
+        </span>
+        <h4 class="govuk-heading-s">
+          <code>{{ diff.path | join(' > ') }}</code>
+        </h4>
+
+        <table class="govuk-table">
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Connector</span></td>
+              <td class="govuk-table__cell">
+                {% if diff.lhs | isObject %}
+                  {{ diff.lhs | dump | truncate(60) }}
+                {% else %}
+                  {{ diff.lhs }}
+                {% endif %}
+              </td>
+
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Ledger</span></td>
+              <td class="govuk-table__cell">
+                {% if diff.rhs | isObject %}
+                  {{ diff.rhs | dump | truncate(60) }}
+                {% else %}
+                  {{ diff.rhs }}
+                {% endif %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    {% endfor %}
   {% endif %}
-
-  {% if not parity.length %}
-    {{ govukPanel({
-      titleText: "Parity",
-      html: "No meaningful differences found between in-flight and Ledger payment record"
-      })
-    }}
-  {% endif %}
-
-  {% for diff in parity %}
-    <div>
-      <span class="govuk-body-s">
-      {% if diff.kind === "E" %}Mismatched property value
-      {% elif diff.kind === "D" %}<span class="missing-text">Property missing</span>
-      {% elif diff.kind === "N" %}<span class="extra-text">Extra property</span>
-      {% elif diff.kind === "A" %}Mismatched array property values
-      {% endif %}
-      </span>
-      <h4 class="govuk-heading-s">
-        <code>{{ diff.path | join(' > ') }}</code>
-      </h4>
-
-      <table class="govuk-table">
-        <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Connector</span></td>
-            <td class="govuk-table__cell">
-              {% if diff.lhs | isObject %}
-                {{ diff.lhs | dump | truncate(60) }}
-              {% else %}
-                {{ diff.lhs }}
-              {% endif %}
-            </td>
-
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell fixed-cell"><span class="govuk-caption-m">Ledger</span></td>
-            <td class="govuk-table__cell">
-              {% if diff.rhs | isObject %}
-                {{ diff.rhs | dump | truncate(60) }}
-              {% else %}
-                {{ diff.rhs }}
-              {% endif %}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  {% endfor %}
 
   {{ json("Ledger source", ledgerEntry) }}
-  {{ json("Connector source", connectorEntry) }}
+
+  {% if connectorEntry.charge_id !== 'Not found' %}
+    {{ json("Connector source", connectorEntry) }}
+  {% endif %}
+
 {% endblock %}

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -14,8 +14,7 @@
   </div>
   {% if message %}
     {{ govukInsetText({
-      text: message,
-      iconFallbackText: "Warning"
+      text: message
       })
     }}
   {% else %}


### PR DESCRIPTION
Context: The parity check in toolbox compares responses from connector and ledger in relation to a given transaction. It should only check the fields that are common to both responses, highlighting any missing or different fields. If connector returns 404 (charge not found), a message should be displayed rather than an error page.

- Omit some fields which are specific to connector or ledger (i.e. those which are not common to both).
- Handle a 404 from connector by way of a message on the parity check page rather than presenting an error page.
- Improve layout so that differences in values, and missing fields, are shown under separate sub-headings

### **Screenshot: Charge not found in connector:**

![Screenshot 2024-09-18 at 17 50 55](https://github.com/user-attachments/assets/60e5cb8b-fa04-4fd8-8f7c-0b8f5cef0da9)

### **Screenshot: Differences found:**

![Screenshot 2024-09-18 at 17 52 17](https://github.com/user-attachments/assets/07ee1cb3-3e6d-4254-b152-b4074b6b7377)
