### PR TITLE
PP-13895 update frontend and header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express": "4.21.2",
         "fast-csv": "^4.3.6",
         "google-libphonenumber": "~3.2.21",
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "^5.10.2",
         "helmet": "^7.0.0",
         "http-errors": "^2.0.0",
         "https-proxy-agent": "5.0.1",
@@ -9412,9 +9412,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
+      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": "4.21.2",
     "fast-csv": "^4.3.6",
     "google-libphonenumber": "~3.2.21",
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "^5.10.2",
     "helmet": "^7.0.0",
     "http-errors": "^2.0.0",
     "https-proxy-agent": "5.0.1",

--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<html lang="en" class="govuk-template govuk-template--rebranded">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Updating `govuk-frontend` module to version 5.10.2 and adding global nunjucks to enable the branding. See new branding below:
![Screenshot 2025-06-17 at 15 36 45](https://github.com/user-attachments/assets/45b38fac-c533-4f88-aa0f-e4f6137d844f)

