### PR TITLE
PP-13672 Fix account payment links page to properly order links

### DIFF
--- a/src/web/modules/payment_links/account/list_account.http.ts
+++ b/src/web/modules/payment_links/account/list_account.http.ts
@@ -2,6 +2,7 @@ import {NextFunction, Request, Response} from "express";
 import {AdminUsers, Products} from "../../../../lib/pay-request/client";
 import {aggregateServicesByGatewayAccountId} from "../../../../lib/gatewayAccounts";
 import {extractProductData} from "../list/list_all.http";
+import _ from "lodash";
 
 export async function get(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -16,11 +17,12 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
 
         const serviceGatewayAccountIndex = aggregateServicesByGatewayAccountId([service])
         const paymentLinks = extractProductData(productStats, false, [], serviceGatewayAccountIndex)
+        const orderedPaymentLinks = _.orderBy(paymentLinks, sortKey, 'desc')
 
         const context = {
             sort: sortKey,
             accountId,
-            paymentLinks,
+            paymentLinks: orderedPaymentLinks,
             serviceName: service.name,
             used
         }

--- a/src/web/modules/payment_links/account/list_account_csv.http.ts
+++ b/src/web/modules/payment_links/account/list_account_csv.http.ts
@@ -3,6 +3,7 @@ import {extractProductData} from "../list/list_all.http";
 import {format} from "../csv";
 import {AdminUsers, Products} from "../../../../lib/pay-request/client";
 import {aggregateServicesByGatewayAccountId} from "../../../../lib/gatewayAccounts";
+import _ from "lodash";
 
 export async function get(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -17,11 +18,12 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
 
         const serviceGatewayAccountIndex = aggregateServicesByGatewayAccountId([service])
         const paymentLinks = extractProductData(productStats, false, [], serviceGatewayAccountIndex)
+        const orderedPaymentLinks = _.orderBy(paymentLinks, sortKey, 'desc')
 
         const name = accountId
         res.set('Content-Type', 'text/csv')
         res.set('Content-Disposition', `attachment; filename="GOVUK_Pay_payment_links_usage_${name}.csv"`)
-        res.status(200).send(format(paymentLinks))
+        res.status(200).send(format(orderedPaymentLinks))
     } catch (error) {
         next(error)
     }


### PR DESCRIPTION
#1878 introduced a small issue with the ordering of payment links on the account payment links pages not being ordered according to the selected option

This fixes that issue