### PR TITLE
PP-15376 session logout functionality

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -40,6 +40,6 @@ export function revokeSession(req: Request, res: Response, next: NextFunction) {
   logger.info(`Revoking session for user ${req.user && req.user.username}`)
     req.logout((err?: unknown) => {
         if (err) return next(err);
-        res.redirect('/');
+        res.redirect('/auth');
     });
 }

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -13,7 +13,15 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
+      <span>
+        <form method="POST" action="/logout">
+          {{ govukButton({
+            text: "Sign out"
+            })
+            }}
+          <input type="hidden" name="_csrf" value="{{ csrf }}">
+        </form>
+      </span>
     </div>
   {% else %}
     <div class="user-profile__item">(OAUTH disabled)</div>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -36,13 +36,26 @@ const router = express.Router()
 const storage = multer.memoryStorage()
 const upload = multer({storage})
 
-router.get('/auth', passport.authenticate('github'))
+const {
+  rateLimitMiddleware
+} = require('@govuk-pay/pay-js-commons/lib/utils/middleware/csp')
+
+router.get(
+  '/auth',
+  passport.authenticate('github', {
+    scope: ['user:email'],
+    prompt: 'consent',
+  })
+);
+
 router.get('/auth/github/callback', (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
-    successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
-  })(req, res, next)
-})
+    successRedirect:
+      (req.session && req.session.authBlockedRedirectUrl) || '/',
+  })(req, res, next);
+});
+
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured(PermissionLevel.VIEW_ONLY), landing.root)
@@ -190,7 +203,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', rateLimitMiddleware, auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -65,6 +65,11 @@ function configureSecureHeaders(instance) {
     crossOriginResourcePolicy: { policy: "cross-origin" }
   }))
   instance.use(csurf())
+
+  instance.use((req, res, next) => {
+    res.locals.csrf = req.csrfToken()
+    next()
+  })
 }
 
 function configureRequestParsing(instance) {


### PR DESCRIPTION
Amending clear session to a full logout.

- This should logout users from Toolbox without logging them out of Github.
- Changed the logout route to use POST instead of GET as per the Passport documentation.
- Changed the anchor tag with an href to a form and button to facilitate a post request.
- Adding csrfToken globally so that the banner can make use of it. At the moment we only pass it in with each rendered view.
- CodeQL is marking the POST route as missing rate limiting. These changes implement it via pay-js-commons but it looks like CodeQL isn't familiar with custom middleware. Nonetheless, this should be considered in reviewing.
- This PR will be reverted after staging as there will likely be some issues around the styling of the 'Sign out' button, at the moment we just want to know if the code works as expected in the test environment. Also will need to clean up unused `req.csrfToken()` on rendered views.