### PR TITLE
PP-13282 Update express to 4.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-ecs": "~3.623.0",
         "@aws-sdk/client-s3": "~3.623.0",
-        "@govuk-pay/pay-js-commons": "^6.0.15",
+        "@govuk-pay/pay-js-commons": "6.0.15",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "^6.12.0",
         "axios": "^1.7.4",
@@ -22,7 +22,7 @@
         "csurf": "^1.11.0",
         "deep-diff": "1.0.2",
         "dotenv": "16.0.3",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "fast-csv": "^4.3.6",
         "google-libphonenumber": "~3.2.21",
         "govuk-frontend": "^4.8.0",
@@ -9104,16 +9104,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -9145,9 +9145,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "csurf": "^1.11.0",
     "deep-diff": "1.0.2",
     "dotenv": "16.0.3",
-    "express": "4.21.0",
+    "express": "4.21.1",
     "fast-csv": "^4.3.6",
     "google-libphonenumber": "~3.2.21",
     "govuk-frontend": "^4.8.0",


### PR DESCRIPTION
Update `express` to `v4.21.1`
 - this updates the transitive `cookie` dependency to `0.7.0`, which resolves a small vulnerability