### PR TITLE
PP-13106 disregard refund summary in parity check for disputes

### DIFF
--- a/src/lib/pay-request/services/ledger/types.ts
+++ b/src/lib/pay-request/services/ledger/types.ts
@@ -54,6 +54,7 @@ export interface Transaction {
   live: boolean;
   parent_transaction_id?: string;
   gateway_transaction_id?: string;
+  disputed?: boolean;
 }
 
 export interface PaymentInstrument {

--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -57,6 +57,9 @@ export async function validateLedgerTransaction(
       parity = diff(connectorResponseWithoutConnectorSpecificFields, ledgerResponseWithoutLedgerSpecificFields)?.filter(obj => {
           switch (obj.kind) {
             case DiffKind.Edit: {
+              if (obj.path[0] === 'refund_summary' && obj.path[1] === 'status' && ledgerEntry.disputed) {
+                return false;
+              }
               if (obj.path[0] !== 'created_date') {
                 return true
               } else {


### PR DESCRIPTION
Context: When Stripe notifies Pay of a dispute, the payment's `refund_status` is updated in ledger. Connector does not have knowledge of disputes, so parity checks will show a discrepancy for `refund_status` for disputed payments. A [previous PR](https://github.com/alphagov/pay-connector/pull/5547) ensured that this would not prevent payments from being expunged from connector. Therefore showing this discrepancy in the toolbox parity check is not helpful.

- Disregard discrepancies in refund_status in parity checks for disputed payments.

This has been manually tested locally using a payment where the `refund_status` has been updated to `unavailable` in ledger and `disputed=true` has been added to the ledger `transaction_details` field.

Before this change, this payment shows the discrepancy in the parity check:

![Screenshot 2024-10-09 at 10 17 30](https://github.com/user-attachments/assets/e17af608-2805-46a8-9bd6-a199f58f1d9a)

After the change, the discrepancy is not shown:

![Screenshot 2024-10-09 at 11 22 36](https://github.com/user-attachments/assets/8189860a-dfe5-4e7c-9284-25bb807c7f51)

To check that any other discrepancies within the `refund_summary` are still considered in the parity check, the value in the `refund_amount_available` field was altered in ledger, and the discrepancy is correctly shown:

![Screenshot 2024-10-09 at 11 07 57](https://github.com/user-attachments/assets/0f238ea1-5705-4063-9387-e4053bb4a01e)




