### PR TITLE
PP-14146 toolbox uses refund template to display dispute

### DIFF
--- a/src/lib/pay-request/shared.ts
+++ b/src/lib/pay-request/shared.ts
@@ -86,7 +86,8 @@ export interface State<T> {
 
 export enum TransactionType {
   Payment = 'PAYMENT',
-  Refund = 'REFUND'
+  Refund = 'REFUND',
+  Dispute = 'DISPUTE'
 }
 
 export enum ResourceType {

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -110,7 +110,6 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
       ...accountId && {account_id: Number(accountId)},
       ...transactionType === TransactionType.Payment && {payment_states: resolvePaymentStates(selectedStatus)},
       ...transactionType === TransactionType.Refund && {refund_states: resolveRefundStates(selectedStatus)},
-      ...transactionType === TransactionType.Dispute && {dispute_states: resolveRefundStates(selectedStatus)},
       ...filters
     })
 
@@ -211,13 +210,13 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
       logger.warn('Failed to fetch webhooks data for the payments page', webhooksError)
     }
 
-    const renderKey = transaction.transaction_type.toLowerCase()
-
     if (transaction.gateway_transaction_id && account.payment_provider === 'stripe') {
       stripeDashboardUri = `https://dashboard.stripe.com/${transaction.live ? '' : 'test/'}payments/${transaction.gateway_transaction_id}`
     }
 
-    if (renderKey === 'payment') {
+    const renderKey = transaction.transaction_type
+
+    if (renderKey === TransactionType.Payment) {
       res.render(`transactions/payment`, {
         transaction,
         relatedTransactions,
@@ -228,7 +227,7 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
         humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions,
         userJourneyDurationFriendly
       })
-    } else if (renderKey === 'refund') {
+    } else if (renderKey === TransactionType.Refund) {
       const refundExpunged = await isRefundExpunged(transaction)
       res.render(`transactions/refund`, {
         transaction,

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -216,36 +216,37 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
 
     const renderKey = transaction.transaction_type
 
-    if (renderKey === TransactionType.Payment) {
-      res.render(`transactions/payment`, {
-        transaction,
-        relatedTransactions,
-        service,
-        events,
-        stripeDashboardUri,
-        webhookMessages,
-        humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions,
-        userJourneyDurationFriendly
-      })
-    } else if (renderKey === TransactionType.Refund) {
-      const refundExpunged = await isRefundExpunged(transaction)
-      res.render(`transactions/refund`, {
-        transaction,
-        parentTransaction,
-        refundExpunged,
-        service,
-        events,
-        webhookMessages,
-      })
-    } else {
-      res.render(`transactions/dispute`, {
-        transaction,
-        parentTransaction,
-        service,
-        events,
-        webhookMessages,
-      })
-    }
+    switch (renderKey) {
+      case TransactionType.Payment:
+        return res.render(`transactions/payment`, {
+          transaction,
+          relatedTransactions,
+          service,
+          events,
+          stripeDashboardUri,
+          webhookMessages,
+          humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions,
+          userJourneyDurationFriendly
+        })
+      case TransactionType.Refund:
+        const refundExpunged = await isRefundExpunged(transaction)
+        return res.render(`transactions/refund`, {
+          transaction,
+          parentTransaction,
+          refundExpunged,
+          service,
+          events,
+          webhookMessages,
+        })
+      case TransactionType.Dispute:
+        return res.render(`transactions/dispute`, {
+          transaction,
+          parentTransaction,
+          service,
+          events,
+          webhookMessages,
+        })
+      }
   } catch (error) {
     next(error)
   }

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -217,7 +217,7 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
     const renderKey = transaction.transaction_type
 
     switch (renderKey) {
-      case TransactionType.Payment:
+      case TransactionType.Payment: {
         return res.render(`transactions/payment`, {
           transaction,
           relatedTransactions,
@@ -228,7 +228,8 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
           humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions,
           userJourneyDurationFriendly
         })
-      case TransactionType.Refund:
+      }
+      case TransactionType.Refund: {
         const refundExpunged = await isRefundExpunged(transaction)
         return res.render(`transactions/refund`, {
           transaction,
@@ -238,7 +239,8 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
           events,
           webhookMessages,
         })
-      case TransactionType.Dispute:
+      }
+      case TransactionType.Dispute: {
         return res.render(`transactions/dispute`, {
           transaction,
           parentTransaction,
@@ -247,6 +249,7 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
           webhookMessages,
         })
       }
+    }
   } catch (error) {
     next(error)
   }

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -110,6 +110,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
       ...accountId && {account_id: Number(accountId)},
       ...transactionType === TransactionType.Payment && {payment_states: resolvePaymentStates(selectedStatus)},
       ...transactionType === TransactionType.Refund && {refund_states: resolveRefundStates(selectedStatus)},
+      ...transactionType === TransactionType.Dispute && {dispute_states: resolveRefundStates(selectedStatus)},
       ...filters
     })
 
@@ -227,12 +228,20 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
         humanReadableSubscriptions: constants.webhooks.humanReadableSubscriptions,
         userJourneyDurationFriendly
       })
-    } else {
+    } else if (renderKey === 'refund') {
       const refundExpunged = await isRefundExpunged(transaction)
       res.render(`transactions/refund`, {
         transaction,
         parentTransaction,
         refundExpunged,
+        service,
+        events,
+        webhookMessages,
+      })
+    } else {
+      res.render(`transactions/dispute`, {
+        transaction,
+        parentTransaction,
         service,
         events,
         webhookMessages,


### PR DESCRIPTION
[PP-14146](https://payments-platform.atlassian.net/browse/PP-14146)

Previously, transactions which were disputed were incorrectly displaying the refund template.
This change causes the dispute template to be displayed which is the intended behaviour. 

[PP-14146]: https://payments-platform.atlassian.net/browse/PP-14146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ