### PR TITLE
PP-15524-Upgrade npm to 11.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # Upgrade npm — if updating the Node.js version, check if this
 # is still necessary and make sure it never downgrades npm
-RUN npm install -g npm@11.14.1
+RUN npm install -g npm@11.18.0
 
 # takes both package and package-lock for CI
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/core": "^7.0.6",
         "@sentry/node": "^6.12.0",
         "axios": "1.18.0",
-        "class-validator": "0.14.0",
+        "class-validator": "0.15.1",
         "client-sessions": "^0.8.0",
         "cls-hooked": "4.2.2",
         "connect-flash": "0.1.1",
@@ -62,7 +62,7 @@
         "@types/mocha": "^8.2.3",
         "@types/morgan": "^1.9.2",
         "@types/multer": "^1.4.5",
-        "@types/node": "20.5.9",
+        "@types/node": "26.1.2",
         "@types/passport": "^1.0.17",
         "@types/qs": "6.9.6",
         "@types/stripe": "6.25.8",
@@ -82,13 +82,13 @@
         "ts-loader": "^9.4.4",
         "ts-node": "^10.9.1",
         "tsc-watch": "^6.0.4",
-        "typescript": "^5.2.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.54.0",
         "url-loader": "^4.1.1"
       },
       "engines": {
         "node": "^22.22.0",
-        "npm": "^11.14.1"
+        "npm": "^11.18.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2919,9 +2919,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2993,9 +2997,10 @@
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "node_modules/@types/validator": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.1.tgz",
-      "integrity": "sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A=="
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -4363,13 +4368,14 @@
       }
     },
     "node_modules/class-validator": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
-      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/validator": "^13.7.10",
-        "libphonenumber-js": "^1.10.14",
-        "validator": "^13.7.0"
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
       }
     },
     "node_modules/client-sessions": {
@@ -7364,9 +7370,10 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.44",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.44.tgz",
-      "integrity": "sha512-svlRdNBI5WgBjRC20GrCfbFiclbF0Cx+sCcQob/C1r57nsoq0xg8r65QbTyVyweQIlB33P+Uahyho6EMYgcOyQ=="
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.10.tgz",
+      "integrity": "sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -10798,9 +10805,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10878,6 +10885,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Internal administrative tools service for the GOV.UK Pay products.",
   "engines": {
     "node": "^22.22.0",
-    "npm": "^11.14.1"
+    "npm": "^11.18.0"
   },
   "private": true,
   "main": "dist/index.js",
@@ -37,7 +37,7 @@
     "@octokit/core": "^7.0.6",
     "@sentry/node": "^6.12.0",
     "axios": "1.18.0",
-    "class-validator": "0.14.0",
+    "class-validator": "0.15.1",
     "client-sessions": "^0.8.0",
     "cls-hooked": "4.2.2",
     "connect-flash": "0.1.1",
@@ -82,7 +82,7 @@
     "@types/mocha": "^8.2.3",
     "@types/morgan": "^1.9.2",
     "@types/multer": "^1.4.5",
-    "@types/node": "20.5.9",
+    "@types/node": "26.1.2",
     "@types/passport": "^1.0.17",
     "@types/qs": "6.9.6",
     "@types/stripe": "6.25.8",
@@ -102,7 +102,7 @@
     "ts-loader": "^9.4.4",
     "ts-node": "^10.9.1",
     "tsc-watch": "^6.0.4",
-    "typescript": "^5.2.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "url-loader": "^4.1.1"
   },

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -66,7 +66,7 @@ const addSentryBreadcrumb = format((info) => {
     Sentry.configureScope((scope) => {
       scope.addBreadcrumb({
         category: 'log',
-        message: info.message,
+        message: `${info.message}`,
         level: levelMap[info.level],
         type: 'debug'
       })

--- a/src/web/modules/services/services.http.ts
+++ b/src/web/modules/services/services.http.ts
@@ -99,7 +99,7 @@ export async function detail(req: Request, res: Response, next: NextFunction): P
     const [serviceGatewayAccounts, testGatewayAccount] = await Promise.all([
         getServiceGatewayAccounts(service.gateway_account_ids),
         Connector.accounts.retrieveByServiceExternalIdAndAccountType(serviceId, 'test')
-            .catch(e => {
+            .catch<any>(e => {
               if (e instanceof EntityNotFoundError) {
                 // don't 404 if no test account is found, show a misconfigured service error instead
                 return null


### PR DESCRIPTION
Upgrade `npm` to v11.8.0 to address vulnerabilities. Due to compiling errors `class-validator`, `@types/node`, and `typescript` were also upgraded.

Typescript was complaining about `message` in configure scope for addBreadcrumb so turned it into a string