### PR TITLE
BAU — Remove rogue ‘g’ from refund page

### DIFF
--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -107,7 +107,7 @@
       <div class="center bottom-spacer"><span class="govuk-caption-m">No events</span></div>
     {% endfor %}
     </tbody>
-  </table>g
+  </table>
 </div>
 
 {{ json("Transaction source", transaction) }}


### PR DESCRIPTION
This is annoying me.