### PR TITLE
PP-13510: Slow down the dashboard

### DIFF
--- a/browser/src/dashboard/EventCard.tsx
+++ b/browser/src/dashboard/EventCard.tsx
@@ -75,7 +75,20 @@ interface EventCardProps {
   showAllEvents: boolean
 }
 
-export class EventCard extends React.Component<EventCardProps, {}> {
+export class EventCard extends React.Component<EventCardProps, { shouldShow: boolean, showTimer?: NodeJS.Timer }> {
+  state = {
+    shouldShow: false,
+  }
+
+  componentDidMount() {
+    setTimeout(() => this.setState({ shouldShow: true }))
+  }
+  componentWillUnmount() {
+    // if(this.state.showTimer) {
+        // clearTimeout(this.state.showTimer)
+    // }
+  }
+
   render() {
     const profile = this.props.showAllEvents ? (profileMap[this.props.event.event_type] || DefaultProfile) : DefaultProfile
     const paymentTypeIcon = paymentTypeMap[this.props.event.card_brand] || UnknownIcon
@@ -104,8 +117,9 @@ export class EventCard extends React.Component<EventCardProps, {}> {
     if (this.props.event.is_recent) {
       recentTag = <div style={{ textAlign: 'left', marginBottom: '8px', marginLeft: '8px', marginTop: '16px' }}><span className="govuk-tag govuk-tag--blue">new service</span></div>
     }
+    const showClass = this.state.shouldShow ? 'show' : ''
     return (
-      <div>
+      <div className={ "slide-card slide-fade " + showClass }>
         <OpacitySpring>
           { recentTag }
           <div className="event-card govuk-!-margin-bottom-2" style={{ backgroundColor: profile.backgroundColour }}>

--- a/browser/src/dashboard/EventCard.tsx
+++ b/browser/src/dashboard/EventCard.tsx
@@ -71,18 +71,21 @@ const profileMap: { [key: string]: CardProfile } = {
 }
 
 interface EventCardProps {
-  event: Event
+  event: Event,
+  showAllEvents: boolean
 }
 
 export class EventCard extends React.Component<EventCardProps, {}> {
   render() {
-    const profile = profileMap[this.props.event.event_type] || DefaultProfile
+    const profile = this.props.showAllEvents ? (profileMap[this.props.event.event_type] || DefaultProfile) : DefaultProfile
     const paymentTypeIcon = paymentTypeMap[this.props.event.card_brand] || UnknownIcon
     const paymentProviderIcon = providerLogoMap[this.props.event.payment_provider]
 
     let statusIcon: string
 
-    if (this.props.event.event_type === 'PAYMENT_DETAILS_ENTERED') {
+    if (!this.props.showAllEvents) {
+      statusIcon = paymentTypeIcon
+    } else if (this.props.event.event_type === 'PAYMENT_DETAILS_ENTERED') {
       statusIcon = paymentTypeIcon
     } else if (eventsActiveSuccess.includes(this.props.event.event_type)) {
       statusIcon = StatusSuccessIcon

--- a/browser/src/dashboard/EventListPanel.tsx
+++ b/browser/src/dashboard/EventListPanel.tsx
@@ -10,7 +10,8 @@ interface EventListPanelProps {
   numberOfAggregateSyncs: number,
   events: Event[],
   fetchedServices: boolean,
-  isFetching: boolean
+  isFetching: boolean,
+  showAllEvents: boolean
 }
 
 function LoadingCard(props: any): JSX.Element {
@@ -23,7 +24,7 @@ function LoadingCard(props: any): JSX.Element {
 export class EventListPanel extends React.Component<EventListPanelProps, {}> {
   render() {
     let syncStatus
-    const events = this.props.events.map((event, index) => <EventCard key={event.key} event={event} />)
+    const events = this.props.events.map((event, index) => <EventCard key={event.key} event={event} showAllEvents={this.props.showAllEvents} />)
     
     if(this.props.sync && this.props.sync.pending && this.props.numberOfAggregateSyncs <= 1) {
       syncStatus = <LoadingCard>Sync</LoadingCard>

--- a/browser/src/dashboard/Spring.tsx
+++ b/browser/src/dashboard/Spring.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useSpring, animated, useTransition } from 'react-spring'
+import { useSpring, animated, useTransition, config } from 'react-spring'
 
 // this top level method has to be any type right now as of
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20356
@@ -24,9 +24,12 @@ interface ValueSpringProps {
   formatter: Intl.NumberFormat
 }
 
+// Use configuration preset 'slow' to slow down the £value animations
+// https://react-spring.dev/docs/advanced/config#presets
 export const ValueSpring = (props: ValueSpringProps) => {
   const springProps = useSpring({
-    value: props.value
+    value: props.value,
+    config: config.slow
   })
 
   return (

--- a/browser/src/dashboard/events.ts
+++ b/browser/src/dashboard/events.ts
@@ -7,6 +7,13 @@ const eventsSuccess = [
 
 // only include the first salient successful event - this will mitigate background processes capturing old payments from
 // impacting optimistic numbers
+
+// notes: ideally user approved for capture await service approval would show up on the events feed and "service approved for capture" would change the stats
+// there's an existing behaviour 
+
+// (note notes) if we've increased the aggregate amounts for the "awaiting service approval" event we _shouldn't_ then update it for the service approved for capture, if we haven't then we should but shouldn't show it(?)
+
+// this should probably be done as a separate PR, we have similar mechanisms to avoid double counting it can just updated for this scenario
 export const eventsActiveSuccess = [
   'USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL',
   'USER_APPROVED_FOR_CAPTURE',

--- a/browser/src/dashboard/format.ts
+++ b/browser/src/dashboard/format.ts
@@ -1,6 +1,8 @@
 export const currencyFormatter = new Intl.NumberFormat('en-GB', {
   style: 'currency',
-  currency: 'GBP'
+  currency: 'GBP',
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0
 })
 
 export const numberFormatter = new Intl.NumberFormat('en-GB', {

--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -260,3 +260,23 @@
       transform: rotate(360deg);
   }
 }
+
+.slide-card {
+  height: 0px;
+  // line-height: 75px;
+  transform: translateY(-100px);
+}
+
+.slide-card.slide-fade {
+  transition: all 0.7s ease;
+  opacity: 0;
+}
+
+.slide-card.slide-fade.show {
+  opacity: 1;
+  height: 75px;
+  transform: translateY(0px);
+
+  // temporary - needs to be worked out how this interacts with event-card etc.
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
Builds on @sfount's branch with changes to the live payments dashboard:

- Adds a toggle option to show/hide unsuccessful payment events
- Smoother transition of the event ticker
- Removes the 'pence' on the `Value of complete payments` and `Value of all payments today` stats, to reduce the amount of fast-moving numbers on screen
- Adds the preset `config.slow` to the `ValueSpring` animated component in an effort to slow things down even more