### PR TITLE
PP-13984 Upgrade pay-toolbox with latest pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-ecs": "~3.623.0",
         "@aws-sdk/client-s3": "~3.623.0",
-        "@govuk-pay/pay-js-commons": "^7.0.1",
+        "@govuk-pay/pay-js-commons": "^7.0.2",
         "@govuk-pay/pay-js-metrics": "^1.0.13",
         "@sentry/node": "^6.12.0",
         "axios": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aws-sdk/client-ecs": "~3.623.0",
     "@aws-sdk/client-s3": "~3.623.0",
-    "@govuk-pay/pay-js-commons": "^7.0.1",
+    "@govuk-pay/pay-js-commons": "^7.0.2",
     "@govuk-pay/pay-js-metrics": "^1.0.13",
     "@sentry/node": "^6.12.0",
     "axios": "^1.8.3",


### PR DESCRIPTION
## What

With this change, we are updating pay-toolbox to use the new pay-js-commons.

We are also updating the version for pay-js-metrics.