### PR TITLE
PP-14847 Update font for new warning message

### DIFF
--- a/src/web/modules/transactions/payment.njk
+++ b/src/web/modules/transactions/payment.njk
@@ -306,8 +306,8 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="2">
             <div class="govuk-details__text">
-                <code>Do not share reasons for declined payments with paying users because of the risk of fraud.
-                    Read about <a class="govuk-link govuk-link--no-visited-state" href="https://manual.payments.service.gov.uk/manual/how-to/declined-payments.html">declined payment reasons and what can be shared with teams</a></code>
+                <p>Do not share reasons for declined payments with paying users because of the risk of fraud.
+                    Read about <a class="govuk-link govuk-link--no-visited-state" href="https://manual.payments.service.gov.uk/manual/how-to/declined-payments.html">declined payment reasons and what can be shared with teams</a></p>
             </div>
           </td>
           <td class="govuk-table__cell"> </td>


### PR DESCRIPTION
With this change, we are updating the new warning message displayed with AUTHORISATION_REJECTED events so that its font is 'GDS Transport' instead of 'monospace'.

Further information in the Jira ticket.

https://payments-platform.atlassian.net/browse/PP-14847?focusedCommentId=80701

# BEFORE

<img width="935" height="381" alt="BEFORE" src="https://github.com/user-attachments/assets/c160abd0-09cc-4be0-99dd-656531ac369a" />

# AFTER

<img width="765" height="406" alt="AFTER" src="https://github.com/user-attachments/assets/a60e5be0-fdf2-46cf-b6dc-3dd20ad6bec1" />
