### PR TITLE
ZD-6110472 Show service roles on User page

### DIFF
--- a/src/web/modules/transactions/dispute.njk
+++ b/src/web/modules/transactions/dispute.njk
@@ -83,7 +83,7 @@
           <td class="govuk-table__cell payment__cell">{{ transaction.gateway_transaction_id }}</td>
         </tr>
         {% endif %}
-      </tobdy>
+      </tbody>
     </table>
   </div>
 

--- a/src/web/modules/users/users.show.njk
+++ b/src/web/modules/users/users.show.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "common/json.njk" import json %}
 {% extends "layout/layout.njk" %}
 
@@ -63,6 +64,11 @@
       <a class="govuk-link govuk-link--no-visited-state" href="/services/{{ role.service.external_id }}">
         {{ role.service.name }}
       </a>
+    </dd>
+    <dd>
+      {{ govukTag({
+        text: role.role.name
+      }) }}
     </dd>
     <dd class="govuk-summary-list__value">
       <code title="{{ role.service.external_id }}">{{ role.service.external_id | truncate(10) }}</code>


### PR DESCRIPTION
### What
- add tags to show user's role on each service on User page

![Screenshot 2025-05-07 at 14 03 43](https://github.com/user-attachments/assets/75cbf208-a3cb-4050-af2a-2ee7b5ae019c)
