### PR TITLE
PP-15376 session logout functionality

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import logger from './logger'
 import {disableAuth} from './../config'
 import {NextFunction, Request, Response} from 'express'
 import {PermissionLevel} from './auth/types'
+import { revokeGithubGrant } from './auth/github/strategy'
 
 export function secured(permissionLevel: PermissionLevel) {
   return function checkUserIsAuthenticatedAndPermitted(req: Request, res: Response, next: NextFunction) {
@@ -36,10 +37,33 @@ export function unauthorised(req: Request, res: Response) {
   res.status(403).send('User does not have permissions to access the resource')
 }
 
-export function revokeSession(req: Request, res: Response, next: NextFunction) {
-  logger.info(`Revoking session for user ${req.user && req.user.username}`)
-    req.logout((err?: unknown) => {
-        if (err) return next(err);
-        res.redirect('/');
-    });
+export async function revokeSession(req: Request, res: Response, next: NextFunction) {
+    logger.info(`Revoking session for user ${req.user && req.user.username}`)
+
+    const accessToken = req.user && (req.user as any).accessToken
+
+    if (!disableAuth && accessToken) {
+        try {
+            await revokeGithubGrant(accessToken)
+        } catch (err) {
+            logger.warn(`Failed to revoke GitHub grant: ${err}`)
+        }
+    }
+
+    req.logout((err) => {
+        if (err) {
+            return next(err)
+        }
+
+        if (req.session && typeof req.session.reset === 'function') {
+            req.session.reset()
+        }
+        res.clearCookie('session', { path: '/' })
+
+        if (disableAuth) {
+            return res.redirect('/')
+        }
+
+        return res.redirect('/auth')
+    })
 }

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -20,7 +20,7 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
 ) {
   const { username, displayName } = profile
   const avatarUrl = profile._json && profile._json.avatar_url
-  const sessionProfile = { username, displayName, avatarUrl }
+  const sessionProfile = { username, displayName, avatarUrl, accessToken }
 
   logger.info(`Successful account auth from GitHub for user ${username}`)
 
@@ -40,4 +40,27 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
   }
 }
 
-module.exports = { Strategy, githubAuthCredentials, handleGitHubOAuthSuccessResponse }
+
+async function revokeGithubGrant(accessToken) {
+  if (!accessToken) return
+
+  const { clientID, clientSecret } = githubAuthCredentials
+  const credentials = Buffer.from(`${clientID}:${clientSecret}`).toString('base64')
+
+  const resp = await fetch(`https://api.github.com/applications/${clientID}/grant`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28'
+    },
+    body: JSON.stringify({ access_token: accessToken })
+  })
+
+  if (resp.status !== 204 && resp.status !== 404) {
+    throw new Error(`GitHub grant revoke failed: ${resp.status}`)
+  }
+}
+
+module.exports = { Strategy, githubAuthCredentials, handleGitHubOAuthSuccessResponse, revokeGithubGrant }

--- a/src/lib/auth/github/strategy.spec.js
+++ b/src/lib/auth/github/strategy.spec.js
@@ -21,7 +21,7 @@ describe('GitHub OAuth strategy', () => {
         username: profile.username,
         displayName: profile.displayName,
         permissionLevel: PermissionLevel.VIEW_ONLY,
-
+        accessToken: 'some-access-token',
         avatarUrl: profile._json.avatar_url
       }
     )

--- a/src/lib/auth/passport.js
+++ b/src/lib/auth/passport.js
@@ -23,7 +23,7 @@ if (!disableAuth) {
   const httpsProxy = process.env.https_proxy
   if (httpsProxy) strategy._oauth2.setAgent(new HTTPSProxyAgent(httpsProxy))
 
-  passport.use(strategy)
+  passport.use('github', strategy)
 }
 
 module.exports = passport

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -13,8 +13,17 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
+      <span>
+        <form method="POST" action="/logout">
+          {{ govukButton({
+            text: "Sign out"
+            })
+            }}
+          <input type="hidden" name="_csrf" value="{{ csrf }}">
+        </form>
+      </span>
     </div>
+
   {% else %}
     <div class="user-profile__item">(OAUTH disabled)</div>
   {% endif %}

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -36,13 +36,25 @@ const router = express.Router()
 const storage = multer.memoryStorage()
 const upload = multer({storage})
 
-router.get('/auth', passport.authenticate('github'))
+const {
+  rateLimitMiddleware
+} = require('@govuk-pay/pay-js-commons/lib/utils/middleware/csp')
+
+router.get(
+  '/auth',
+  passport.authenticate('github', {
+    scope: ['user:email'],
+  })
+);
+
 router.get('/auth/github/callback', (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
-    successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
-  })(req, res, next)
-})
+    successRedirect:
+      (req.session && req.session.authBlockedRedirectUrl) || '/',
+  })(req, res, next);
+});
+
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured(PermissionLevel.VIEW_ONLY), landing.root)
@@ -190,7 +202,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', rateLimitMiddleware, auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -65,6 +65,11 @@ function configureSecureHeaders(instance) {
     crossOriginResourcePolicy: { policy: "cross-origin" }
   }))
   instance.use(csurf())
+
+  instance.use((req, res, next) => {
+    res.locals.csrf = req.csrfToken()
+    next()
+  })
 }
 
 function configureRequestParsing(instance) {


### PR DESCRIPTION
## Draft
Amending clear session to a full logout.

- This should logout users from Toolbox without logging them out of Github.
- Changed the logout route to use POST instead of GET as per the Passport documentation.
- Changed the anchor tag with an href to a form and button to facilitate a post request.
- Adding csrfToken globally so that the banner can make use of it. At the moment we only pass it in with each rendered view.
- CodeQL is marking the POST route as missing rate limiting. These changes implement it via pay-js-commons but it looks like CodeQL isn't familiar with custom middleware. Nonetheless, this should be considered in reviewing.
- Passport allows you to explicitly name your strategy on registration by passing the name as the first argument. This has been added in the custom `passport.js` file so that to force the identifier to be 'github'.
- Added a `revokeGithubGrant` method to the Github Strategy that revokes the Oauth grant on Gihub's side before redirecting back to `/auth`. You can read the documentation for it [here](https://docs.github.com/en/enterprise-server@3.3/rest/apps/oauth-applications#revoke-a-grant-for-an-application).
- This PR will be reverted after staging as there will likely be some issues around the styling of the 'Sign out' button, at the moment we just want to know if the code works as expected in the test environment. Also will need to clean up unused req.csrfToken() on rendered views.