### PR TITLE
PP-11009 Add page for revoked API keys

### DIFF
--- a/scripts/run-dev
+++ b/scripts/run-dev
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 npm run build:copy
 npm start

--- a/src/lib/pay-request/services/public_auth/client.ts
+++ b/src/lib/pay-request/services/public_auth/client.ts
@@ -1,13 +1,14 @@
-import Client, { PayHooks } from '../../base'
+import Client from '../../base'
 import {
-  ListTokenRequest,
-  ListTokenResponse,
+  CreateTokenRequest,
+  CreateTokenResponse,
   DeleteTokenRequest,
   DeleteTokenResponse,
-  CreateTokenRequest,
-  CreateTokenResponse
+  ListTokenRequest,
+  ListTokenResponse,
+  TokenState
 } from './types'
-import { App } from '../../shared'
+import {App} from '../../shared'
 
 export default class PublicAuth extends Client {
   constructor() {
@@ -20,7 +21,7 @@ export default class PublicAuth extends Client {
      */
     list(params: ListTokenRequest): Promise<ListTokenResponse | undefined> {
       return client._axios
-        .get(`/v1/frontend/auth/${params.gateway_account_id}`)
+        .get(`/v1/frontend/auth/${params.gateway_account_id}`, { params: { state: params.token_state || TokenState.Active } })
         .then(response => client._unpackResponseData<ListTokenResponse>(response));
     },
 

--- a/src/lib/pay-request/services/public_auth/types.ts
+++ b/src/lib/pay-request/services/public_auth/types.ts
@@ -10,6 +10,11 @@ export enum TokenSource {
   Products = 'PRODUCTS'
 }
 
+export enum TokenState {
+  Active = 'ACTIVE',
+  Revoked = 'REVOKED'
+}
+
 export interface Token {
   token_link: string;
   token_type: TokenType;
@@ -22,6 +27,7 @@ export interface Token {
 
 export interface ListTokenRequest {
   gateway_account_id: string;
+  token_state?: TokenState
 }
 
 export interface DeleteTokenRequest {

--- a/src/web/modules/gateway_accounts/api_keys.njk
+++ b/src/web/modules/gateway_accounts/api_keys.njk
@@ -6,7 +6,7 @@
 {% set isTestData = not (account.type === "live") %}
 
 {% block main %}
-  <h1 class="govuk-heading-m">Manage active API keys</h1>
+  <h1 class="govuk-heading-m">Manage active API keys for Gateway account {{ gatewayAccountId }}</h1>
 
   {% for message in messages %}
     <div class="govuk-error-summary success-summary" role="alert">
@@ -17,7 +17,7 @@
   <div>
     <a href="/gateway_accounts/{{ gatewayAccountId }}" class="govuk-back-link">Gateway account ({{ gatewayAccountId }})</a>
   </div>
-  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/revoked_api_keys">View revoked API keys</a></div>
+  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/revoked_api_keys">View revoked API keys for Gateway account {{ gatewayAccountId }}</a></div>
   <br>
 
   {% for token in tokens %}

--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -75,16 +75,31 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><span class="govuk-caption-m">API</span></dt>
         <dd class="govuk-summary-list__value">
-          {% if tokensCount === 0 %}
-            <i>(No API keys configured)</i>
-          {% elif tokensCount === 1 %}
+          {% if activeTokensCount === 0 %}
+            <i>(No active API keys configured)</i>
+          {% elif activeTokensCount === 1 %}
             1 API Key
           {% else %}
-            {{ tokensCount }} API keys
+            {{ activeTokensCount }} active API keys
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage<span class="govuk-visually-hidden"> API keys</span></a>
+          <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage<span class="govuk-visually-hidden">active API keys</span></a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"></dt>
+        <dd class="govuk-summary-list__value">
+          {% if revokedTokensCount === 0 %}
+            <i>(No revoked API keys)</i>
+            {% elif revokedTokensCount === 1 %}
+            1 API Key
+          {% else %}
+            {{ revokedTokensCount }} revoked API keys
+          {% endif %}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/revoked_api_keys">View<span class="govuk-visually-hidden">revoked API keys</span></a>
         </dd>
       </div>
     </dl>

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -317,8 +317,7 @@ async function revokedApiKeys (req: Request, res: Response): Promise<void> {
   res.render('gateway_accounts/revoked_api_keys', {
     account,
     tokens: tokensResponse.tokens,
-    gatewayAccountId,
-    messages: req.flash('info')
+    gatewayAccountId
   })
 }
 

--- a/src/web/modules/gateway_accounts/index.ts
+++ b/src/web/modules/gateway_accounts/index.ts
@@ -29,6 +29,7 @@ export default {
     exceptions: exceptions.detail
   },
   apiKeys: http.apiKeys,
+  revokedApiKeys: http.revokedApiKeys,
   deleteApiKey: http.deleteApiKey,
   surcharge: http.surcharge,
   updateSurcharge: http.updateSurcharge,

--- a/src/web/modules/gateway_accounts/revoked_api_keys.njk
+++ b/src/web/modules/gateway_accounts/revoked_api_keys.njk
@@ -6,7 +6,7 @@
 {% set isTestData = not (account.type === "live") %}
 
 {% block main %}
-  <h1 class="govuk-heading-m">Manage active API keys</h1>
+  <h1 class="govuk-heading-m">Revoked API keys</h1>
 
   {% for message in messages %}
     <div class="govuk-error-summary success-summary" role="alert">
@@ -17,7 +17,7 @@
   <div>
     <a href="/gateway_accounts/{{ gatewayAccountId }}" class="govuk-back-link">Gateway account ({{ gatewayAccountId }})</a>
   </div>
-  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/revoked_api_keys">View revoked API keys</a></div>
+  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage active API keys</a></div>
   <br>
 
   {% for token in tokens %}
@@ -27,6 +27,7 @@
       [ { text: "Token" }, { text: token.token_link } ],
       [ { text: "Issued Date" }, { text: token.issued_date } ],
       [ { text: "Last Used Date" }, { text: token.last_used } ],
+      [ { text: "Revoked Date" }, { text: token.revoked } ],
       [ { text: "Description" }, { text: token.description } ],
       [ { text: "Token Type" }, { text: token.token_type } ],
       [ { text: "Created By" }, { text: token.created_by } ]
@@ -34,16 +35,8 @@
     })
     }}
 
-    <div>
-      {{ govukButton({
-        text: "Revoke API Key",
-        href: "/gateway_accounts/" + gatewayAccountId + "/api_keys/" + token.token_link + "/delete"
-        })
-      }}
-    </div>
-
   {% else %}
-    <p class="govuk-body top-spacer">No Active API keys found for gateway account.</p>
+    <p class="govuk-body top-spacer">No revoked API keys found for gateway account.</p>
   {% endfor %}
 
   {{ json("API tokens source", tokens) }}

--- a/src/web/modules/gateway_accounts/revoked_api_keys.njk
+++ b/src/web/modules/gateway_accounts/revoked_api_keys.njk
@@ -6,7 +6,7 @@
 {% set isTestData = not (account.type === "live") %}
 
 {% block main %}
-  <h1 class="govuk-heading-m">Revoked API keys</h1>
+  <h1 class="govuk-heading-m">Revoked API keys for Gateway account {{ gatewayAccountId }}</h1>
 
   {% for message in messages %}
     <div class="govuk-error-summary success-summary" role="alert">
@@ -17,7 +17,7 @@
   <div>
     <a href="/gateway_accounts/{{ gatewayAccountId }}" class="govuk-back-link">Gateway account ({{ gatewayAccountId }})</a>
   </div>
-  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage active API keys</a></div>
+  <div><a class="govuk-link" href="/gateway_accounts/{{ gatewayAccountId }}/api_keys">Manage active API keys for Gateway account {{ gatewayAccountId }}</a></div>
   <br>
 
   {% for token in tokens %}

--- a/src/web/modules/gateway_accounts/revoked_api_keys.njk
+++ b/src/web/modules/gateway_accounts/revoked_api_keys.njk
@@ -8,12 +8,6 @@
 {% block main %}
   <h1 class="govuk-heading-m">Revoked API keys for Gateway account {{ gatewayAccountId }}</h1>
 
-  {% for message in messages %}
-    <div class="govuk-error-summary success-summary" role="alert">
-      <h2 class="govuk-error-summary__title">{{message}}</h2>
-    </div>
-  {% endfor %}
-
   <div>
     <a href="/gateway_accounts/{{ gatewayAccountId }}" class="govuk-back-link">Gateway account ({{ gatewayAccountId }})</a>
   </div>

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -4,19 +4,20 @@ import {ParsedQs, stringify} from 'qs'
 import logger from '../../../lib/logger'
 import {AdminUsers, Connector, PublicAuth} from '../../../lib/pay-request/client'
 import type {Service} from '../../../lib/pay-request/services/admin_users/types'
+import {GoLiveStage} from "../../../lib/pay-request/services/admin_users/types";
 import {sanitiseCustomBrandingURL} from './branding'
 import GatewayAccountRequest from './gatewayAccountRequest.model'
 import {formatPerformancePlatformCsv} from './performancePlatformCsv'
-import {formatErrorsForTemplate, ClientFormError} from '../common/validationErrorFormat'
+import {ClientFormError, formatErrorsForTemplate} from '../common/validationErrorFormat'
 import UpdateOrganisationFormRequest from './UpdateOrganisationForm'
 import {IOValidationError, ValidationError as CustomValidationError} from '../../../lib/errors'
 import {formatServiceExportCsv} from './serviceExportCsv'
 import {BooleanFilterOption} from '../common/BooleanFilterOption'
-import {ServiceFilters, fetchAndFilterServices, getLiveNotArchivedServices} from './getFilteredServices'
-import {GoLiveStage} from "../../../lib/pay-request/services/admin_users/types";
+import {fetchAndFilterServices, getLiveNotArchivedServices, ServiceFilters} from './getFilteredServices'
 import {providers} from "../../../lib/providers";
 import {CreateGatewayAccountRequest} from "../../../lib/pay-request/services/connector/types";
 import {AccountType} from "../../../lib/pay-request/shared";
+import {TokenState} from "../../../lib/pay-request/services/public_auth/types";
 
 function extractFiltersFromQuery(query: ParsedQs): ServiceFilters {
   return {
@@ -368,7 +369,7 @@ export async function toggleArchiveService(
       const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
 
       serviceGatewayAccounts.map(async account => {
-        const tokensResponse = await PublicAuth.tokens.list({gateway_account_id: account.gateway_account_id})
+        const tokensResponse = await PublicAuth.tokens.list({ gateway_account_id: account.gateway_account_id, token_state: TokenState.Active })
 
         tokensResponse.tokens.map(async token => {
           await PublicAuth.tokens.delete({gateway_account_id: account.gateway_account_id, token_link: token.token_link})

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -65,6 +65,7 @@ router.get('/gateway_accounts/search', auth.secured(PermissionLevel.VIEW_ONLY), 
 router.post('/gateway_accounts/search', auth.secured(PermissionLevel.VIEW_ONLY), gatewayAccounts.searchRequest)
 router.get('/gateway_accounts/:id', auth.secured(PermissionLevel.VIEW_ONLY), gatewayAccounts.detail.http, gatewayAccounts.detail.exceptions)
 router.get('/gateway_accounts/:id/api_keys', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.apiKeys)
+router.get('/gateway_accounts/:id/revoked_api_keys', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.revokedApiKeys)
 router.get('/gateway_accounts/:accountId/api_keys/:tokenId/delete', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.deleteApiKey)
 router.get('/gateway_accounts/:id/block_prepaid_cards', auth.secured(PermissionLevel.VIEW_ONLY), gatewayAccounts.blockPrepaidCards)
 router.post('/gateway_accounts/:id/block_prepaid_cards', auth.secured(PermissionLevel.USER_SUPPORT), gatewayAccounts.updateBlockPrepaidCards)


### PR DESCRIPTION
 - Add page to show revoked API keys with links between active and revoked API key pages
 - Update text on "Delete API key" button to "Revoke API key"
 - Update heading on "Manage API keys" page to "Manage active API keys for Gateway account [ID]"

Links to API key pages on gateway account:
![Screenshot 2024-11-18 at 14-54-34 Toolbox](https://github.com/user-attachments/assets/68e27a3a-d58f-4886-bab9-c6ad977a804d)

New revoked API keys page:
![Screenshot 2024-11-18 at 15-11-52 Toolbox](https://github.com/user-attachments/assets/6cac3e33-0acb-4d92-a68c-4d0b42296503)


Updated active API keys page
![Screenshot 2024-11-18 at 15-11-42 Toolbox](https://github.com/user-attachments/assets/58c26771-e5f9-4294-9fe2-5c05f47091b8)

