### PR TITLE
PP-13826 Include gateway account ID in misconfigured service error message

### DIFF
--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -103,7 +103,7 @@ export async function detail(req: Request, res: Response, next: NextFunction): P
 
     const misconfiguredServiceErrors = []
     if (!serviceGatewayAccounts.some(account => account.gateway_account_id === testGatewayAccount.gateway_account_id)) {
-      misconfiguredServiceErrors.push("The test Gateway Account returned by Connector is not associated with this service in Adminusers. If this is not an internal Pay service, this needs to be fixed")
+      misconfiguredServiceErrors.push(`The test Gateway Account (${testGatewayAccount.gateway_account_id}) returned by Connector is not associated with this service in Adminusers. If this is not an internal Pay service, this needs to be fixed`)
     }
 
     const adminEmails = userDetails


### PR DESCRIPTION
### What
 - Add the gateway account ID to the error message added in #1890 

![Screenshot 2025-03-28 at 11-19-18 Toolbox](https://github.com/user-attachments/assets/48ebafbc-491d-4972-b542-1af546c89daf)
