### PR TITLE
PP-12854 Allow for identical responses in parity check

### DIFF
--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -54,7 +54,7 @@ export async function validateLedgerTransaction(
 
     let parity
     try {
-      parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields).filter(obj => {
+      parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields)?.filter(obj => {
           switch (obj.kind) {
             case DiffKind.Edit: {
               if (obj.path[0] !== 'created_date') {


### PR DESCRIPTION
Context: the parity check is failing for at least one payment in connector. This has been traced to a bug in the latest improvements to the parity check. If the responses from connector and ledger are identical, the diff returns `undefined`, which is expected behaviour according to the [npm docs](https://www.npmjs.com/package/deep-diff#diff) but we failed to code for this. This wasn't spotted sooner because in the vast majority of cases there is a small difference in the `created_date` (which creates a valid diff and small differences in created_date are subsequently filtered out).

- if the responses from connector and ledger are identical, don't attempt to filter the `undefined` result from `diff`, just display the page showing that there are no differences.