### PR TITLE
PP-15378 Add logout feature

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -39,7 +39,10 @@ export function unauthorised(req: Request, res: Response) {
 export function revokeSession(req: Request, res: Response, next: NextFunction) {
   logger.info(`Revoking session for user ${req.user && req.user.username}`)
     req.logout((err?: unknown) => {
-        if (err) return next(err);
-        res.redirect('/');
+        if (err) {
+            logger.error("Logout Error **:", err)
+            return next(err)
+        }
+        res.redirect('/login');
     });
 }

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -4,7 +4,7 @@ const config = require('../../../config')
 const logger = require('../../logger')
 
 const { checkUserAccess} = require('./permissions')
-const {PermissionLevel} = require("../types");
+const {PermissionLevel} = require("../types")
 
 const githubAuthCredentials = {
   clientID: config.auth.AUTH_GITHUB_CLIENT_ID,

--- a/src/lib/auth/passport.js
+++ b/src/lib/auth/passport.js
@@ -23,7 +23,7 @@ if (!disableAuth) {
   const httpsProxy = process.env.https_proxy
   if (httpsProxy) strategy._oauth2.setAgent(new HTTPSProxyAgent(httpsProxy))
 
-  passport.use(strategy)
+  passport.use('github', strategy)
 }
 
 module.exports = passport

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -1,6 +1,6 @@
 <div class="user-profile">
   <div class="user-profile__container">
-  {% if not disableAuth %}
+
     <div class="user-profile__item">
       <img class="avatar" height="20" width="20" src="{{ user.avatarUrl }}" crossorigin>
     </div>
@@ -13,10 +13,16 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
+      <span>
+        <form method="POST" action="/logout">
+          {{ govukButton({
+            text: "Sign out"
+            })
+            }}
+          <input type="hidden" name="_csrf" value="{{ csrf }}">
+        </form>
+      </span>
     </div>
-  {% else %}
-    <div class="user-profile__item">(OAUTH disabled)</div>
-  {% endif %}
+
   </div>
 </div>

--- a/src/web/modules/login/login.http.ts
+++ b/src/web/modules/login/login.http.ts
@@ -1,0 +1,9 @@
+import {NextFunction, Request, Response} from 'express'
+
+export async function login(req: Request, res: Response, next: NextFunction) {
+    try {
+        res.render('login/login')
+    } catch (err) {
+        next(err)
+    }
+}

--- a/src/web/modules/login/login.njk
+++ b/src/web/modules/login/login.njk
@@ -1,0 +1,4 @@
+{% block main %}
+  <h1>Login</h1>
+{% endblock %}
+

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -8,6 +8,7 @@ const healthcheck = require('./../lib/healthcheck')
 
 // module HTTP controllers
 const landing = require('./modules/landing/landing.http')
+const login = require('./modules/login/login.http')
 const statistics = require('./modules/statistics/statistics.http')
 const gatewayAccounts = require('./modules/gateway_accounts').default
 const switchPSP = require('./modules/gateway_accounts/switch_psp/switch_psp.http')
@@ -25,8 +26,6 @@ const ledgerPayouts = require('./modules/ledger_payouts/payout.http')
 const performance = require('./modules/statistics/performance.http')
 const events = require('./modules/events')
 const fixRefunds = require('./modules/transactions/fix_async_failed_stripe_refund')
-
-
 const users = require('./modules/users/users.http').default
 
 const {PermissionLevel} = require('../lib/auth/types')
@@ -36,16 +35,22 @@ const router = express.Router()
 const storage = multer.memoryStorage()
 const upload = multer({storage})
 
-router.get('/auth', passport.authenticate('github'))
+router.get(
+  '/auth',
+  passport.authenticate('github')
+)
+
 router.get('/auth/github/callback', (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
     successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
   })(req, res, next)
 })
+
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured(PermissionLevel.VIEW_ONLY), landing.root)
+router.get('/login', auth.secured(PermissionLevel.VIEW_ONLY), login.login)
 
 router.get('/statistics/services', auth.secured(PermissionLevel.VIEW_ONLY), statistics.csvServices)
 router.post('/statistics/services', auth.secured(PermissionLevel.VIEW_ONLY), statistics.byServices)
@@ -190,7 +195,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -65,6 +65,10 @@ function configureSecureHeaders(instance) {
     crossOriginResourcePolicy: { policy: "cross-origin" }
   }))
   instance.use(csurf())
+  instance.use((req, res, next) => {
+    res.locals.csrf = req.csrfToken()
+    next()
+  })
 }
 
 function configureRequestParsing(instance) {


### PR DESCRIPTION
Amending clear session to a full logout.

- This should logout users from Toolbox without logging them out of Github.
- Changed the logout route to use POST instead of GET as per the Passport documentation.
- Changed the anchor tag with an href to a form and button to facilitate a post request.
- Adding csrfToken globally so that the banner can make use of it. At the moment we only pass it in with each rendered view (if we decide to keep this some clean up will need to be performed to remove explicit inclusion in page renders).
- Passport allows you to explicitly name your strategy on registration by passing the name as the first argument. This has been added in the custom passport.js file so that to force the identifier to be 'github'.

This is a very basic test to see if passports `req.logout()` method is working as expected and will be reverted.