### PR TITLE
PP-13280 Update pay-js-commons to 6.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-ecs": "~3.623.0",
         "@aws-sdk/client-s3": "~3.623.0",
-        "@govuk-pay/pay-js-commons": "4.0.2",
+        "@govuk-pay/pay-js-commons": "^6.0.15",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "^6.12.0",
         "axios": "^1.7.4",
@@ -3670,10 +3670,11 @@
       "integrity": "sha512-Y8ETZc8afYf6lQ/mVp096phIVsgD/GmDxtm3YaPcc+71jmi/J6zdwbwaUU4JvS56mq6aSfbpkcKhQ5WugrWFPw=="
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.2.tgz",
-      "integrity": "sha512-mPqsrxCyWym+Wb7E+PsOOj9leVdF668ke5z+DsdqyVRXqub8XHG3URjCH7Kddq0y6HmgQ22K+2nwOAvW4JcQmQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.15.tgz",
+      "integrity": "sha512-2Q3JRyXCJwMD1qj/Mwgt47MHLhBLc4cHfhSw1tQVc1eS0MRlPHO6ogJTENzVDtDOxLNYvWc6YH5Gv9rXz2xE2w==",
       "dependencies": {
+        "axios": "^1.6.5",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
         "rfc822-validate": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aws-sdk/client-ecs": "~3.623.0",
     "@aws-sdk/client-s3": "~3.623.0",
-    "@govuk-pay/pay-js-commons": "4.0.2",
+    "@govuk-pay/pay-js-commons": "6.0.15",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "^6.12.0",
     "axios": "^1.7.4",


### PR DESCRIPTION
Update `pay-js-commons` to `v6.0.15`
 - This is a change of two major versions, but should be safe.
 - There are only minimal changes to the code between these versions (diff can be seen [here](https://github.com/alphagov/pay-js-commons/compare/v4.0.2...v6.0.15))
 - The changes almost entirely pertain to the new `axios` client, which is not used as toolbox uses `axios` directly
 - The only uses of `pay-js-commons` in toolbox are `constants.webhooks.humanReadableSubscriptions` and logging formats from `logging`, which do not appear to be impacted by the changes in this upgrade