### PR TITLE
PP-11009 Update content on API key pages

### DIFF
--- a/src/web/modules/gateway_accounts/detail.njk
+++ b/src/web/modules/gateway_accounts/detail.njk
@@ -78,7 +78,7 @@
           {% if activeTokensCount === 0 %}
             <i>(No active API keys configured)</i>
           {% elif activeTokensCount === 1 %}
-            1 API Key
+            1 active API Key
           {% else %}
             {{ activeTokensCount }} active API keys
           {% endif %}
@@ -93,7 +93,7 @@
           {% if revokedTokensCount === 0 %}
             <i>(No revoked API keys)</i>
             {% elif revokedTokensCount === 1 %}
-            1 API Key
+            1 revoked API Key
           {% else %}
             {{ revokedTokensCount }} revoked API keys
           {% endif %}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -325,9 +325,9 @@ async function deleteApiKey(req: Request, res: Response): Promise<void> {
   const {accountId, tokenId} = req.params
 
   await PublicAuth.tokens.delete({gateway_account_id: accountId, token_link: tokenId})
-  logger.info(`Deleted API Token with token_link ${tokenId} for Gateway Account ${accountId}`)
+  logger.info(`Revoked API Token with token_link ${tokenId} for Gateway Account ${accountId}`)
 
-  req.flash('info', `Token ${tokenId} successfully deleted`)
+  req.flash('info', `Token ${tokenId} successfully revoked`)
   res.redirect(`/gateway_accounts/${accountId}/api_keys`)
 }
 


### PR DESCRIPTION
 - use "revoked" in place of "deleted" in success banner

![Screenshot 2024-11-21 at 10-39-31 Toolbox](https://github.com/user-attachments/assets/087c166e-1294-4ccb-b742-298b8cf9d07a)

 - update "1 API Key" to "1 active API Key"/"1 revoked API Key" on gateway account page

![Screenshot 2024-11-21 at 10-39-46 Toolbox](https://github.com/user-attachments/assets/dfea31cd-30f2-48e6-a8ec-55c544ad56a7)
