### PR TITLE
PP-12244: Use Typescript option for CodeQL scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,4 +19,4 @@ jobs:
     name: "Run CodeQL"
     uses: alphagov/pay-ci/.github/workflows/_run-codeql-scan.yml@master
     with:
-      is_node_repo: true
+      is_typescript_repo: true


### PR DESCRIPTION
For Toolbox, the typescript files we want to scan are in a different folder (src).

This PR accompanies the change in https://github.com/alphagov/pay-ci/pull/1322 to adjust the workflow to handle Typescript scans as well as Node.