### PR TITLE
PP-13672 Fix some issues with payment links pages

### DIFF
--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -26,6 +26,7 @@ export interface Charge {
 }
 
 export interface GatewayAccount {
+  // this may be inconsistent in being returned as either or a string or number
   gateway_account_id: string;
   payment_provider: PaymentProvider;
   type: AccountType;

--- a/src/web/modules/payment_links/detail/detail.http.ts
+++ b/src/web/modules/payment_links/detail/detail.http.ts
@@ -7,7 +7,7 @@ export async function get(req: Request, res: Response, next: NextFunction) {
         const {id} = req.params
         const paymentLink = await Products.products.retrieve(id)
 
-        res.render('payment_links/detail', {
+        res.render('payment_links/detail/detail', {
             paymentLink,
             url: extractFriendlyLink(paymentLink._links),
             messages: req.flash('info'),

--- a/src/web/modules/payment_links/list/list_all.http.ts
+++ b/src/web/modules/payment_links/list/list_all.http.ts
@@ -18,7 +18,7 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
             // is to get a list of all the live account IDs from connector and compare against that
             Connector.accounts.list({type: AccountType.Live})
                 .then((response) => response.accounts)
-                .then(accounts => accounts.map((account: GatewayAccount) => account.gateway_account_id)),
+                .then(accounts => accounts.map((account: GatewayAccount) => `${account.gateway_account_id}`)), // This endpoint actually returns account IDs as numbers, despite the `string` type
             Products.reports.listStats()
         ])
 

--- a/src/web/modules/payment_links/search/search.http.ts
+++ b/src/web/modules/payment_links/search/search.http.ts
@@ -1,7 +1,7 @@
 import {Request, Response} from "express";
 
 export function get(req: Request, res: Response) {
-    res.render('payment_links/search', {csrf: req.csrfToken()})
+    res.render('payment_links/search/search', {csrf: req.csrfToken()})
 }
 
 export function post(req: Request, res: Response) {


### PR DESCRIPTION
PR #1878 introduced a few issues with the payment link pages, with the `detail` and `search` controllers specifying the wrong template path, and the live accounts not being filtered correctly

this fixes these issues