### PR TITLE
PP-13300 Remove warning in Toolbox for new Refund fix button

### DIFF
--- a/src/web/modules/transactions/confirmFixAsyncFailedStripeRefund.njk
+++ b/src/web/modules/transactions/confirmFixAsyncFailedStripeRefund.njk
@@ -41,11 +41,6 @@
       autocomplete: "off"
     }) }}
 
-    {{ govukWarningText({
-      text: "This feature is under development and you should NOT press the button yet.",
-      iconFallbackText: "Warning"
-    }) }}
-
     <input type="hidden" name="_csrf" value="{{ csrf }}">
     {{ govukButton({
       text: "Correct asynchronously failed Stripe refund "


### PR DESCRIPTION
With this change, we are delighted to remove the warning from the new button in Toolbox which enables the functionality to fix a refund that failed asynchronously in Stripe.

The functionality has already been used twice on production and it works perfectly.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13300