### PR TITLE
PP-12854 Add logging for failing parity check

### DIFF
--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -3,6 +3,7 @@ import {diff, DiffDeleted, DiffEdit, DiffNew} from 'deep-diff'
 import { Ledger, Connector } from '../../../../lib/pay-request/client'
 import * as _ from 'lodash'
 import moment from 'moment'
+import logger from "../../../../lib/logger";
 
 enum DiffKind {
     Edit = 'E',
@@ -18,78 +19,84 @@ export async function validateLedgerTransaction(
   try {
     const ledgerEntry = await Ledger.transactions.retrieve(req.params.id)
     const connectorEntry = await Connector.charges.parityCheck(req.params.id, ledgerEntry.gateway_account_id)
-    let message
+    const messages = []
     if (typeof connectorEntry === 'string') {
-        message = connectorEntry
+      messages.push(connectorEntry)
     }
 
     const ledgerResponseWithoutLedgerSpecificFields = _.omit(ledgerEntry, [
-    'gateway_account_id',
-    'transaction_id',
-    'disputed',
-    'source',
-    'live',
-    'transaction_type',
-    'credential_external_id',
-    'service_id',
-    'refund_summary.amount_refunded',
-    'evidence_due_date',
-    'gateway_payout_id',
-    'parent_transaction_id',
-    'payment_details',
-    'reason'
+      'gateway_account_id',
+      'transaction_id',
+      'disputed',
+      'source',
+      'live',
+      'transaction_type',
+      'credential_external_id',
+      'service_id',
+      'refund_summary.amount_refunded',
+      'evidence_due_date',
+      'gateway_payout_id',
+      'parent_transaction_id',
+      'payment_details',
+      'reason'
     ])
     const connectorResponseWithoutConnectorSpecificFields = _.omit(connectorEntry, [
-    'links',
-    'charge_id',
-    'auth_code',
-    'authorised_date',
-    'payment_outcome',
-    'processor_id',
-    'provider_id',
-    'telephone_number'
+      'links',
+      'charge_id',
+      'auth_3ds_data',
+      'auth_code',
+      'authorised_date',
+      'payment_outcome',
+      'processor_id',
+      'provider_id',
+      'telephone_number'
     ])
 
-    const parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
-        switch (obj.kind) {
+    let parity
+    try {
+      parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
+          switch (obj.kind) {
             case DiffKind.Edit: {
-                if (obj.path[0] !== 'created_date') {
-                    return true
-                } else {
-                    const castedDiffObj = obj as DiffEdit<string>
-                    const lhsDate = moment(castedDiffObj.lhs)
-                    const rhsDate = moment(castedDiffObj.rhs)
-                    return Math.abs(lhsDate.diff(rhsDate)) > 5000;
-                }
+              if (obj.path[0] !== 'created_date') {
+                return true
+              } else {
+                const castedDiffObj = obj as DiffEdit<string>
+                const lhsDate = moment(castedDiffObj.lhs)
+                const rhsDate = moment(castedDiffObj.rhs)
+                return Math.abs(lhsDate.diff(rhsDate)) > 5000;
+              }
             }
             case DiffKind.Deleted: {
-                const castedDeletedObj = obj as DiffDeleted<string>
-                return castedDeletedObj.lhs != null;
+              const castedDeletedObj = obj as DiffDeleted<string>
+              return castedDeletedObj.lhs != null;
             }
             case DiffKind.New: {
-                const castedNewObj = obj as DiffNew<string>
-                return castedNewObj.rhs != null;
+              const castedNewObj = obj as DiffNew<string>
+              return castedNewObj.rhs != null;
             }
-        }
-    })
-    let parityDisplay
-    if (parity.length > 0) {
+          }
+        })
+    } catch (e) {
+      logger.warn('Error when comparing responses from connector and ledger', e)
+      messages.push('Error when comparing responses from connector and ledger')
+    }
+      let parityDisplay
+      if (parity && parity.length > 0) {
         const diffEdit = parity.filter((obj) => obj.kind === DiffKind.Edit)
         const diffNew = parity.filter((obj) => obj.kind === DiffKind.New)
         const diffDelete = parity.filter((obj) => obj.kind === DiffKind.Deleted)
         if (diffEdit.length > 0) {
-            parityDisplay = { 'Fields which have different values': diffEdit }
+          parityDisplay = {'Fields which have different values': diffEdit}
         }
         if (diffNew.length > 0) {
-            parityDisplay = { ...parityDisplay, 'Fields missing from Connector': diffNew }
+          parityDisplay = {...parityDisplay, 'Fields missing from Connector': diffNew}
         }
         if (diffDelete.length > 0) {
-            parityDisplay = { ...parityDisplay, 'Fields missing from Ledger': diffDelete }
+          parityDisplay = {...parityDisplay, 'Fields missing from Ledger': diffDelete}
         }
+      }
+      res.render('transactions/discrepancies/validateLedger', {ledgerEntry, connectorEntry, parityDisplay, messages})
+    } catch (error) {
+      next(error)
     }
-    res.render('transactions/discrepancies/validateLedger', { ledgerEntry, connectorEntry, parityDisplay, message})
-  } catch (error) {
-    next(error)
   }
-
-}

--- a/src/web/modules/transactions/discrepancies/validateLedger.njk
+++ b/src/web/modules/transactions/discrepancies/validateLedger.njk
@@ -12,11 +12,13 @@
   <div>
     <a href="/transactions/{{ ledgerEntry.transaction_id }}" class="govuk-back-link">Back to transaction ({{ ledgerEntry.transaction_id }})</a>
   </div>
-  {% if message %}
-    {{ govukInsetText({
-      text: message
-      })
-    }}
+  {% if messages.length %}
+    {% for message in messages %}
+      {{ govukInsetText({
+        text: message
+        })
+      }}
+    {% endfor %}
   {% else %}
 
     {% if not parityDisplay %}
@@ -78,9 +80,6 @@
   {% endif %}
 
   {{ json("Ledger source", ledgerEntry) }}
-
-  {% if message === undefined %}
-    {{ json("Connector source", connectorEntry) }}
-  {% endif %}
+  {{ json("Connector source", connectorEntry) }}
 
 {% endblock %}


### PR DESCRIPTION
Context: Parity check is failing for at least one transaction in production.

- Add logging in the event that the parity check fails to provide further info for investigation
- Also, add `auth_3ds_data` to the list of excluded fields because this field is only ever present in the connector response.