### PR TITLE
PP-12428 reset stripe onboarding when enabling psp switch for account

### DIFF
--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -6,6 +6,19 @@ import logger from "../../../../lib/logger";
 
 import stripeTestAccount from '../../stripe/test-account.http'
 
+async function setConnectorStripeSetup(gatewayAccountId: string, isTest: boolean) {
+  const defaultValue = isTest
+  await Connector.accounts.updateStripeSetup(gatewayAccountId, {
+          bank_account: defaultValue,
+          company_number: defaultValue,
+          responsible_person: defaultValue,
+          vat_number: defaultValue,
+          director: defaultValue,
+          organisation_details: defaultValue,
+          government_entity_document: defaultValue
+        })
+}
+
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
   const account = await Connector.accounts.retrieve(req.params.id)
   const service = await AdminUsers.services.retrieve({gatewayAccountId: `${account.gateway_account_id}`})
@@ -50,20 +63,13 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
         const accountDetails = new AccountDetails(req.body)
         const tosAcceptance = {ip_address: req.ip, agreement_time: Date.now()}
         const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, tosAcceptance)
+        // in the niche case where a gateway account was Stripe in the past, reset the onboarding steps
+        await setConnectorStripeSetup(account.gateway_account_id.toString(), false)
         stripeCredentials = {stripe_account_id: stripeAccount.id}
       } else {
         // use new stripe account setup and fully configure it for
         const stripeAccount = await stripeTestAccount.createStripeTestAccount(service.service_name.en)
-
-        await Connector.accounts.updateStripeSetup(`${account.gateway_account_id}`, {
-          bank_account: true,
-          company_number: true,
-          responsible_person: true,
-          vat_number: true,
-          director: true,
-          organisation_details: true,
-          government_entity_document: true
-        })
+        await setConnectorStripeSetup(account.gateway_account_id.toString(), true)
         stripeCredentials = {stripe_account_id: stripeAccount.id}
       }
     }

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -6,16 +6,16 @@ import logger from "../../../../lib/logger";
 
 import stripeTestAccount from '../../stripe/test-account.http'
 
-async function setConnectorStripeSetup(gatewayAccountId: string, isTest: boolean) {
-  const defaultValue = isTest
+async function updateConnectorStripeOnboardingSteps(gatewayAccountId: string, operation: 'complete' | 'reset') {
+  const addOrRemove = operation === 'complete' ? true : false
   await Connector.accounts.updateStripeSetup(gatewayAccountId, {
-          bank_account: defaultValue,
-          company_number: defaultValue,
-          responsible_person: defaultValue,
-          vat_number: defaultValue,
-          director: defaultValue,
-          organisation_details: defaultValue,
-          government_entity_document: defaultValue
+          bank_account: addOrRemove,
+          company_number: addOrRemove,
+          responsible_person: addOrRemove,
+          vat_number: addOrRemove,
+          director: addOrRemove,
+          organisation_details: addOrRemove,
+          government_entity_document: addOrRemove
         })
 }
 
@@ -64,12 +64,12 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
         const tosAcceptance = {ip_address: req.ip, agreement_time: Date.now()}
         const stripeAccount = await setupProductionStripeAccount(service.external_id, accountDetails, tosAcceptance)
         // in the niche case where a gateway account was Stripe in the past, reset the onboarding steps
-        await setConnectorStripeSetup(account.gateway_account_id.toString(), false)
+        await updateConnectorStripeOnboardingSteps(account.gateway_account_id.toString(), 'reset')
         stripeCredentials = {stripe_account_id: stripeAccount.id}
       } else {
         // use new stripe account setup and fully configure it for
         const stripeAccount = await stripeTestAccount.createStripeTestAccount(service.service_name.en)
-        await setConnectorStripeSetup(account.gateway_account_id.toString(), true)
+        await updateConnectorStripeOnboardingSteps(account.gateway_account_id.toString(), 'complete')
         stripeCredentials = {stripe_account_id: stripeAccount.id}
       }
     }


### PR DESCRIPTION
### What

- when enabling psp switch on a worldpay account, ensure that stripe onboarding is reset