### PR TITLE
PP-13998 add sendpayer ip and send payer email to gateway creation

### DIFF
--- a/src/lib/pay-request/services/connector/types.ts
+++ b/src/lib/pay-request/services/connector/types.ts
@@ -127,6 +127,8 @@ export interface CreateGatewayAccountRequest {
   requires_3ds?: boolean;
   allow_apple_pay?: boolean;
   allow_google_pay?: boolean;
+  send_payer_email_to_gateway: boolean;
+  send_payer_ip_address_to_gateway: boolean;
 }
 
 export interface ListCardTypesResponse {

--- a/src/web/modules/gateway_accounts/gatewayAccount.model.ts
+++ b/src/web/modules/gateway_accounts/gatewayAccount.model.ts
@@ -1,7 +1,8 @@
 import {
   IsNotEmpty,
   IsIn,
-  IsString
+  IsString,
+  IsBoolean
 } from 'class-validator'
 
 import Validated from '../common/validated'
@@ -39,6 +40,14 @@ class GatewayAccount extends Validated {
 
   public serviceId: string;
 
+  @IsBoolean()
+  @IsNotEmpty()
+  public sendPayerEmailToGateway: boolean;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  public sendPayerIpAddressToGateway: boolean;
+
   public validate(): void {
     super.validate()
 
@@ -60,6 +69,8 @@ class GatewayAccount extends Validated {
     this.credentials = formValues.credentials
     this.sector = formValues.sector
     this.internalFlag = formValues.internalFlag === "true"
+    this.sendPayerEmailToGateway = true
+    this.sendPayerIpAddressToGateway = true
     this.validate()
   }
 
@@ -70,7 +81,9 @@ class GatewayAccount extends Validated {
       description: this.description,
       type: this.isLive() ? AccountType.Live : AccountType.Test,
       service_name: this.serviceName,
-      service_id: this.serviceId
+      service_id: this.serviceId,
+      send_payer_email_to_gateway: this.sendPayerEmailToGateway,
+      send_payer_ip_address_to_gateway: this.sendPayerEmailToGateway,
     }
 
     if (this.isLive() || this.provider === 'stripe' || this.provider === 'worldpay') {

--- a/src/web/modules/gateway_accounts/gateway_accounts.spec.js
+++ b/src/web/modules/gateway_accounts/gateway_accounts.spec.js
@@ -128,6 +128,18 @@ describe('Gateway Accounts', () => {
       expect(payload.allow_apple_pay).to.eql(true)
       expect(payload.allow_google_pay).to.eql(true)
     });
+
+    it('successfully creates model with send_payer_email_to_gateway and send_payer_ip_address_to_gateway set to true', function () {
+      const details = _.cloneDeep(validGatewayAccountDetails)
+      details.live = 'not-live'
+
+      const account = new GatewayAccount(details)
+      expect(account).to.be.an('object')
+      account.serviceId = 'service-id'
+      const payload = account.formatPayload()
+      expect(payload.send_payer_email_to_gateway).to.eql(true)
+      expect(payload.send_payer_ip_address_to_gateway).to.eql(true)
+    });
   })
 })
 

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -473,7 +473,9 @@ export async function createWorldpayTestService(
       description: `Worldpay test account spun off from service ${serviceId}`,
       type: AccountType.Test,
       service_name: service.service_name.en,
-      service_id: serviceForWorldpayTestGatewayAccount.external_id
+      service_id: serviceForWorldpayTestGatewayAccount.external_id,
+      send_payer_email_to_gateway: true,
+      send_payer_ip_address_to_gateway: true
     }
     const createGatewayAccountResponse = await Connector.accounts.create(payload)
 


### PR DESCRIPTION
Set the send_payer_ip_address_to_gateway and send_payer_email_to_gateway settings to true when creating a new gateway account.

This is based on the new requirements by Visa.