### PR TITLE
PP-14377 Show whether a transaction is expunged for charges & refunds

### DIFF
--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -33,6 +33,12 @@ export default class Connector extends Client {
     }
 
     refunds = ((client: Connector) => ({
+        retrieve (chargeExternalId: string, refundExternalId: string, accountId: string) {
+            return client._axios
+                .get(`/v1/api/accounts/${accountId}/charges/${chargeExternalId}/refunds/${refundExternalId}`)
+                .then(response => client._unpackResponseData<Charge>(response))
+                .catch(handleEntityNotFound(`Refund for charge [${chargeExternalId}]`, refundExternalId))
+        },
 
         /**
          * @param refundExternalId

--- a/src/lib/pay-request/services/connector/client.ts
+++ b/src/lib/pay-request/services/connector/client.ts
@@ -33,29 +33,13 @@ export default class Connector extends Client {
     }
 
     refunds = ((client: Connector) => ({
-        retrieve (chargeExternalId: string, refundExternalId: string, accountId: string) {
+        retrieve (chargeExternalId: string, refundExternalId: string, accountId: string): Promise<Charge> {
             return client._axios
                 .get(`/v1/api/accounts/${accountId}/charges/${chargeExternalId}/refunds/${refundExternalId}`)
                 .then(response => client._unpackResponseData<Charge>(response))
                 .catch(handleEntityNotFound(`Refund for charge [${chargeExternalId}]`, refundExternalId))
         },
 
-        /**
-         * @param refundExternalId
-         * @param parentExternalId
-         * @param gatewayAccountId
-         */
-        async doesRefundExist(refundExternalId: string, parentExternalId: string, gatewayAccountId: string): Promise<boolean> {
-            const response = await client._axios.get(
-                `/v1/api/accounts/${gatewayAccountId}/charges/${parentExternalId}/refunds/${refundExternalId}`,
-                { validateStatus: status => [404,200].includes(status) },)
-            switch (response.status) {
-                case 404: return false
-                case 200: return true
-                default:
-                    throw new Error('Should not have reached here')
-            }
-        }
     }))(this)
 
     charges = ((client: Connector) => ({

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -29,8 +29,13 @@
         transaction.refund_summary and transaction.refund_summary.status,
         transaction.refund_summary and transaction.refund_summary.amount_submitted
         ) }}
+
       {{ govukTag({
-        text: "Expunged" if isExpunged else "Not expunged"
+        text: "Expunged",
+        classes: "govuk-tag--pink"
+      }) if isExpunged else govukTag({
+        text: "Not expunged",
+        classes: "govuk-tag--purple"
       }) }}
     </div>
   </div>

--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "transactions/status.macro.njk" import status %}
 {% from "transactions/features.macro.njk" import features %}
 {% from "transactions/card_payment_method.macro.njk" import card_payment_method %}
@@ -28,6 +29,9 @@
         transaction.refund_summary and transaction.refund_summary.status,
         transaction.refund_summary and transaction.refund_summary.amount_submitted
         ) }}
+      {{ govukTag({
+        text: "Expunged" if isExpunged else "Not expunged"
+      }) }}
     </div>
   </div>
 

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "common/json.njk" import json %}
 
 {% extends "layout/layout.njk" %}
@@ -5,7 +6,11 @@
 {% set isTestData = not (parentTransaction and parentTransaction.live) %}
 
 {% block main %}
+
+<span class="govuk-caption-m">{{ transaction.created_date | formatDate }}</span>
 <h1 class="govuk-heading-m">Refund</h1>
+
+<div class="govuk-grid-row"></div>
 
 {% if transaction.parent_transaction_id %}
   <div class="govuk-body govuk-!-margin-bottom-4">
@@ -14,14 +19,14 @@
   </div>
 {% endif %}
 
-<div class="status-inline-spacer">
-  <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
-</div>
-
-<div class="govuk-grid-row status-spacer payment-detail-row">
+<div class="govuk-grid-row status-spacer">
   <div class="govuk-grid-column-one-quarter">
-    <span class="govuk-caption-m">Date</span>
-    <span class="govuk-body">{{ transaction.created_date | formatDate }}</span>
+    <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
+  </div>
+  <div class="govuk-grid-column-three-quarters text-right">
+    {{ govukTag({
+      text: "Expunged" if isExpunged else "Not expunged"
+    }) }}
   </div>
 </div>
 
@@ -113,14 +118,14 @@
 {{ json("Transaction source", transaction) }}
 
 <div>
-  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and refundExpunged %}
+  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and isExpunged %}
     {{ govukButton({
       text: "Correct asynchronously failed Stripe refund",
       classes: "govuk-button--warning",
       href: "/confirm-fix-async-failed-stripe-refund/" + transaction.transaction_id
     }) }}
   {% endif %}
-  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and not refundExpunged %}
+  {% if (transaction.state and transaction.state.status === "success") and (parentTransaction.payment_provider === "stripe") and not isExpunged %}
     <div class="govuk-body govuk-!-margin-bottom-4">
       Cannot asynchronously correct Stripe refund as it is not expunged from Connector microservice. Come back later.
     </div>

--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -25,7 +25,11 @@
   </div>
   <div class="govuk-grid-column-three-quarters text-right">
     {{ govukTag({
-      text: "Expunged" if isExpunged else "Not expunged"
+      text: "Expunged",
+      classes: "govuk-tag--pink"
+    }) if isExpunged else govukTag({
+      text: "Not expunged",
+      classes: "govuk-tag--purple"
     }) }}
   </div>
 </div>

--- a/src/web/modules/transactions/transactions.http.ts
+++ b/src/web/modules/transactions/transactions.http.ts
@@ -275,14 +275,6 @@ export async function show(req: Request, res: Response, next: NextFunction): Pro
   }
 }
 
-async function isRefundExpunged(transaction: Transaction): Promise<boolean> {
-  if (transaction.transaction_type === TransactionType.Refund) {
-    const doesRefundExist = await Connector.refunds.doesRefundExist(transaction.transaction_id, transaction.parent_transaction_id, transaction.gateway_account_id)
-    return !doesRefundExist
-  }
-  return true
-}
-
 const sum = (a: number, b: number): number => a + b
 
 export async function statistics(req: Request, res: Response, next: NextFunction): Promise<void> {


### PR DESCRIPTION
### What
- add a tag to show if a transaction has been expunged or not for charges & refunds (disputes are not stored in Connector)

Screenshots:
<img width="1067" height="389" alt="Screenshot 2025-08-11 at 16 48 16" src="https://github.com/user-attachments/assets/22be82ca-eb8e-4191-b9b6-4cbcf8755216" />
<img width="1027" height="363" alt="Screenshot 2025-08-11 at 16 48 20" src="https://github.com/user-attachments/assets/0775996a-c554-4c75-aebb-e0b7e5ff3b47" />
<img width="1017" height="394" alt="Screenshot 2025-08-11 at 16 49 32" src="https://github.com/user-attachments/assets/091119a8-7010-437e-a7aa-6676766eb57b" />
<img width="1056" height="361" alt="Screenshot 2025-08-11 at 16 49 47" src="https://github.com/user-attachments/assets/cd590ed0-aaa2-4ea9-8201-7cab453e85ac" />
