### PR TITLE
PP-15180 Log URL used to query the GitHub API

### DIFF
--- a/src/lib/auth/github/permissions.ts
+++ b/src/lib/auth/github/permissions.ts
@@ -14,7 +14,7 @@ async function isUserMemberOfGitHubTeam(username: string, token: string, team: s
     }
   }
 
-  logger.info(`Requesting team ${team} permissions for ${username}`)
+  logger.info(`Requesting team permissions via ${url}`)
   try {
     await axios.get(url, githubRestOptions)
     logger.info(`User ${username} is a member of team ${team}`)


### PR DESCRIPTION
The URL includes the team ID and username, logging them as well would be redundant.