### PR TITLE
PP-15378 passport logout with post request

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -40,7 +40,7 @@ export function revokeSession(req: Request, res: Response, next: NextFunction) {
   logger.info(`Revoking session for user ${req.user && req.user.username}`)
     req.logout((err?: unknown) => {
         if (err) {
-            logger.error(`Revoke session Error ***: ${err}`);
+            logger.error(`Revoking session Error: ${err}`);
             return next(err);
         }
         logger.info("Revoking session redirect")

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -13,7 +13,15 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
+      <span>
+        <form method="POST" action="/logout">
+          {{ govukButton({
+            text: "Sign out"
+            })
+            }}
+          <input type="hidden" name="_csrf" value="{{ csrf }}">
+        </form>
+      </span>
     </div>
   {% else %}
     <div class="user-profile__item">(OAUTH disabled)</div>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -36,13 +36,15 @@ const router = express.Router()
 const storage = multer.memoryStorage()
 const upload = multer({storage})
 
-router.get('/auth', passport.authenticate('github'))
-router.get('/auth/github/callback', (req, res, next) => {
+router.post('/auth', passport.authenticate('github'))
+
+router.post('/auth/github/callback', (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
     successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
   })(req, res, next)
 })
+
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured(PermissionLevel.VIEW_ONLY), landing.root)
@@ -190,7 +192,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -65,6 +65,10 @@ function configureSecureHeaders(instance) {
     crossOriginResourcePolicy: { policy: "cross-origin" }
   }))
   instance.use(csurf())
+  instance.use((req, res, next) => {
+    res.locals.csrf = req.csrfToken()
+    next()
+  })
 }
 
 function configureRequestParsing(instance) {


### PR DESCRIPTION
Amending clear session to a full logout.

- Adding additional logging to revokeSession method.
- Removing anchor tag and replacing with a for with POST method and action /logout 
- Changing router for /logout to POST as per passport.js suggestion.
- Add CSRF values globally
- Made  `/auth/github/callback` post requests