### PR TITLE
ZD6038173 Change `scheme and host` to lowercase when sending to Stripe

### DIFF
--- a/src/web/modules/stripe/account.ts
+++ b/src/web/modules/stripe/account.ts
@@ -13,6 +13,16 @@ interface TOSAcceptance {
   agreement_time: string | number
 }
 
+function normalizeUrl(urlString: string): string {
+  const url = new URL(urlString)
+
+  url.protocol = url.protocol.toLowerCase()
+  url.host = url.host.toLowerCase()
+
+  return url.toString()
+}
+
+
 export async function setupProductionStripeAccount(serviceExternalId: string, stripeAccountDetails: AccountDetails, tosAcceptance: TOSAcceptance): Promise<Stripe.Account> {
   if (!STRIPE_ACCOUNT_API_KEY) {
     throw new CustomValidationError('Stripe API Key was not configured for this Toolbox instance')
@@ -50,7 +60,7 @@ export async function setupProductionStripeAccount(serviceExternalId: string, st
     },
     business_profile: {
       mcc: 9399,
-      url: service.merchant_details.url,
+      url: normalizeUrl(service.merchant_details.url),
       product_description: `Payments for public sector services for organisation ${service.merchant_details.name}`
     },
     capabilities: {


### PR DESCRIPTION
## WHAT
- Stripe doesn't allow upper case (HTTPS://)in URLs. So change the scheme & host to lowercase before sending it to Stripe