### PR TITLE
PP-13526 Use /account/<id>/dashboard URL for selfservice link in go-live

### DIFF
--- a/src/web/modules/gateway_accounts/createSuccess.njk
+++ b/src/web/modules/gateway_accounts/createSuccess.njk
@@ -44,7 +44,7 @@ A {{ account.type | upper }} Gateway account has been created through Admin User
             ]
             if isStripe else
             [
-                [ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/service/" + linkedService + "/dashboard/live", classes: "stripe-go-live-url-table-cell"  } ]
+                [ { text: "***GO_LIVE_URL***" }, { text: selfServiceBaseUrl + "/account/" + account.external_id + "/dashboard", classes: "stripe-go-live-url-table-cell"  } ]
             ]
             })
     }}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -134,11 +134,7 @@ async function confirm(req: Request, res: Response, next: NextFunction): Promise
   }
 }
 
-function getGoLiveUrlForServiceUsingWorldpay(serviceId: string) {
-  return `${config.services.SELFSERVICE_URL}/service/${serviceId}/dashboard/live`
-}
-
-function getGoLiveUrlForServiceUsingStripe(gatewayAccountExternalId: string) {
+function getGoLiveUrlForService(gatewayAccountExternalId: string) {
   return `${config.services.SELFSERVICE_URL}/account/${gatewayAccountExternalId}/dashboard`
 }
 
@@ -198,9 +194,9 @@ async function writeAccount(req: Request, res: Response): Promise<void> {
 
   let zendeskTicketUpdated = false
   if (account.provider === PaymentProvider.Worldpay && ticket) {
-    zendeskTicketUpdated = await updateTicketWithWorldpayGoLiveResponse(ticket, getGoLiveUrlForServiceUsingWorldpay(serviceId));
+    zendeskTicketUpdated = await updateTicketWithWorldpayGoLiveResponse(ticket, getGoLiveUrlForService(createdAccount.external_id));
   } else if (account.provider === PaymentProvider.Stripe && ticket) {
-    zendeskTicketUpdated = await updateTicketWithStripeGoLiveResponse(ticket, getGoLiveUrlForServiceUsingStripe(createdAccount.external_id),
+    zendeskTicketUpdated = await updateTicketWithStripeGoLiveResponse(ticket, getGoLiveUrlForService(createdAccount.external_id),
       stripeAccountStatementDescriptors.statementDescriptor, stripeAccountStatementDescriptors.payoutStatementDescriptor);
   }
 


### PR DESCRIPTION
### What
- when putting a service live, always link to `/account/<external ID>/dashboard` for the live account in selfservice, rather than linking to `/dashboard/live` for Worldpay accounts
- the URL `/dashboard/live` goes nowhere, always redirecting to `/my-services`
- this is due to a bug in selfservice, however this URL is not necessary - the intention in selfservice was that navigating to `/dashboard/live` would redirect to `/account/<external ID>/dashboard` for the live account, however the account ID is known at this point in toolbox, so this redirect is not necessary, and we can simply use the `/account/<external ID>/dashboard` URL