### PR TITLE
BAU: Exclude Ledger settled_date field from Parity Checker

### DIFF
--- a/src/web/modules/transactions/discrepancies/validateLedger.http.ts
+++ b/src/web/modules/transactions/discrepancies/validateLedger.http.ts
@@ -38,7 +38,8 @@ export async function validateLedgerTransaction(
       'gateway_payout_id',
       'parent_transaction_id',
       'payment_details',
-      'reason'
+      'reason',
+      'settlement_summary.settled_date'
     ])
     const connectorResponseWithoutConnectorSpecificFields = _.omit(connectorEntry, [
       'links',


### PR DESCRIPTION
The `settled_date` field does not appear in the Connector response, so should be excluded from the Parity Check validator page (see below for a screengrab of how this currently looks):

![Screenshot 2024-11-19 at 12 25 33](https://github.com/user-attachments/assets/8319cc28-fd00-4096-8590-06393fce826a)
