### PR TITLE
PP-15180 Switch to new GitHub org OAuth variables

### DIFF
--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -5,11 +5,11 @@ const expectedAuthEnvironmentValues = Joi.object({
   AUTH_GITHUB_CLIENT_ID: Joi.string(),
   AUTH_GITHUB_CLIENT_SECRET: Joi.string(),
   AUTH_GITHUB_RETURN_URL: Joi.string(),
-  AUTH_GITHUB_VIEW_ONLY_TEAM_ID: Joi.number(),
-  AUTH_GITHUB_USER_SUPPORT_TEAM_ID: Joi.number(),
-  AUTH_GITHUB_ADMIN_TEAM_ID: Joi.number(),
+  GITHUB_OAUTH_VIEW_ONLY_TEAM_ID: Joi.number(),
+  GITHUB_OAUTH_USER_SUPPORT_TEAM_ID: Joi.number(),
+  GITHUB_OAUTH_ADMIN_TEAM_ID: Joi.number(),
   GITHUB_API_ENDPOINT: Joi.string(),
-  GITHUB_ALPHAGOV_ORGANISATION_ID: Joi.string()
+  GITHUB_OAUTH_ORGANISATION_ID: Joi.string()
 })
 
 const { error, value: validatedAuthEnvironmentValues } = expectedAuthEnvironmentValues.validate(

--- a/src/lib/auth/github/permissions.spec.js
+++ b/src/lib/auth/github/permissions.spec.js
@@ -7,11 +7,11 @@ const {PermissionLevel} = require("../types");
 const username = 'a-user'
 const token = 'a-token'
 const authConfig = {
-  AUTH_GITHUB_ADMIN_TEAM_ID: 101,
-  AUTH_GITHUB_USER_SUPPORT_TEAM_ID: 102,
-  AUTH_GITHUB_VIEW_ONLY_TEAM_ID: 103,
+  GITHUB_OAUTH_ADMIN_TEAM_ID: 101,
+  GITHUB_OAUTH_USER_SUPPORT_TEAM_ID: 102,
+  GITHUB_OAUTH_VIEW_ONLY_TEAM_ID: 103,
   GITHUB_API_ENDPOINT: 'http://localhost:8000/github',
-  GITHUB_ALPHAGOV_ORGANISATION_ID: 201
+  GITHUB_OAUTH_ORGANISATION_ID: 201
 }
 const githubMock = nock(authConfig.GITHUB_API_ENDPOINT)
 
@@ -27,30 +27,30 @@ describe('Permissions util', () => {
   })
 
   it('should return ADMIN permission level when user is a member of the admin GitHub team', async () => {
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_ADMIN_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_ADMIN_TEAM_ID)
 
     const result = await permissions.checkUserAccess(username, token);
     expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.ADMIN})
   })
 
   it('should return ADMIN permission level when user is a member of multiple GitHub teams including the admin team', async () => {
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_ADMIN_TEAM_ID)
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_ADMIN_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_USER_SUPPORT_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_VIEW_ONLY_TEAM_ID)
 
     const result = await permissions.checkUserAccess(username, token);
     expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.ADMIN})
   })
 
   it('should return USER_SUPPORT permission level when user is a member of the user support GitHub team', async () => {
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_USER_SUPPORT_TEAM_ID)
 
     const result = await permissions.checkUserAccess(username, token);
     expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.USER_SUPPORT})
   })
 
   it('should return VIEW_ONLY permission level when user is a member of the view-only GitHub team', async () => {
-    mockSuccessGetUserMembershipOfTeam(authConfig.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)
+    mockSuccessGetUserMembershipOfTeam(authConfig.GITHUB_OAUTH_VIEW_ONLY_TEAM_ID)
 
     const result = await permissions.checkUserAccess(username, token);
     expect(result).to.deep.equal({permitted: true, permissionLevel: PermissionLevel.VIEW_ONLY})
@@ -63,7 +63,7 @@ describe('Permissions util', () => {
 })
 
 function mockSuccessGetUserMembershipOfTeam(team) {
-  githubMock.get(`/organizations/${authConfig.GITHUB_ALPHAGOV_ORGANISATION_ID}/team/${team}/memberships/${username}`)
+  githubMock.get(`/organizations/${authConfig.GITHUB_OAUTH_ORGANISATION_ID}/team/${team}/memberships/${username}`)
     .reply(200)
 }
 

--- a/src/lib/auth/github/permissions.ts
+++ b/src/lib/auth/github/permissions.ts
@@ -7,7 +7,7 @@ import logger from '../../logger'
 import {PermissionLevel} from '../types'
 
 async function isUserMemberOfGitHubTeam(username: string, token: string, team: string): Promise<boolean> {
-  const url = `${config.auth.GITHUB_API_ENDPOINT}/organizations/${config.auth.GITHUB_ALPHAGOV_ORGANISATION_ID}/team/${team}/memberships/${username}`
+  const url = `${config.auth.GITHUB_API_ENDPOINT}/organizations/${config.auth.GITHUB_OAUTH_ORGANISATION_ID}/team/${team}/memberships/${username}`
   const githubRestOptions = {
     headers: {
       Authorization: `token ${token}`
@@ -27,11 +27,11 @@ async function isUserMemberOfGitHubTeam(username: string, token: string, team: s
 }
 
 export async function checkUserAccess(username: string, token: string) {
-  if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_ADMIN_TEAM_ID)) {
+  if (await isUserMemberOfGitHubTeam(username, token, config.auth.GITHUB_OAUTH_ADMIN_TEAM_ID)) {
     return {permitted: true, permissionLevel: PermissionLevel.ADMIN}
-  } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_USER_SUPPORT_TEAM_ID)) {
+  } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.GITHUB_OAUTH_USER_SUPPORT_TEAM_ID)) {
     return {permitted: true, permissionLevel: PermissionLevel.USER_SUPPORT}
-  } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.AUTH_GITHUB_VIEW_ONLY_TEAM_ID)) {
+  } else if (await isUserMemberOfGitHubTeam(username, token, config.auth.GITHUB_OAUTH_VIEW_ONLY_TEAM_ID)) {
     return {permitted: true, permissionLevel: PermissionLevel.VIEW_ONLY}
   } else {
     return {permitted: false}


### PR DESCRIPTION
As part of the migration to the new `govuk-pay` organisation, we need to update the organisation ID and team IDs used with the GitHub API for determining user permissions.

I've added these as new variables, partially to make it (hopefully) a little clearer, but also to avoid breaking anything by doing something out of sequence (overwriting environment variables before the code can properly handle the change).