### PR TITLE
PP-13826 Fix error message shown when no test account is found

### DIFF
--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -101,6 +101,7 @@ export async function detail(req: Request, res: Response, next: NextFunction): P
         Connector.accounts.retrieveByServiceExternalIdAndAccountType(serviceId, 'test')
             .catch(e => {
               if (e instanceof EntityNotFoundError) {
+                // don't 404 if no test account is found, show a misconfigured service error instead
                 return null
               } else {
                 throw e

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -10,7 +10,7 @@ import GatewayAccountRequest from './gatewayAccountRequest.model'
 import {formatPerformancePlatformCsv} from './performancePlatformCsv'
 import {ClientFormError, formatErrorsForTemplate} from '../common/validationErrorFormat'
 import UpdateOrganisationFormRequest from './UpdateOrganisationForm'
-import {IOValidationError, ValidationError as CustomValidationError} from '../../../lib/errors'
+import {EntityNotFoundError, IOValidationError, ValidationError as CustomValidationError} from '../../../lib/errors'
 import {formatServiceExportCsv} from './serviceExportCsv'
 import {BooleanFilterOption} from '../common/BooleanFilterOption'
 import {fetchAndFilterServices, getLiveNotArchivedServices, ServiceFilters} from './getFilteredServices'
@@ -99,10 +99,19 @@ export async function detail(req: Request, res: Response, next: NextFunction): P
     const [serviceGatewayAccounts, testGatewayAccount] = await Promise.all([
         getServiceGatewayAccounts(service.gateway_account_ids),
         Connector.accounts.retrieveByServiceExternalIdAndAccountType(serviceId, 'test')
+            .catch(e => {
+              if (e instanceof EntityNotFoundError) {
+                return null
+              } else {
+                throw e
+              }
+            })
     ])
 
     const misconfiguredServiceErrors = []
-    if (!serviceGatewayAccounts.some(account => account.gateway_account_id === testGatewayAccount.gateway_account_id)) {
+    if (!testGatewayAccount) {
+      misconfiguredServiceErrors.push('No test Gateway Account was returned by Connector')
+    } else if (!serviceGatewayAccounts.some(account => account.gateway_account_id === testGatewayAccount.gateway_account_id)) {
       misconfiguredServiceErrors.push(`The test Gateway Account (${testGatewayAccount.gateway_account_id}) returned by Connector is not associated with this service in Adminusers. If this is not an internal Pay service, this needs to be fixed`)
     }
 


### PR DESCRIPTION
This fixes a bug introduced in #1890 where if Connector returned no test account for a service, toolbox would only show an error

This instead shows a warning that no test account was found

New view:
![Screenshot 2025-04-08 at 10-35-58 Toolbox](https://github.com/user-attachments/assets/ca078999-a933-4a43-bf1e-d961bb0d7d1f)

old view:
![Screenshot 2025-04-08 at 10-47-39 Toolbox](https://github.com/user-attachments/assets/f5227563-44ba-453e-9f5a-c30108fd8253)
