### PR TITLE
PP-12022 V5 - fix agreement tags

### DIFF
--- a/src/web/modules/agreements/status.macro.njk
+++ b/src/web/modules/agreements/status.macro.njk
@@ -12,5 +12,5 @@
 } %}
 
 {% macro agreementStatusTag(status) %}
-<strong class="govuk-tag {{ statusStyleMap[status] }}">{{ statusTextMap[status] }}</strong>
+<span class="govuk-tag {{ statusStyleMap[status] }}">{{ statusTextMap[status] | capitalize }}</span>
 {% endmacro %}


### PR DESCRIPTION
- Update code for displaying tags on agreements pages - so that it is in sentence case and complies with V5 govuk-frontend guidelines.