### PR TITLE
PP-15599 Add summary list component for service features

### DIFF
--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -73,35 +73,36 @@
     </div>
   </div>
 
+  {% if service.service_features %}
     <div class="govuk-summary-card">
-    <div class="govuk-summary-card__title-wrapper">
-      <h2 class="govuk-heading-s">Service Features</h2>
-        </div>
-          <div class="govuk-summary-card__content">
-          {% set summaryRows = [] %}
-          {% for featureKey, featureValue in service.service_features %}
-            {% set summaryRows = (summaryRows.push({
-              key: {
-                html: "<span class='govuk-caption-m'>" + featureKey | replace("_", " ") | capitalize + "</span>"
-              },
-              value: {
-                text: featureValue.enabled | string | capitalize
-              },
-              actions: {
-                items: [
-                  {
-                    {# href: "/services/" + service.external_id + "/features/" + featureKey, #}
-                    text: "Manage"
-                  }
-                ]
-              }
-            }), summaryRows) %}
-          {% endfor %}
-          {{ govukSummaryList({
-            rows: summaryRows
-          }) }}
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-heading-s">Service Features</h2>
+          </div>
+            <div class="govuk-summary-card__content">
+            {% set summaryRows = [] %}
+            {% for featureKey, featureValue in service.service_features %}
+              {% set summaryRows = (summaryRows.push({
+                key: {
+                  html: "<span class='govuk-caption-m'>" + featureKey | replace("_", " ") | capitalize + "</span>"
+                },
+                value: {
+                  text: "On" if featureValue.enabled else "Off"
+                },
+                actions: {
+                  items: [
+                    {
+                      text: "Manage"
+                    }
+                  ]
+                }
+              }), summaryRows) %}
+            {% endfor %}
+            {{ govukSummaryList({
+              rows: summaryRows
+            }) }}
+      </div>
     </div>
-  </div>
+  {% endif %}
 
   <div>
     <table class="govuk-table">

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -73,6 +73,36 @@
     </div>
   </div>
 
+    <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-heading-s">Service Features</h2>
+        </div>
+          <div class="govuk-summary-card__content">
+          {% set summaryRows = [] %}
+          {% for featureKey, featureValue in service.service_features %}
+            {% set summaryRows = (summaryRows.push({
+              key: {
+                html: "<span class='govuk-caption-m'>" + featureKey | replace("_", " ") | capitalize + "</span>"
+              },
+              value: {
+                text: featureValue.enabled | string | capitalize
+              },
+              actions: {
+                items: [
+                  {
+                    {# href: "/services/" + service.external_id + "/features/" + featureKey, #}
+                    text: "Manage"
+                  }
+                ]
+              }
+            }), summaryRows) %}
+          {% endfor %}
+          {{ govukSummaryList({
+            rows: summaryRows
+          }) }}
+    </div>
+  </div>
+
   <div>
     <table class="govuk-table">
       <thead class="govuk-table__head">


### PR DESCRIPTION
- Display the list of features and their enabled status from the service response in a summary card
- summary card includes a manage link, this is to be implement in a subsequent ticket

<img width="735" height="221" alt="Screenshot 2026-07-31 at 14 57 37" src="https://github.com/user-attachments/assets/d6a599da-b4c1-4da9-bfcb-cc0a5c7aab39" />


