### PR TITLE
PP-15224 update pay-js packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@aws-sdk/client-ecs": "~3.975.0",
         "@aws-sdk/client-s3": "~3.1027.0",
-        "@govuk-pay/pay-js-commons": "^7.0.56",
-        "@govuk-pay/pay-js-metrics": "^2.0.2",
+        "@govuk-pay/pay-js-commons": "^7.0.71",
+        "@govuk-pay/pay-js-metrics": "^2.0.7",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/core": "^7.0.6",
         "@sentry/node": "^6.12.0",
@@ -1312,12 +1312,12 @@
       "integrity": "sha512-Y8ETZc8afYf6lQ/mVp096phIVsgD/GmDxtm3YaPcc+71jmi/J6zdwbwaUU4JvS56mq6aSfbpkcKhQ5WugrWFPw=="
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "7.0.56",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.56.tgz",
-      "integrity": "sha512-3W7Y/Yn1BTG8Wgw59lZYJp4bwZuin6jDVy3vmHbyouFnYMkUR3PR+ElCfxEfElIvhePU1qFKD3YDGruAIePUAg==",
+      "version": "7.0.71",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.71.tgz",
+      "integrity": "sha512-wYWBcXEArIkaKq8cLj0a0+xghwhTrOkYEOG5w3sJ71kYtoSlb97yClhhDUBBZIVR1AKr21zQKbQD/2gjJL5zrQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.15.2",
+        "axios": "1.18.0",
         "csrf": "^3.1.0",
         "express-rate-limit": "^8.1.0",
         "lodash": "4.18.1",
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.2.tgz",
-      "integrity": "sha512-//b//jtK8jDAgTOMeyBlO6r44yMU53V+G6yP9NIxNKPaSVZghyFubTYqZJbNV0G0FlVPBFNmMq8cmOHRP6ePTA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.7.tgz",
+      "integrity": "sha512-dFpfKa+v3Lv60FxsPxJFOcd+77JEAgWe8U0eWoznNQygFpYd2/Ge+0PlLnNObiyCtx22BTk2ANhC8nENFecsLw==",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@aws-sdk/client-ecs": "~3.975.0",
     "@aws-sdk/client-s3": "~3.1027.0",
-    "@govuk-pay/pay-js-commons": "^7.0.56",
-    "@govuk-pay/pay-js-metrics": "^2.0.2",
+    "@govuk-pay/pay-js-commons": "^7.0.71",
+    "@govuk-pay/pay-js-metrics": "^2.0.7",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/core": "^7.0.6",
     "@sentry/node": "^6.12.0",
@@ -123,16 +123,16 @@
       "brace-expansion": "^2.1.2"
     },
     "copyfiles": {
-      "brace-expansion": "^1.1.6"
+      "brace-expansion": "^1.1.8"
     },
     "eslint": {
-      "brace-expansion": "^1.1.6"
+      "brace-expansion": "^1.1.8"
     },
     "eslint-plugin-import": {
-      "brace-expansion": "^1.1.6"
+      "brace-expansion": "^1.1.8"
     },
     "stylelint": {
-      "brace-expansion": "^1.1.6",
+      "brace-expansion": "^1.1.8",
       "postcss": "8.5.25"
     },
     "stylelint-order": {


### PR DESCRIPTION
pay-js-commons and pay-js-metrics are behind the latest releases. Update package to the latest ones.