### PR TITLE
PP-13757: Disable 'Correct asynchronously...' button if refund is not…

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -32,6 +32,26 @@ export default class Connector extends Client {
         super(App.Connector)
     }
 
+    refunds = ((client: Connector) => ({
+
+        /**
+         * @param refundExternalId
+         * @param parentExternalId
+         * @param gatewayAccountId
+         */
+        async doesRefundExist(refundExternalId: string, parentExternalId: string, gatewayAccountId: string): Promise<boolean> {
+            const response = await client._axios.get(
+                `/v1/api/accounts/${gatewayAccountId}/charges/${parentExternalId}/refunds/${refundExternalId}`,
+                { validateStatus: status => [404,200].includes(status) },)
+            switch (response.status) {
+                case 404: return false
+                case 200: return true
+                default:
+                    throw new Error('Should not have reached here')
+            }
+        }
+    }))(this)
+
     charges = ((client: Connector) => ({
         /**
          * Fetch an in-flight payment

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -114,11 +114,21 @@
 {{ json("Transaction source", transaction) }}
 
 <div>
-  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") %}
+  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and refundExpunged %}
     {{ govukButton({
       text: "Correct asynchronously failed Stripe refund",
       classes: "govuk-button--warning",
       href: "/confirm-fix-async-failed-stripe-refund/" + transaction.transaction_id
+    }) }}
+  {% endif %}
+  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and not refundExpunged %}
+    <div class="govuk-body govuk-!-margin-bottom-4">
+      Cannot asynchronously correct Stripe refund as it is not expunged from Connector microservice. Come back later.
+    </div>
+    {{ govukButton({
+      text: "Correct asynchronously failed Stripe refund",
+      disabled: true,
+      classes: "govuk-button--warning"
     }) }}
   {% endif %}
 


### PR DESCRIPTION
… expunged

If refund is corrected asynchonously whilst it is not expunged from connector, correction events will be emitted to ledger as normal but not connector, leading to parity check failures and a failure to expunge from connector.

## Screenshots

### Button disabled

<img width="866" alt="button disabled" src="https://github.com/user-attachments/assets/f9997392-0b38-4d5d-ad42-a2441be498e3" />

### Button not disabled

<img width="844" alt="button not disabled" src="https://github.com/user-attachments/assets/59c26f40-363e-400f-a85f-43530c8e81f2" />
