### PR TITLE
PP-12481 Show orphaned transactions

### DIFF
--- a/src/lib/pay-request/services/admin_users/client.ts
+++ b/src/lib/pay-request/services/admin_users/client.ts
@@ -34,16 +34,18 @@ export default class AdminUsers extends Client {
           .then(response => client._unpackResponseData<Service>(response));
     },
 
-    retrieve(idOrParams: string | RetrieveServiceByGatewayAccountIdRequest): Promise<Service | undefined> {
-      const url = isRetrieveServiceParams(idOrParams)
-        ? '/v1/api/services'
-        : `/v1/api/services/${idOrParams}`
-      const config = isRetrieveServiceParams(idOrParams)
-        ? { params: idOrParams } || {}
-        : {}
+    retrieve(serviceExternalId: string): Promise<Service | undefined> {
       return client._axios
-        .get(url, config)
-        .then(response => client._unpackResponseData<Service>(response));
+        .get(`/v1/api/services/${serviceExternalId}`)
+        .then(response => client._unpackResponseData<Service>(response))
+        .catch(handleEntityNotFound("Service by external ID", serviceExternalId));
+    },
+
+    retrieveByGatewayAccountId (gatewayAccountId: string): Promise<Service | undefined> {
+      return client._axios
+          .get('/v1/api/services', { params: { gatewayAccountId } })
+          .then(response => client._unpackResponseData<Service>(response))
+          .catch(handleEntityNotFound("Service by gateway account ID", gatewayAccountId));
     },
 
     list(): Promise<Service[] | undefined> {

--- a/src/web/modules/agreements/agreements.http.ts
+++ b/src/web/modules/agreements/agreements.http.ts
@@ -65,7 +65,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
     })
 
     if (req.query.account) {
-      service = await AdminUsers.services.retrieve({gatewayAccountId: accountId as string})
+      service = await AdminUsers.services.retrieveByGatewayAccountId(`${accountId}`)
       account = await Connector.accounts.retrieve(accountId as string)
     }
 

--- a/src/web/modules/common/ifEntityNotFound.ts
+++ b/src/web/modules/common/ifEntityNotFound.ts
@@ -1,0 +1,12 @@
+import {EntityNotFoundError} from "../../../lib/errors";
+
+export function ifEntityNotFound (callback: Function, necessaryConditions: boolean = true) {
+    return (e: Error): null => {
+        if (e instanceof EntityNotFoundError && necessaryConditions) {
+            callback()
+            return null
+        } else {
+            throw e
+        }
+    }
+}

--- a/src/web/modules/gateway_accounts/gateway_accounts.http.ts
+++ b/src/web/modules/gateway_accounts/gateway_accounts.http.ts
@@ -230,7 +230,7 @@ async function detail(req: Request, res: Response): Promise<void> {
 
   let service = {}
   try {
-    service = await AdminUsers.services.retrieve({gatewayAccountId: id})
+    service = await AdminUsers.services.retrieveByGatewayAccountId(id)
   } catch (error: any) {
     logger.warn(`Services request for gateway account ${id} returned "${error.message}"`)
   }
@@ -341,7 +341,7 @@ async function surcharge(req: Request, res: Response): Promise<void> {
   const account = await getAccount(id)
 
   try {
-    service = await AdminUsers.services.retrieve({gatewayAccountId: id})
+    service = await AdminUsers.services.retrieveByGatewayAccountId(id)
   } catch (error: any) {
     logger.warn(`Services request for gateway account ${id} returned "${error.message}"`)
   }

--- a/src/web/modules/gateway_accounts/moto.http.ts
+++ b/src/web/modules/gateway_accounts/moto.http.ts
@@ -16,7 +16,7 @@ export async function motoSettings(req: Request,
     const {id} = req.params
     const [account, service, products] = await Promise.all([
       Connector.accounts.retrieve(id),
-      AdminUsers.services.retrieve({gatewayAccountId: id}),
+      AdminUsers.services.retrieveByGatewayAccountId(id),
       Products.accounts.listProductsByType(id, ProductType.Moto)
     ])
     const motoPaymentLinkExists = products.length > 0
@@ -107,7 +107,7 @@ export async function agentInitiatedMoto(
 
     const [account, service, products] = await Promise.all([
       Connector.accounts.retrieve(id),
-      AdminUsers.services.retrieve({gatewayAccountId: id}),
+      AdminUsers.services.retrieveByGatewayAccountId(id),
       Products.accounts.listProductsByType(id, ProductType.Moto)
     ])
 
@@ -135,7 +135,7 @@ export async function agentInitiatedMotoProduct(
 
     const [account, service, products] = await Promise.all([
       Connector.accounts.retrieve(id),
-      AdminUsers.services.retrieve({gatewayAccountId: id}),
+      AdminUsers.services.retrieveByGatewayAccountId(id),
       Products.accounts.listProductsByType(id, ProductType.Moto)
     ])
 
@@ -247,7 +247,7 @@ export async function toggleAgentInitiatedMotoEnabledFlag(
 
     const [account, service] = await Promise.all([
       Connector.accounts.retrieve(id),
-      AdminUsers.services.retrieve({gatewayAccountId: id})
+      AdminUsers.services.retrieveByGatewayAccountId(id)
     ])
     const enable = !service.agent_initiated_moto_enabled
     await AdminUsers.services.update(service.external_id, {

--- a/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
+++ b/src/web/modules/gateway_accounts/switch_psp/switch_psp.http.ts
@@ -21,7 +21,7 @@ async function updateConnectorStripeOnboardingSteps(gatewayAccountId: string, op
 
 export async function switchPSPPage(req: Request, res: Response, next: NextFunction) {
   const account = await Connector.accounts.retrieve(req.params.id)
-  const service = await AdminUsers.services.retrieve({gatewayAccountId: `${account.gateway_account_id}`})
+  const service = await AdminUsers.services.retrieveByGatewayAccountId(`${account.gateway_account_id}`)
   res.render('gateway_accounts/switch_psp/switch_psp', {account, service, flash: req.flash(), csrf: req.csrfToken()})
 }
 
@@ -31,7 +31,7 @@ export async function postSwitchPSP(req: Request, res: Response, next: NextFunct
 
   try {
     const account = await Connector.accounts.retrieve(req.params.id)
-    const service = await AdminUsers.services.retrieve({gatewayAccountId: gatewayAccountId})
+    const service = await AdminUsers.services.retrieveByGatewayAccountId(gatewayAccountId)
 
     if (!req.body.paymentProvider) {
       req.flash('error', 'Payment provider is required')

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -138,6 +138,18 @@
               Test data
           </div>
           {% endif %}
+
+          {% if warnings | length %}
+            <div class="govuk-error-summary" role="alert">
+              <h2 class="govuk-error-summary__title">Error</h2>
+              {% for warning in warnings %}
+                <div class="govuk-error-summary__body">
+                  {{ warning }}
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+
           {% block main %}
           {% endblock %}
         </div>

--- a/src/web/modules/ledger_payouts/payout.http.ts
+++ b/src/web/modules/ledger_payouts/payout.http.ts
@@ -17,7 +17,7 @@ export async function list(req: Request, res: Response, next: NextFunction): Pro
     })
 
     if (req.query.account) {
-      service = await AdminUsers.services.retrieve({gatewayAccountId})
+      service = await AdminUsers.services.retrieveByGatewayAccountId(gatewayAccountId)
       account = await Connector.accounts.retrieve(gatewayAccountId)
     }
 

--- a/src/web/modules/payment_links/account/list_account.http.ts
+++ b/src/web/modules/payment_links/account/list_account.http.ts
@@ -11,7 +11,7 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
         const used = req.query.used !== 'false'
 
         const [service, productStats] = await Promise.all([
-            AdminUsers.services.retrieve({ gatewayAccountId: accountId }),
+            AdminUsers.services.retrieveByGatewayAccountId(accountId),
             Products.reports.listStats({ gatewayAccountId: Number(accountId), used })
         ])
 

--- a/src/web/modules/payment_links/account/list_account_csv.http.ts
+++ b/src/web/modules/payment_links/account/list_account_csv.http.ts
@@ -12,7 +12,7 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
         const used = req.query.used !== 'false'
 
         const [service, productStats] = await Promise.all([
-            AdminUsers.services.retrieve({ gatewayAccountId: accountId }),
+            AdminUsers.services.retrieveByGatewayAccountId(accountId),
             Products.reports.listStats({ gatewayAccountId: Number(accountId), used })
         ])
 


### PR DESCRIPTION
- allow viewing transactions which are orphaned in Ledger, i.e. the `gateway_account_id` on the transaction corresponds to a Gateway account which does not exist in Connector
- show error messages when viewing orphaned transactions

Screenshots:
![Screenshot 2025-06-09 at 15 48 41](https://github.com/user-attachments/assets/ba43ae52-57cb-420b-be03-43dfa0c9b2fd)
![Screenshot 2025-06-09 at 15 48 50](https://github.com/user-attachments/assets/0310bee6-c6ec-4828-981d-90ae707b586a)
