### PR TITLE
PP-12022 Update `test data` banner

### DIFF
--- a/src/assets/payuk-toolbox.scss
+++ b/src/assets/payuk-toolbox.scss
@@ -214,7 +214,6 @@ $govuk-suppressed-warnings: legacy-organisation-colours;
 
 .test-data-banner {
   text-align: center;
-  border-top: 5px solid govuk-colour("orange");
   z-index: 10;
 }
 
@@ -223,16 +222,6 @@ $govuk-suppressed-warnings: legacy-organisation-colours;
   .test-data-banner {
     margin-top: -#{govuk-spacing(4)};
   }
-}
-
-.test-data-tag {
-  position: relative;
-  display: inline-block;
-  padding: 2px;
-  padding-right: 8px;
-  padding-left: 8px;
-  background-color: govuk-colour("orange");
-  color: govuk-colour("white")
 }
 
 .stripe-go-live-url-table-cell{

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -134,10 +134,8 @@
 
         <div class="govuk-grid-column-three-quarters">
           {% if isTestData %}
-          <div class="test-data-banner govuk-body govuk-!-margin-bottom-2">
-            <div class="test-data-tag">
+          <div class="test-data-banner govuk-body govuk-tag--orange govuk-!-margin-bottom-4">
               Test data
-            </div>
           </div>
           {% endif %}
           {% block main %}


### PR DESCRIPTION
- Make the contrast ratio of the colours accessible.
- Update the styling so that it goet all the way across the screen.

# New `test data` banner

![image](https://github.com/user-attachments/assets/b9c21e51-aef0-4459-856c-b4a057751b12)
