### PR TITLE
PP-12022 Upgrade to govuk-frontend V5

### DIFF
--- a/browser/src/dashboard/Dashboard.tsx
+++ b/browser/src/dashboard/Dashboard.tsx
@@ -482,7 +482,7 @@ export class Dashboard extends React.Component<DashboardProps, DashboardState> {
                   </span>
                 </div>
                 <div className="govuk-header__content" style={{ paddingTop: "2px" }}>
-                  <a href="#" className="govuk-header__link govuk-header__link--service-name govuk-header__service-name">{ this.state.date.format("D MMMM YYYY") }</a>
+                  <a href="#" className="govuk-header__link govuk-header__service-name">{ this.state.date.format("D MMMM YYYY") }</a>
                 </div>
               </div>
             </header>
@@ -522,7 +522,7 @@ export class Dashboard extends React.Component<DashboardProps, DashboardState> {
         </div>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-full govuk-body">
-          <details className="govuk-details" data-module="govuk-details">
+          <details className="govuk-details" >
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
                 Display options

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express": "4.21.2",
         "fast-csv": "^4.3.6",
         "google-libphonenumber": "~3.2.21",
-        "govuk-frontend": "^4.8.0",
+        "govuk-frontend": "^5.9.0",
         "helmet": "^7.0.0",
         "http-errors": "^2.0.0",
         "https-proxy-agent": "5.0.1",
@@ -9393,9 +9393,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": "4.21.2",
     "fast-csv": "^4.3.6",
     "google-libphonenumber": "~3.2.21",
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^5.9.0",
     "helmet": "^7.0.0",
     "http-errors": "^2.0.0",
     "https-proxy-agent": "5.0.1",

--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -1,5 +1,8 @@
 /*  @TODO(sfount) only import scss from frontend that is required */
-@import "govuk-frontend/govuk/all";
+$govuk-suppressed-warnings: legacy-organisation-colours;
+
+@import "govuk-frontend/dist/govuk/index";
+
 
 .success-summary {
   border-color: govuk-colour("green");

--- a/src/web/modules/agreements/detail.njk
+++ b/src/web/modules/agreements/detail.njk
@@ -91,7 +91,7 @@
       {% if event.data %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell" colspan="2">
-          <details class="govuk-details" data-module="govuk-details">
+          <details class="govuk-details">
             <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
                     Event details

--- a/src/web/modules/common/json.njk
+++ b/src/web/modules/common/json.njk
@@ -1,6 +1,6 @@
 {% macro json(title, content) %}
   <div class="govuk-body">
-    <details class="govuk-details" data-module="govuk-details">
+    <details class="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
           {{ title }}

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.njk
@@ -72,7 +72,7 @@
     {{ govukButton({ text: "Enable provider switching" }) }}
   </form>
 
-  <script src="/javascripts/govuk-frontend.js"></script>
-  <script>GOVUKFrontend.initAll()</script>
+  <script type="module" src="/javascripts/govuk-frontend.js"></script>
+  <script type="module">GOVUKFrontend.initAll()</script>
 {% endblock %}
 

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -136,7 +136,7 @@
           {% if isTestData %}
           <div class="test-data-banner govuk-body govuk-!-margin-bottom-2">
             <div class="test-data-tag">
-              <strong>TEST DATA</strong>
+              Test data
             </div>
           </div>
           {% endif %}

--- a/src/web/modules/stripe/success.njk
+++ b/src/web/modules/stripe/success.njk
@@ -22,7 +22,7 @@
  <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
+    <span class="govuk-visually-hidden">Warning</span>
     This Stripe account was created for a service, continue to create the GOV.UK Pay Gateway Account
   </strong>
  </div>

--- a/src/web/modules/transactions/dispute.njk
+++ b/src/web/modules/transactions/dispute.njk
@@ -102,7 +102,7 @@
         {% if event.data %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="2">
-            <details class="govuk-details" data-module="govuk-details">
+            <details class="govuk-details">
               <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
                   Event details

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -283,7 +283,7 @@
         {% if event.data %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="2">
-            <details class="govuk-details" data-module="govuk-details">
+            <details class="govuk-details">
               <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
                   Event details

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -90,7 +90,7 @@
       {% if event.data %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="2">
-            <details class="govuk-details" data-module="govuk-details">
+            <details class="govuk-details">
               <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
                   Event details

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -81,9 +81,9 @@ function configureRequestParsing(instance) {
 function configureServingPublicStaticFiles(instance) {
   const cache = { maxage: '1y' }
   instance.use('/public', express.static(path.join(__dirname, '../public'), cache))
-  instance.use('/assets/fonts', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/assets/fonts'), cache))
-  instance.use('/images/favicon.ico', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/assets/images/', 'favicon.ico'), cache))
-  instance.use('/javascripts/govuk-frontend.js', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/govuk/all.js'), cache))
+  instance.use('/assets/fonts', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/dist/govuk/assets/fonts'), cache))
+  instance.use('/images/favicon.ico', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/dist/govuk/assets/images/', 'favicon.ico'), cache))
+  instance.use('/javascripts/govuk-frontend.js', express.static(path.join(process.cwd(), 'node_modules/govuk-frontend/dist/govuk/all.bundle.js'), cache))
   instance.use('/assets/logos', express.static(path.join(process.cwd(), 'src/assets/logos'), cache))
 }
 
@@ -120,7 +120,7 @@ async function configureTemplateRendering(instance) {
   const templateRendererConfig = { autoescape: true, express: instance }
 
   // include both templates from this repository and from govuk frontend
-  const templatePathRoots = [path.join(process.cwd(), 'node_modules/govuk-frontend'), path.join(__dirname, 'modules')]
+  const templatePathRoots = [path.join(process.cwd(), 'node_modules/govuk-frontend/dist'), path.join(__dirname, 'modules')]
   const templaterEnvironment = nunjucks.configure(templatePathRoots, templateRendererConfig)
 
   // make static manifest details available to all templates


### PR DESCRIPTION
- Upgrade as per release notes:  https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0
- Main visual way to see that we have upgraded is by looking at the tags - see screenshot below.
- Also had to do a minor update to the dashboard.
- Updated the `Test data` orange tag so that it is in sentance case.  Better for accessibility.

# New tags

<img width="773" alt="image" src="https://github.com/user-attachments/assets/b3b8acfc-0c6f-49c0-b246-6750640bf450" />

# Make the orange `Test data` tag text sentence case.

<img width="996" alt="image" src="https://github.com/user-attachments/assets/524f44f2-3fe5-4952-8572-dddfa57695c3" />
