### PR TITLE
PP-14377 Temporarily remove expunged/not expunged tag from refund page

### DIFF
--- a/src/web/modules/transactions/refund.njk
+++ b/src/web/modules/transactions/refund.njk
@@ -24,13 +24,7 @@
     <span class="govuk-body-l status-amount">{{ (transaction.total_amount or transaction.amount) | currency }}</span>
   </div>
   <div class="govuk-grid-column-three-quarters text-right">
-    {{ govukTag({
-      text: "Expunged",
-      classes: "govuk-tag--pink"
-    }) if isExpunged else govukTag({
-      text: "Not expunged",
-      classes: "govuk-tag--purple"
-    }) }}
+{#    TODO: add expunged status tag back in when bug with checking expunged state is fixed #}
   </div>
 </div>
 


### PR DESCRIPTION
### What
There is a bug in the method of checking if a refund is expunged, since Connector will return a 404 when querying `/charge/<charge_id>/refund/<refund_id>` if the parent charge does not exist, even if the refund does. This means that refunds always appear to be expunged if the parent charge has been expunged, regardless of whether the refund has been expunged or not

this temporarily removes the expunged/not expunged tag until this bug is resolved