### PR TITLE
PP-13672 Make type of gateway_account_id on GatewayAccount a number

### DIFF
--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -27,7 +27,7 @@ export interface Charge {
 
 export interface GatewayAccount {
   // this may be inconsistent in being returned as either or a string or number
-  gateway_account_id: string;
+  gateway_account_id: number;
   payment_provider: PaymentProvider;
   type: AccountType;
   description: string;

--- a/src/web/modules/gateway_accounts/csv_data.ts
+++ b/src/web/modules/gateway_accounts/csv_data.ts
@@ -19,9 +19,9 @@ export async function createCsvData(filters: Filters): Promise<any> {
   const servicesByGatewayAccountId = await getServiceGatewayAccountIndex()
 
   return accountsResponse
-    .filter((account: GatewayAccount) => servicesByGatewayAccountId.get(account.gateway_account_id) != undefined)
+    .filter((account: GatewayAccount) => servicesByGatewayAccountId.get(`${account.gateway_account_id}`) != undefined)
     .map((account: GatewayAccount) => {
-      const service = servicesByGatewayAccountId.get(account.gateway_account_id)
+      const service = servicesByGatewayAccountId.get(`${account.gateway_account_id}`)
       return {
         account,
         service,
@@ -40,7 +40,7 @@ export async function createCsvWithAdminEmailsData(filters: Filters): Promise<an
   const accountsResponse = await getAccounts(filters)
   const servicesByGatewayAccountId = await getServiceGatewayAccountIndex()
   const gatewayAccountToAdminEmails =
-    await AdminUsers.users.listAdminEmailsForGatewayAccounts(accountsResponse.map((account: GatewayAccount) => account.gateway_account_id))
+    await AdminUsers.users.listAdminEmailsForGatewayAccounts(accountsResponse.map((account: GatewayAccount) => `${account.gateway_account_id}`))
   const gatewayAccountIndex = accountsResponse.reduce((aggregate: any, account: GatewayAccount) => {
     aggregate[account.gateway_account_id] = account
     return aggregate

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -8,7 +8,7 @@ import stripeTestAccount from '../../stripe/test-account.http'
 
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
   const account = await Connector.accounts.retrieve(req.params.id)
-  const service = await AdminUsers.services.retrieve({gatewayAccountId: account.gateway_account_id})
+  const service = await AdminUsers.services.retrieve({gatewayAccountId: `${account.gateway_account_id}`})
   res.render('gateway_accounts/switch_psp/switch_psp', {account, service, flash: req.flash(), csrf: req.csrfToken()})
 }
 
@@ -55,7 +55,7 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
         // use new stripe account setup and fully configure it for
         const stripeAccount = await stripeTestAccount.createStripeTestAccount(service.service_name.en)
 
-        await Connector.accounts.updateStripeSetup(account.gateway_account_id, {
+        await Connector.accounts.updateStripeSetup(`${account.gateway_account_id}`, {
           bank_account: true,
           company_number: true,
           responsible_person: true,

--- a/src/web/modules/payment_links/list/list_all_csv.http.ts
+++ b/src/web/modules/payment_links/list/list_all_csv.http.ts
@@ -19,7 +19,7 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
             AdminUsers.services.list(),
             Connector.accounts.list({type: AccountType.Live})
                 .then((response) => response.accounts)
-                .then(accounts => accounts.map((account: GatewayAccount) => account.gateway_account_id)),
+                .then(accounts => accounts.map((account: GatewayAccount) => `${account.gateway_account_id}`)),
             Products.reports.listStats()
         ])
         const serviceGatewayAccountIndex = aggregateServicesByGatewayAccountId(services)

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -369,10 +369,10 @@ export async function toggleArchiveService(
       const serviceGatewayAccounts = await getServiceGatewayAccounts(service.gateway_account_ids)
 
       serviceGatewayAccounts.map(async account => {
-        const tokensResponse = await PublicAuth.tokens.list({ gateway_account_id: account.gateway_account_id, token_state: TokenState.Active })
+        const tokensResponse = await PublicAuth.tokens.list({ gateway_account_id: `${account.gateway_account_id}`, token_state: TokenState.Active })
 
         tokensResponse.tokens.map(async token => {
-          await PublicAuth.tokens.delete({gateway_account_id: account.gateway_account_id, token_link: token.token_link})
+          await PublicAuth.tokens.delete({gateway_account_id: `${account.gateway_account_id}`, token_link: token.token_link})
           logger.info(`Deleted API Token with token_link ${token.token_link} for Gateway Account ${account.gateway_account_id}`)
         })
       })

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -195,7 +195,7 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     try {
       const webhooks = await Webhooks.webhooks.list({
         service_id: service.external_id,
-        gateway_account_id: account.gateway_account_id,
+        gateway_account_id: `${account.gateway_account_id}`,
         live: account.type === AccountType.Live
       })
 

--- a/src/web/modules/webhooks/webhooks.http.ts
+++ b/src/web/modules/webhooks/webhooks.http.ts
@@ -46,7 +46,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
 
     const webhooks = await Webhooks.webhooks.list({
       service_id: service.external_id,
-      gateway_account_id: account.gateway_account_id,
+      gateway_account_id: `${account.gateway_account_id}`,
       live: account.type === AccountType.Live
     })
 


### PR DESCRIPTION
The type of `gateway_account_id` on the `GatewayAccount` type was listed as `string`, however in many cases it is returned by Connector as a number. Since types are not enforced at runtime, the type of `gateway_account_id` would be `number` in cases where it is returned as a number by Connector. This causes some issues where it is expected to be a string, but these are not picked up at compile time.

Changing the type on the object to `number` requires that it be explicitly converted to a string in cases where it is being used as a string.