### PR TITLE
PP-13282: Override cookie subdependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4780,6 +4780,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@sentry/node/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -7804,14 +7812,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7986,9 +7986,9 @@
       }
     },
     "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,9 @@
   "overrides": {
     "csurf": {
       "cookie": "0.7.2"
+    },
+    "@sentry/node": {
+      "cookie": "0.7.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,5 +118,10 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-manifest-plugin": "^5.0.0"
+  },
+  "overrides": {
+    "csurf": {
+      "cookie": "0.7.2"
+    }
   }
 }


### PR DESCRIPTION
## WHAT
We're currently blocked on upgrading `@sentry/node` and replacing the deprecated `csurf` package.

To resolve a vulnerability in the `cookie` subdependency of both these packages, I've added in an override. The overrided version 0.7.2 does not have any breaking changes [according to the changelog](https://github.com/jshttp/cookie/releases). 
