### PR TITLE
PP-13826 highlight accounts that will be shown to degatewayed services

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -102,6 +102,19 @@ export default class Connector extends Client {
         },
 
         /**
+         * Get gateway account by service external ID and account type
+         * @param serviceExternalId - Service external ID
+         * @param accountType - Gateway account type
+         * @returns Gateway account object
+         */
+        retrieveByServiceExternalIdAndAccountType(serviceExternalId: string, accountType: string): Promise<GatewayAccount | undefined> {
+            return client._axios
+                .get(`/v1/api/service/${serviceExternalId}/account/${accountType}`)
+                .then(response => client._unpackResponseData<GatewayAccount>(response))
+                .catch(handleEntityNotFound("Account by service external ID and account Type", `${serviceExternalId}:${accountType}`));
+        },
+
+        /**
          * Fetch Stripe credentials map for a given gateway account. If the gateway
          * account doesn't have Stripe credentials this route will return not found.
          * @param id - Gateway account ID

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "common/json.njk" import json %}
 
 {% extends "layout/layout.njk" %}
@@ -24,6 +25,15 @@
   {% for message in messages %}
     <div class="govuk-error-summary success-summary" role="alert">
       <h2 class="govuk-error-summary__title">{{ message }}</h2>
+    </div>
+  {% endfor %}
+
+  {% for error in misconfiguredServiceErrors %}
+    <div class="govuk-error-summary" role="alert">
+      <h2 class="govuk-error-summary__title">Service is misconfigured</h2>
+      <div class="govuk-error-summary__body">
+        {{ error }}
+      </div>
     </div>
   {% endfor %}
 
@@ -67,7 +77,8 @@
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col" colspan="2">Gateway accounts</th>
+        <th class="govuk-table__header" scope="col">Gateway accounts</th>
+        <th class="govuk-table__header" scope="col">Visible to service</th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -77,6 +88,11 @@
             <a class="govuk-link govuk-link--no-visited-state"
                href="/gateway_accounts/{{ account.gateway_account_id }}">{{ account.payment_provider }}
               ({{ account.type }})</a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ govukTag({
+              text: "Visible"
+            }) if account.gateway_account_id === testGatewayAccount.gateway_account_id or account.type | lower === 'live'  }}
           </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
###  What
- adds a tag to show which accounts are shown to services following degatewayaccountification
- this should aid support work by making it easy to determine which test account a service is using
- also adds an error to the service page if the test account returned by connector is not associated with the service in adminusers

screenshots:
![Screenshot 2025-03-24 at 11-36-14 Toolbox](https://github.com/user-attachments/assets/3deaf6f8-34ae-4b26-857e-910276cd85bd)
![Screenshot 2025-03-24 at 11-36-03 Toolbox](https://github.com/user-attachments/assets/7dfd638e-b407-459d-bbda-ad5cfdc98e92)
![Screenshot 2025-03-24 at 11-35-23 Toolbox](https://github.com/user-attachments/assets/9f990c06-aadc-4e50-9a25-283a05ff5a20)
![Screenshot 2025-03-24 at 11-35-45 Toolbox](https://github.com/user-attachments/assets/3cd31d62-bd97-4387-b138-4e23f2bdcb42)
