### PR TITLE
PP-15378 passport js logout with Github OAuth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@aws-sdk/client-s3": "~3.1027.0",
         "@govuk-pay/pay-js-commons": "^7.0.56",
         "@govuk-pay/pay-js-metrics": "^2.0.2",
+        "@octokit/auth-app": "^8.2.0",
+        "@octokit/core": "^7.0.6",
         "@sentry/node": "^6.12.0",
         "axios": "1.16.0",
         "class-validator": "0.14.0",
@@ -42,6 +44,7 @@
         "rfc822-validate": "^1.0.0",
         "sass": "^1.62.1",
         "stripe": "^8.174.0",
+        "undici": "^7.28.0",
         "winston": "^3.10.0"
       },
       "devDependencies": {
@@ -1566,6 +1569,207 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
+      "integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
+      "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
+      "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
+      "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
+      "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -3740,6 +3944,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -6999,6 +7209,12 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
     },
     "node_modules/json2csv": {
       "version": "5.0.7",
@@ -10280,6 +10496,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -10639,6 +10864,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@aws-sdk/client-s3": "~3.1027.0",
     "@govuk-pay/pay-js-commons": "^7.0.56",
     "@govuk-pay/pay-js-metrics": "^2.0.2",
+    "@octokit/auth-app": "^8.2.0",
+    "@octokit/core": "^7.0.6",
     "@sentry/node": "^6.12.0",
     "axios": "1.16.0",
     "class-validator": "0.14.0",
@@ -62,6 +64,7 @@
     "rfc822-validate": "^1.0.0",
     "sass": "^1.62.1",
     "stripe": "^8.174.0",
+    "undici": "^7.28.0",
     "winston": "^3.10.0"
   },
   "devDependencies": {

--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -7,5 +7,6 @@ declare namespace Express {
   interface User {
     username?: string;
     permissionLevel?: number;
+    githubAccessToken?: string;
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import logger from './logger'
 import {disableAuth} from './../config'
 import {NextFunction, Request, Response} from 'express'
 import {PermissionLevel} from './auth/types'
+import {revokeGithubGrant}  from './../lib/auth/github/strategy'
 
 export function secured(permissionLevel: PermissionLevel) {
   return function checkUserIsAuthenticatedAndPermitted(req: Request, res: Response, next: NextFunction) {
@@ -36,12 +37,26 @@ export function unauthorised(req: Request, res: Response) {
   res.status(403).send('User does not have permissions to access the resource')
 }
 
-export function revokeSession(req: Request, res: Response, next: NextFunction) {
-  logger.info(`Revoking session for user ${req.user && req.user.username}`)
+export async function revokeSession(req: Request, res: Response, next: NextFunction) {
+    logger.info(`Revoking session for user ${req.user && req.user.username}`)
+
+    try {
+        const accessToken = req.user?.githubAccessToken
+
+        if (accessToken) {
+            await revokeGithubGrant(accessToken)
+            logger.info(`Revoked GitHub grant for user ${req.user?.username}`)
+        } else {
+            logger.warn(`No GitHub access token found for user ${req.user?.username}`)
+        }
+    } catch (err) {
+        logger.error(`Failed to revoke GitHub grant before logout: ${err}`)
+    }
+
     req.logout((err?: unknown) => {
         if (err) {
-            logger.error(`Revoke session Error: ${err}`);
-            return next(err);
+            logger.error(`Revoke session Error: ${err}`)
+            return next(err)
         }
         logger.info("Revoking session redirect")
         res.redirect('/');

--- a/src/lib/auth/github/strategy.js
+++ b/src/lib/auth/github/strategy.js
@@ -1,10 +1,13 @@
 // github OAuth strategy
 const { Strategy } = require('passport-github2')
+const { createOAuthAppAuth } = require('@octokit/auth-oauth-app')
 const config = require('../../../config')
 const logger = require('../../logger')
 
 const { checkUserAccess} = require('./permissions')
 const {PermissionLevel} = require("../types");
+const {Octokit} = require("@octokit/core");
+const undici = require('undici')
 
 const githubAuthCredentials = {
   clientID: config.auth.AUTH_GITHUB_CLIENT_ID,
@@ -20,7 +23,13 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
 ) {
   const { username, displayName } = profile
   const avatarUrl = profile._json && profile._json.avatar_url
-  const sessionProfile = { username, displayName, avatarUrl }
+
+  const sessionProfile = {
+    username,
+    displayName,
+    avatarUrl,
+    githubAccessToken: accessToken
+  }
 
   logger.info(`Successful account auth from GitHub for user ${username}`)
 
@@ -40,4 +49,47 @@ const handleGitHubOAuthSuccessResponse = async function handleGitHubOAuthSuccess
   }
 }
 
-module.exports = { Strategy, githubAuthCredentials, handleGitHubOAuthSuccessResponse }
+async function revokeGithubGrant(accessToken) {
+  if (!accessToken) return;
+
+  try {
+    const octokit = new Octokit({
+      authStrategy: createOAuthAppAuth,
+      auth:{
+        clientType: 'oauth-app',
+        clientId: githubAuthCredentials.clientID,
+        clientSecret: githubAuthCredentials.clientSecret,
+      },
+      request: {
+        fetch: octokitHttpProxy
+      }
+    })
+
+    await octokit.request('DELETE /applications/{client_id}/grant', {
+      client_id: githubAuthCredentials.clientID,
+      access_token: accessToken,
+      headers: {
+        'X-GitHub-Api-Version': '2026-03-10'
+      }
+    })
+
+  } catch (error) {
+    logger.error(`Failed to revoke GitHub grant: ${error.response?.data?.message || error.message}`);
+    throw error;
+  }
+}
+
+const octokitHttpProxy = (url, options) => {
+  const httpsProxy = process.env.https_proxy
+  try {
+    return undici.fetch(url, {
+      ...options,
+      dispatcher: new undici.ProxyAgent(httpsProxy)
+    })
+  } catch (error) {
+    logger.error(`Failed to fetch undici proxy agent: ${error.message}`);
+  }
+}
+
+
+module.exports = { Strategy, githubAuthCredentials, handleGitHubOAuthSuccessResponse, revokeGithubGrant }

--- a/src/lib/auth/github/strategy.spec.js
+++ b/src/lib/auth/github/strategy.spec.js
@@ -22,7 +22,8 @@ describe('GitHub OAuth strategy', () => {
         displayName: profile.displayName,
         permissionLevel: PermissionLevel.VIEW_ONLY,
 
-        avatarUrl: profile._json.avatar_url
+        avatarUrl: profile._json.avatar_url,
+        githubAccessToken: 'some-access-token'
       }
     )
   })

--- a/src/lib/auth/passport.js
+++ b/src/lib/auth/passport.js
@@ -23,7 +23,7 @@ if (!disableAuth) {
   const httpsProxy = process.env.https_proxy
   if (httpsProxy) strategy._oauth2.setAgent(new HTTPSProxyAgent(httpsProxy))
 
-  passport.use(strategy)
+  passport.use("github", strategy)
 }
 
 module.exports = passport

--- a/src/web/modules/layout/user_banner.njk
+++ b/src/web/modules/layout/user_banner.njk
@@ -13,7 +13,15 @@
     </div>
 
     <div class="user-profile__item right">
-      <span><a class="govuk-link govuk-link--no-visited-state" href="/logout">Clear session</a></span>
+      <span>
+        <form method="POST" action="/logout">
+          {{ govukButton({
+            text: "Sign out"
+            })
+            }}
+          <input type="hidden" name="_csrf" value="{{ csrf }}">
+        </form>
+      </span>
     </div>
   {% else %}
     <div class="user-profile__item">(OAUTH disabled)</div>

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -36,7 +36,14 @@ const router = express.Router()
 const storage = multer.memoryStorage()
 const upload = multer({storage})
 
-router.get('/auth', passport.authenticate('github'))
+router.get(
+  '/auth',
+  passport.authenticate('github', {
+    scope: ['user:email'],
+    prompt: 'select_account'
+  })
+)
+
 router.get('/auth/github/callback', (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
@@ -190,7 +197,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.get('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -65,6 +65,10 @@ function configureSecureHeaders(instance) {
     crossOriginResourcePolicy: { policy: "cross-origin" }
   }))
   instance.use(csurf())
+  instance.use((req, res, next) => {
+    res.locals.csrf = req.csrfToken()
+    next()
+  })
 }
 
 function configureRequestParsing(instance) {


### PR DESCRIPTION
Amending clear session to a full logout.

- Adding clear logging to revokeSession method.
- Removing anchor tag and replacing with a for with POST method and action /logout
- Changing router for /logout to POST as per passport.js suggestion.
- Add CSRF values globally
- Adds key/value params for Github auth account selection with select_account
- Extracting Github Access Token from the request to pass to newly implemented revokeGithubGrant
- Implementing revokeGithubGrant to revoke Githubs access to Toolbox.
- Adding Github's Octokit package to make the request for revoking the above grant.
- Added HTTPSProxyAgent to the Octokit request options.
- Added Udici package enabling Octokit to use the httpProxy variable.