### PR TITLE
PP-15378 Add rate limiting middleware form js commons to authentication routes

### DIFF
--- a/src/web/router.js
+++ b/src/web/router.js
@@ -31,6 +31,8 @@ const users = require('./modules/users/users.http').default
 
 const {PermissionLevel} = require('../lib/auth/types')
 
+const { rateLimitMiddleware } = require('@govuk-pay/pay-js-commons/lib/utils/middleware/csp')
+
 const router = express.Router()
 
 const storage = multer.memoryStorage()
@@ -38,18 +40,22 @@ const upload = multer({storage})
 
 router.get(
   '/auth',
+  rateLimitMiddleware,
   passport.authenticate('github', {
     scope: ['user:email'],
     prompt: 'select_account'
   })
 )
 
-router.get('/auth/github/callback', (req, res, next) => {
+router.get('/auth/github/callback',
+  rateLimitMiddleware,
+  (req, res, next) => {
   passport.authenticate('github', {
     failureRedirect: '/auth/unauthorised',
     successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
   })(req, res, next)
 })
+
 router.get('/auth/unauthorised', auth.unauthorised)
 
 router.get('/', auth.secured(PermissionLevel.VIEW_ONLY), landing.root)
@@ -197,7 +203,7 @@ router.post('/events/by_date', auth.secured(PermissionLevel.USER_SUPPORT), event
 router.get('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheckerPage)
 router.post('/parity-checker', auth.secured(PermissionLevel.USER_SUPPORT), events.parityCheck)
 
-router.post('/logout', auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
+router.post('/logout', rateLimitMiddleware, auth.secured(PermissionLevel.VIEW_ONLY), auth.revokeSession)
 
 router.get('/healthcheck', healthcheck.response)
 


### PR DESCRIPTION
Amending clear session to a full logout.

- Importing `rateLimitMiddleware` from `pay-js-commons`
- Adding middleware to authentication routes and logout.