### PR TITLE
PP-15673 Add functionality to enable service features in toolbox

### DIFF
--- a/src/lib/pay-request/services/admin_users/client.ts
+++ b/src/lib/pay-request/services/admin_users/client.ts
@@ -1,6 +1,6 @@
 import Client from '../../base'
 import {redactOTP} from '../../utils/redact'
-import {mapRequestParamsToOperation} from '../../utils/request'
+import {mapRequestParamsToOperation, Operation} from '../../utils/request'
 import {
   CreateServiceRequest,
   SearchServicesRequest,
@@ -75,6 +75,20 @@ export default class AdminUsers extends Client {
     ): Promise<Service | undefined> {
       const addOperations = ['gateway_account_ids']
       const payload = mapRequestParamsToOperation(params, addOperations)
+
+      return client._axios
+        .patch(`/v1/api/services/${id}`, payload)
+        .then(response => client._unpackResponseData<Service>(response));
+    },
+
+    updateFeature(
+      id: string,
+      featureName: string,
+      targetState: string
+    ): Promise<Service | undefined> {
+
+      const operation = targetState === 'enabled' ? 'add' : 'remove'
+      const payload: Operation = {op : operation, path: 'feature', value: featureName}
 
       return client._axios
         .patch(`/v1/api/services/${id}`, payload)

--- a/src/lib/pay-request/services/admin_users/types.ts
+++ b/src/lib/pay-request/services/admin_users/types.ts
@@ -12,7 +12,7 @@ export enum GoLiveStage {
 }
 
 export enum PSPTestAccountStage {
-  NotStarted= 'NOT_STARTED',
+  NotStarted = 'NOT_STARTED',
   RequestSubmitted = 'REQUEST_SUBMITTED',
   Created = 'CREATED'
 }
@@ -20,6 +20,10 @@ export enum PSPTestAccountStage {
 export interface CustomBranding {
   image_url?: string;
   css_url?: string;
+}
+
+export interface FeatureStatus {
+  enabled: boolean
 }
 
 /** GOV.UK Pay service entity, contains service level configuration. */
@@ -43,6 +47,7 @@ export interface Service {
   went_live_date?: string;
   created_date?: string;
   current_psp_test_account_stage: PSPTestAccountStage;
+  service_features: Record<string, FeatureStatus>
   // _links
 }
 
@@ -64,7 +69,7 @@ export interface ServiceRole {
 }
 
 export class User {
-  constructor (userData: any) {
+  constructor(userData: any) {
     if (!userData) {
       throw Error('Must provide data')
     }
@@ -101,7 +106,7 @@ export class User {
   // _links
   raw_data?: any; // for instances of the User class where defaults are set
 
-  lastLoginFormatted (): string {
+  lastLoginFormatted(): string {
     return this.last_logged_in_at ? toFormattedDate(new Date(this.last_logged_in_at)) : 'Never'
   }
 }

--- a/src/lib/pay-request/utils/request.ts
+++ b/src/lib/pay-request/utils/request.ts
@@ -1,5 +1,5 @@
-interface Operation {
-  op: 'replace' | 'add';
+export interface Operation {
+  op: 'replace' | 'add' | 'remove';
   path: string;
   value: string | boolean | undefined | unknown;
 }

--- a/src/web/modules/services/detail.njk
+++ b/src/web/modules/services/detail.njk
@@ -91,7 +91,8 @@
                 actions: {
                   items: [
                     {
-                      text: "Manage"
+                      text: "Manage",
+                      href: "/services/" + service.external_id + "/features/" + featureKey
                     }
                   ]
                 }

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -21,8 +21,11 @@ export async function updateFeatureForm(req: Request, res: Response, next: NextF
   try {
     const featureName = req.params.feature
     const service = await AdminUsers.services.retrieve(req.params.id)
-    req.flash('info', `Feature ${featureName} was updated for service ${service.name}`)
-    // TODO replace "updated" with the patch boolean to populate flash message
+
+    const targetState = req.body.enabled
+
+    await AdminUsers.services.updateFeature(service.external_id, featureName, targetState)
+    req.flash('info', `Feature ${featureName} was ${targetState} for service ${service.name}`)
     res.redirect(`/services/${service.external_id}`)
   }
   catch (error) {

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import { AdminUsers } from "../../../../lib/pay-request/client";
 
 
-export async function get(req: Request, res: Response, next: NextFunction): Promise<void> {
+export async function updateFeature(req: Request, res: Response, next: NextFunction): Promise<void> {
 
   try {
     const featureName = req.params.feature
@@ -10,9 +10,20 @@ export async function get(req: Request, res: Response, next: NextFunction): Prom
     const { name: serviceName, external_id: id } = service
     const enabled = service.service_features[featureName].enabled
 
-    console.log("ebaled: " + enabled)
+    res.render('services/features/update', { serviceName, id, featureName, enabled, csrf: req.csrfToken() })
+  }
+  catch (error) {
+    next(error)
+  }
+}
 
-    res.render('services/features/update', { serviceName, id, featureName, enabled })
+export async function updateFeatureForm(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const featureName = req.params.feature
+    const service = await AdminUsers.services.retrieve(req.params.id)
+    req.flash('info', `Feature ${featureName} was updated for service ${service.name}`)
+    // TODO replace "updated" with the patch boolean to populate flash message
+    res.redirect(`/services/${service.external_id}`)
   }
   catch (error) {
     next(error)

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -1,20 +1,20 @@
-import {NextFunction, Request, Response} from 'express'
-import {AdminUsers} from "../../../../lib/pay-request/client";
+import { NextFunction, Request, Response } from 'express'
+import { AdminUsers } from "../../../../lib/pay-request/client";
 
 
 export async function get(req: Request, res: Response, next: NextFunction): Promise<void> {
 
-    try {
-        const featureName = req.params.feature
+  try {
+    const featureName = req.params.feature
+    const service = await AdminUsers.services.retrieve(req.params.id)
+    const { name: serviceName, external_id: id } = service
+    const enabled = service.service_features[featureName].enabled
 
-        const service = await AdminUsers.services.retrieve(req.params.id)
-        const {name : serviceName, external_id: id} = service
+    console.log("ebaled: " + enabled)
 
-        res.render('services/features/update', { serviceName, id, featureName })
-    }
-    catch (error){
-        next(error)
-    }
-
-
+    res.render('services/features/update', { serviceName, id, featureName, enabled })
+  }
+  catch (error) {
+    next(error)
+  }
 }

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import { AdminUsers } from "../../../../lib/pay-request/client";
 
 
-export async function updateFeature(req: Request, res: Response, next: NextFunction): Promise<void> {
+export async function getUpdateFeatureForm(req: Request, res: Response, next: NextFunction): Promise<void> {
 
   try {
     const featureName = req.params.feature
@@ -17,7 +17,7 @@ export async function updateFeature(req: Request, res: Response, next: NextFunct
   }
 }
 
-export async function updateFeatureForm(req: Request, res: Response, next: NextFunction): Promise<void> {
+export async function postUpdateFeatureForm(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const featureName = req.params.feature
     const service = await AdminUsers.services.retrieve(req.params.id)

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express'
+
+export async function get(req: Request, res: Response): Promise<void> {
+  res.render('services/features/update')
+}

--- a/src/web/modules/services/features/features.http.ts
+++ b/src/web/modules/services/features/features.http.ts
@@ -1,5 +1,20 @@
-import { Request, Response } from 'express'
+import {NextFunction, Request, Response} from 'express'
+import {AdminUsers} from "../../../../lib/pay-request/client";
 
-export async function get(req: Request, res: Response): Promise<void> {
-  res.render('services/features/update')
+
+export async function get(req: Request, res: Response, next: NextFunction): Promise<void> {
+
+    try {
+        const featureName = req.params.feature
+
+        const service = await AdminUsers.services.retrieve(req.params.id)
+        const {name : serviceName, external_id: id} = service
+
+        res.render('services/features/update', { serviceName, id, featureName })
+    }
+    catch (error){
+        next(error)
+    }
+
+
 }

--- a/src/web/modules/services/features/update.njk
+++ b/src/web/modules/services/features/update.njk
@@ -1,10 +1,39 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% extends "layout/layout.njk" %}
 
 {% block main %}
+
 <span class="govuk-caption-l"> {{ serviceName }}</span>
 <h1 class="govuk-heading-l">Manage feature - {{ featureName | replace("_", " ") | capitalize }}</h1>
 
 <div>
     <a href="/services/{{ id }}" class="govuk-back-link">Back to service ({{ serviceName }})</a>
   </div>
+
+  {{ govukRadios({
+    name: "enabled",
+    fieldset: {
+        legend: {
+          text: "Manage the " + featureName + " for " + serviceName
+        }
+  },
+    items: [
+      {
+        value: "enabled",
+        text: "Enabled",
+        checked: enabled
+      },
+      {
+        value: "disabled",
+        text: "Disabled",
+        checked: not enabled
+      }
+    ]
+  }) }}
+
+  {{ govukButton({
+    text: "Save"
+  })
+  }}
+
 {% endblock %}

--- a/src/web/modules/services/features/update.njk
+++ b/src/web/modules/services/features/update.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "layout/layout.njk" %}
 
 {% block main %}
@@ -10,30 +11,35 @@
     <a href="/services/{{ id }}" class="govuk-back-link">Back to service ({{ serviceName }})</a>
   </div>
 
-  {{ govukRadios({
-    name: "enabled",
-    fieldset: {
-        legend: {
-          text: "Manage the " + featureName + " for " + serviceName
-        }
-  },
-    items: [
-      {
-        value: "enabled",
-        text: "Enabled",
-        checked: enabled
-      },
-      {
-        value: "disabled",
-        text: "Disabled",
-        checked: not enabled
-      }
-    ]
-  }) }}
+  <form method="POST" action="/services/{{ id }}/features/{{ featureName }}">
 
-  {{ govukButton({
-    text: "Save"
-  })
-  }}
+    {{ govukRadios({
+      name: "enabled",
+      fieldset: {
+          legend: {
+            text: "Manage the " + featureName + " for " + serviceName
+          }
+    },
+      items: [
+        {
+          value: "enabled",
+          text: "Enabled",
+          checked: enabled
+        },
+        {
+          value: "disabled",
+          text: "Disabled",
+          checked: not enabled
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Save"
+    })
+    }}
+
+     <input type="hidden" name="_csrf" value="{{ csrf }}">
+  </form>
 
 {% endblock %}

--- a/src/web/modules/services/features/update.njk
+++ b/src/web/modules/services/features/update.njk
@@ -17,7 +17,7 @@
       name: "enabled",
       fieldset: {
           legend: {
-            text: "Manage the " + featureName + " for " + serviceName
+            text: "Manage " + featureName + " for " + serviceName
           }
     },
       items: [

--- a/src/web/modules/services/features/update.njk
+++ b/src/web/modules/services/features/update.njk
@@ -1,0 +1,5 @@
+{% extends "layout/layout.njk" %}
+
+{% block main %}
+<h1 class="govuk-heading-m">Placeholder</h1>
+{% endblock %}

--- a/src/web/modules/services/features/update.njk
+++ b/src/web/modules/services/features/update.njk
@@ -1,5 +1,10 @@
 {% extends "layout/layout.njk" %}
 
 {% block main %}
-<h1 class="govuk-heading-m">Placeholder</h1>
+<span class="govuk-caption-l"> {{ serviceName }}</span>
+<h1 class="govuk-heading-l">Manage feature - {{ featureName | replace("_", " ") | capitalize }}</h1>
+
+<div>
+    <a href="/services/{{ id }}" class="govuk-back-link">Back to service ({{ serviceName }})</a>
+  </div>
 {% endblock %}

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -19,6 +19,7 @@ import {
   updateOrganisationForm,
   goLive
 } from './services.http'
+import * as updateFeature from './features/features.http'
 
 export default {
   overview: overview,
@@ -44,5 +45,8 @@ export default {
   toggleArchiveService: toggleArchiveService,
   goLive: goLive,
   createWorldpayTestService: createWorldpayTestService,
-  createWorldpayTestServiceConfirmationPage: createWorldpayTestServiceConfirmationPage
+  createWorldpayTestServiceConfirmationPage: createWorldpayTestServiceConfirmationPage,
+  updateFeature: {
+    get: updateFeature.get
+  }
 }

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -19,7 +19,7 @@ import {
   updateOrganisationForm,
   goLive
 } from './services.http'
-import { updateFeature, updateFeatureForm } from './features/features.http'
+import { getUpdateFeatureForm, postUpdateFeatureForm } from './features/features.http'
 
 export default {
   overview: overview,
@@ -46,6 +46,6 @@ export default {
   goLive: goLive,
   createWorldpayTestService: createWorldpayTestService,
   createWorldpayTestServiceConfirmationPage: createWorldpayTestServiceConfirmationPage,
-  updateFeature: updateFeature,
-  updateFeatureForm: updateFeatureForm
+  updateFeature: getUpdateFeatureForm,
+  updateFeatureForm: postUpdateFeatureForm
 }

--- a/src/web/modules/services/index.ts
+++ b/src/web/modules/services/index.ts
@@ -19,7 +19,7 @@ import {
   updateOrganisationForm,
   goLive
 } from './services.http'
-import * as updateFeature from './features/features.http'
+import { updateFeature, updateFeatureForm } from './features/features.http'
 
 export default {
   overview: overview,
@@ -46,7 +46,6 @@ export default {
   goLive: goLive,
   createWorldpayTestService: createWorldpayTestService,
   createWorldpayTestServiceConfirmationPage: createWorldpayTestServiceConfirmationPage,
-  updateFeature: {
-    get: updateFeature.get
-  }
+  updateFeature: updateFeature,
+  updateFeatureForm: updateFeatureForm
 }

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -131,7 +131,8 @@ router.post('/services/:id/organisation', auth.secured(PermissionLevel.USER_SUPP
 router.get('/services/:id/go_live', auth.secured(PermissionLevel.USER_SUPPORT), services.goLive)
 router.get('/services/:id/create_worldpay_test_service', auth.secured(PermissionLevel.USER_SUPPORT), services.createWorldpayTestServiceConfirmationPage)
 router.post('/services/:id/create_worldpay_test_service', auth.secured(PermissionLevel.USER_SUPPORT), services.createWorldpayTestService)
-router.get('/services/:id/features/:feature', auth.secured(PermissionLevel.USER_SUPPORT), services.updateFeature.get)
+router.get('/services/:id/features/:feature', auth.secured(PermissionLevel.USER_SUPPORT), services.updateFeature)
+router.post('/services/:id/features/:feature', auth.secured(PermissionLevel.USER_SUPPORT), services.updateFeatureForm)
 
 router.get('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.search)
 router.post('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.getDiscrepancyReport)

--- a/src/web/router.js
+++ b/src/web/router.js
@@ -29,14 +29,14 @@ const fixRefunds = require('./modules/transactions/fix_async_failed_stripe_refun
 
 const users = require('./modules/users/users.http').default
 
-const {PermissionLevel} = require('../lib/auth/types')
+const { PermissionLevel } = require('../lib/auth/types')
 
 const { rateLimitMiddleware } = require('@govuk-pay/pay-js-commons/lib/utils/middleware/csp')
 
 const router = express.Router()
 
 const storage = multer.memoryStorage()
-const upload = multer({storage})
+const upload = multer({ storage })
 
 router.get(
   '/auth',
@@ -50,11 +50,11 @@ router.get(
 router.get('/auth/github/callback',
   rateLimitMiddleware,
   (req, res, next) => {
-  passport.authenticate('github', {
-    failureRedirect: '/auth/unauthorised',
-    successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
-  })(req, res, next)
-})
+    passport.authenticate('github', {
+      failureRedirect: '/auth/unauthorised',
+      successRedirect: req.session && req.session.authBlockedRedirectUrl || '/'
+    })(req, res, next)
+  })
 
 router.get('/auth/unauthorised', auth.unauthorised)
 
@@ -131,6 +131,7 @@ router.post('/services/:id/organisation', auth.secured(PermissionLevel.USER_SUPP
 router.get('/services/:id/go_live', auth.secured(PermissionLevel.USER_SUPPORT), services.goLive)
 router.get('/services/:id/create_worldpay_test_service', auth.secured(PermissionLevel.USER_SUPPORT), services.createWorldpayTestServiceConfirmationPage)
 router.post('/services/:id/create_worldpay_test_service', auth.secured(PermissionLevel.USER_SUPPORT), services.createWorldpayTestService)
+router.get('/services/:id/features/:feature', auth.secured(PermissionLevel.USER_SUPPORT), services.updateFeature.get)
 
 router.get('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.search)
 router.post('/discrepancies/search', auth.secured(PermissionLevel.USER_SUPPORT), discrepancies.getDiscrepancyReport)


### PR DESCRIPTION
**The key aim with this PR was to add a manage link to each feature on a service. This should then open a new page with radio buttons to either enable or disable a feature. On save this should persist.**

- Updated summary card `'manage'` link in `services/detail.njk` to link to `"/services/" + service.external_id + "/features/" + featureKey`
- Created both a `GET` and `POST` endpoint in router.js with the path `/services/:id/features/:feature`
- Controllers created for use in above endpoints are updateFeature and updateFeatureForm, which have been created in their own folder `src/web/modules/services/features/features.http.ts` rather than chunky services.http.ts
- `src/web/modules/services/features/update.njk` created to be served up on GET endpoint. Includes radio button to enable and disable a feature and save button. 
- On form action for above, POST request (`updateFeatureForm`) is triggered which calls `updateFeature` from src/lib/pay-request/services/admin_users/client.ts
- Added `service_features` property to `Service` interface which includes `FeatureStatus` interface. Also added remove operation to `Operation` interface for reusability.

***

<img width="553" height="408" alt="Screenshot 2026-08-06 at 10 23 55" src="https://github.com/user-attachments/assets/86397f5b-399e-4b89-bee3-efb5ae3b1f82" />

***
<img width="756" height="224" alt="Screenshot 2026-08-06 at 10 25 13" src="https://github.com/user-attachments/assets/eb599cda-7ec3-47d2-9fe3-b9efdedad7b2" />
