### PR TITLE
PP-13895 introduce rebrand switch

### DIFF
--- a/src/web/modules/layout/layout.njk
+++ b/src/web/modules/layout/layout.njk
@@ -16,7 +16,8 @@
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: "Toolbox",
-    useTudorCrown: true
+    useTudorCrown: true,
+    rebrand: true
   }) }}
 
   <div class="govuk-width-container">


### PR DESCRIPTION
Adding the rebrand switch so we get correct sizing of logo and the cyan dot:
<img width="1002" alt="Screenshot 2025-06-18 at 16 17 45" src="https://github.com/user-attachments/assets/1db76eba-8572-44df-9251-eae4bfe84ea0" />
