### PR TITLE
PP-14164 - Correctly show/hide "test data" banner 

### DIFF
--- a/src/web/modules/transactions/fix_async_failed_stripe_refund.ts
+++ b/src/web/modules/transactions/fix_async_failed_stripe_refund.ts
@@ -5,9 +5,11 @@ import {EntityNotFoundError, RESTClientError} from "../../../lib/errors";
 export async function show(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
         const transaction = await Ledger.transactions.retrieve(req.params.id)
+        const parentTransaction = await Ledger.transactions.retrieve(transaction.parent_transaction_id)
 
         res.render(`transactions/confirmFixAsyncFailedStripeRefund`, {
             transaction,
+            parentTransaction,
             csrf: req.csrfToken()
         })
     } catch (error) {


### PR DESCRIPTION
### Summery:
currently "test data" banner is showing for both test data and real data.
confirmFixAsyncFailedStripeRefund.njk is expecting "parentTransaction" object to check "parentTransaction.live" and set "isTestData" to show or hide the "test data" banner 

### Recreate: 

1. Go to a "LIVE" transaction that has a refund transaction (is expunged and is stripe)
2. Click "Correct asynchronously failed Stripe refund"
3. There should be a red banner "Test data"
<img width="1510" height="94" alt="image" src="https://github.com/user-attachments/assets/9bd85d96-2527-496b-a48d-60c0be9592d0" />


### Fix: 
Pass parentTransaction through "show" method, so isTestDat…a can be correctly set to show/hide "test data" banner.


### AC Live Transaction:
1. Go to a "LIVE" transaction that has a refund transaction (is expunged and is stripe)
2. Click "Correct asynchronously failed Stripe refund"
3. There should <p style="color:red;">NO</p> red banner "Test data"

### AC Test Transaction:
1. Go to a "TEST" transaction that has a refund transaction (is expunged and is stripe)
2. Click "Correct asynchronously failed Stripe refund"
3. There should be a red banner "Test data"

