### PR TITLE
PP-15180 Log the actual error when hitting permissions issues

### DIFF
--- a/src/lib/auth/github/permissions.ts
+++ b/src/lib/auth/github/permissions.ts
@@ -19,8 +19,8 @@ async function isUserMemberOfGitHubTeam(username: string, token: string, team: s
     await axios.get(url, githubRestOptions)
     logger.info(`User ${username} is a member of team ${team}`)
     return true
-    /* eslint-disable @typescript-eslint/no-unused-vars */
   } catch (err) {
+    logger.error(`Error when requesting team permissions: ${err}`)
     logger.info(`User ${username} is not a member of team ${team}`)
     return false
   }


### PR DESCRIPTION
The existing logging for permissions issues doesn't log the actual error message from the GitHub API. Add the error log to aid in debugging.